### PR TITLE
feat(ci): enhance CI with separate jobs, cargo-audit, improved caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,35 +21,74 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  test:
-    name: Test & Clippy
+  clippy:
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-          toolchain: "1.75"
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-clippy-
 
-      - name: Build
-        run: cargo build --workspace
+      - run: cargo clippy --workspace -- -D warnings
 
-      - name: Test
-        run: cargo test --workspace
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Clippy
-        run: cargo clippy --workspace -- -D warnings
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
+      - run: cargo build --workspace
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+
+      - run: cargo test --workspace
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   merge-conflict-check:
     name: Merge Conflict Check
@@ -79,7 +118,7 @@ jobs:
 
           if [ -n "$conflicts" ]; then
             echo "::error::Merge conflicts detected"
-            conflict_list=$(echo "$conflicts" | sed 's/^/  - /')
+            conflict_list="  - ${conflicts//$'\n'/$'\n'  - }"
             gh pr comment "$PR_NUMBER" --body ":warning: **Merge conflicts detected with \`${BASE_REF}\`**
 
             Conflicting files:


### PR DESCRIPTION
## Summary
- Split monolithic test job into separate Build, Test, Clippy, and Security Audit jobs
- Add cargo-audit via rustsec/audit-check@v2 for dependency vulnerability scanning
- Per-job cache keys to avoid cross-contamination
- Remove pinned toolchain, use stable default
- Fix merge-conflict-check comment formatting

## Changed files
- .github/workflows/ci.yml

## Test plan
- [x] YAML validated, correct GitHub Actions syntax
- [x] Each job runs independently with its own cache scope
- [x] merge-conflict-check job preserved