### PR TITLE
feat(daemon): native Unix daemon mode — Sprint 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,33 @@ CLI subcommands: `agent`, `gateway`, `serve`, `heartbeat`, `health`, `setup`, `s
 - **Context engineering**: JIT loading, compaction, structured notes outside context window. See Anthropic's blog.
 - **Fewer, better tools**: Consolidate operations. Token-efficient returns. Poka-yoke.
 
+## Current Sprint: Sprint 2 — Native Daemon
+
+**Goal**: Add native Unix daemon mode, inspired by Cloudflare Pingora's Server/Service architecture.
+
+**Reference**: Pingora source at /tmp/pingora/ (if cloned). Key files:
+- `pingora-core/src/server/mod.rs` — Server lifecycle (new → bootstrap → run_forever)
+- `pingora-core/src/server/daemon.rs` — daemonize with `daemonize` crate
+- `pingora-core/src/services/mod.rs` — Service trait, shutdown propagation
+- `pingora-core/src/services/background.rs` — BackgroundService trait
+
+**What to build**: New `crates/nanobot-daemon/` crate with: daemonize (double-fork), PID file (flock), signal handling (SIGTERM/SIGINT/SIGHUP via tokio::signal::unix), file logging (tracing-appender). Integrate into main.rs as `daemon` subcommand (start/stop/restart/status) and into gateway.rs signal handling.
+
+**Design constraints**:
+- Pingora pattern: daemonize runs BEFORE tokio runtime starts (fork kills threads)
+- PID file: use flock(LOCK_EX|LOCK_NB) for atomic lock, not just file existence check
+- Signals: async via tokio::signal::unix::signal(), NOT libc signal()
+- Graceful shutdown: configurable grace_period (default 30s), then force exit
+- Config schema: add `daemon:` section (enabled, pid_file, log_dir, working_directory)
+
+**Full spec**: See SPRINT.md in project root.
+
 ## Pitfalls
 
 - Bus uses tokio broadcast — receivers must handle lag or drop messages.
 - Session store uses SQLite — concurrent access needs care.
 - Provider 429 handling: exponential backoff, not immediate retry.
 - Tests touching filesystem: use tempdir pattern.
+- daemonize MUST run before tokio runtime — fork kills all threads in parent
+- PID file locking: use flock, not "check if file exists" — race condition
+- Signal handlers: tokio::signal::unix requires Unix platform — cfg(target_family = "unix") guard

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ name = "nanobot-daemon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "libc",
  "nanobot-config",
  "nix",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +362,15 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1269,6 +1293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanobot-daemon"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "nanobot-config",
+ "nix",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "nanobot-heartbeat"
 version = "0.1.0"
 dependencies = [
@@ -1325,6 +1363,7 @@ dependencies = [
  "nanobot-config",
  "nanobot-core",
  "nanobot-cron",
+ "nanobot-daemon",
  "nanobot-heartbeat",
  "nanobot-providers",
  "nanobot-security",
@@ -1417,6 +1456,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1493,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1569,6 +1626,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2144,6 +2207,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,6 +2390,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/nanobot-heartbeat",
     "crates/nanobot-channels",
     "crates/nanobot-api",
+    "crates/nanobot-daemon",
 ]
 
 [workspace.package]
@@ -94,6 +95,7 @@ nanobot-cron = { path = "crates/nanobot-cron" }
 nanobot-heartbeat = { path = "crates/nanobot-heartbeat" }
 nanobot-channels = { path = "crates/nanobot-channels" }
 nanobot-api = { path = "crates/nanobot-api" }
+nanobot-daemon = { path = "crates/nanobot-daemon" }
 tokio = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.75%2B-orange?logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![Tests](https://img.shields.io/badge/tests-745%20passing-brightgreen)](./)
 [![License](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
-[![Crates](https://img.shields.io/badge/crates-12-purple)](./crates)
+[![Crates](https://img.shields.io/badge/crates-13-purple)](./crates)
 [![Clippy](https://img.shields.io/badge/clippy-0%20warnings-success)](./)
 
 Fast, streaming-first, and production-ready. Connect Telegram, Discord, and
@@ -29,6 +29,7 @@ OpenAI-compatible clients to any LLM provider through a unified agent loop.
 - **Skill files** — markdown-based skill definitions with hot-reload
 - **Provider resilience** — automatic retry with exponential backoff on 429s
 - **SSRF protection** — network allowlist/denylist and URL validation
+- **Native daemon mode** — start/stop/restart/status with PID file, signal handling, file logging
 
 ## Architecture
 
@@ -36,7 +37,8 @@ OpenAI-compatible clients to any LLM provider through a unified agent loop.
                           ┌──────────────────────────────┐
                           │         CLI (clap)           │
                           │  agent · gateway · serve ·   │
-                          │  heartbeat · setup · status  │
+                          │  daemon · heartbeat · setup · │
+                          │  status                      │
                           └──────────────┬───────────────┘
                                          │
                  ┌───────────────────────┼───────────────────────┐
@@ -87,7 +89,7 @@ OpenAI-compatible clients to any LLM provider through a unified agent loop.
   ── Foundation Layer ──────────────────────────────────
   nanobot-core · nanobot-config · nanobot-bus
   nanobot-session · nanobot-security · nanobot-providers
-  nanobot-cron · nanobot-heartbeat
+  nanobot-cron · nanobot-heartbeat · nanobot-daemon
 ```
 
 ## Quick Start
@@ -122,6 +124,18 @@ nanobot-rs heartbeat
 
 # Show system status
 nanobot-rs status
+
+# Start as daemon (background, PID file)
+nanobot-rs daemon start
+
+# Check status
+nanobot-rs daemon status
+
+# Stop gracefully (SIGTERM)
+nanobot-rs daemon stop
+
+# Restart (stop + start)
+nanobot-rs daemon restart
 ```
 
 Environment variable `NANOBOT_RS_HOME` overrides the default config directory
@@ -161,6 +175,12 @@ security:
       - "10.0.0.0/8"
       - "172.16.0.0/12"
       - "192.168.0.0/16"
+
+daemon:
+  enabled: false          # auto-daemonize on gateway/serve start
+  pid_file: ~/.nanobot-rs/nanobot-rs.pid
+  log_dir: ~/.nanobot-rs/logs
+  grace_period_secs: 30
 ```
 
 ## CLI Commands
@@ -178,6 +198,7 @@ security:
 | `config migrate` | Migrate Python nanobot config to nanobot-rs format |
 | `setup` | Interactive configuration wizard |
 | `status` | Show current configuration and system status |
+| `daemon start/stop/restart/status` | Native daemon management with PID file and signal handling |
 
 ## Crates
 
@@ -195,6 +216,7 @@ security:
 | [`nanobot-heartbeat`](./crates/nanobot-heartbeat) | Health check registry, periodic task monitoring, auto-restart |
 | [`nanobot-channels`](./crates/nanobot-channels) | Platform adapters — Telegram, Discord — via `ChannelManager` |
 | [`nanobot-api`](./crates/nanobot-api) | OpenAI-compatible HTTP API server (Axum) |
+| [`nanobot-daemon`](./crates/nanobot-daemon) | Unix daemon: double-fork, PID file (flock), signal handling, file logging |
 
 ## Stats
 
@@ -203,7 +225,7 @@ security:
 | Rust source files | 97 |
 | Lines of Rust code | 72,566 |
 | Tests | 745 passing |
-| Crates | 12 |
+| Crates | 13 |
 | Clippy warnings | 0 |
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ OpenAI-compatible clients to any LLM provider through a unified agent loop.
 - **Skill files** — markdown-based skill definitions with hot-reload
 - **Provider resilience** — automatic retry with exponential backoff on 429s
 - **SSRF protection** — network allowlist/denylist and URL validation
-- **Native daemon mode** — start/stop/restart/status with PID file, signal handling, file logging
+- **Native daemon mode** — double-fork daemonization, PID file with flock, signal handling (SIGTERM/SIGINT/SIGHUP), graceful shutdown with log flushing, log rotation (daily)
 
 ## Architecture
 
@@ -125,16 +125,16 @@ nanobot-rs heartbeat
 # Show system status
 nanobot-rs status
 
-# Start as daemon (background, PID file)
+# Start as daemon (background, double-fork, PID file + flock)
 nanobot-rs daemon start
 
-# Check status
+# Check status (auto-cleans stale PID files from crashed instances)
 nanobot-rs daemon status
 
-# Stop gracefully (SIGTERM)
+# Stop gracefully (SIGTERM, configurable grace period)
 nanobot-rs daemon stop
 
-# Restart (stop + start)
+# Restart (stop + re-exec)
 nanobot-rs daemon restart
 ```
 
@@ -177,9 +177,9 @@ security:
       - "192.168.0.0/16"
 
 daemon:
-  enabled: false          # auto-daemonize on gateway/serve start
   pid_file: ~/.nanobot-rs/nanobot-rs.pid
   log_dir: ~/.nanobot-rs/logs
+  working_directory: /
   grace_period_secs: 30
 ```
 
@@ -198,7 +198,7 @@ daemon:
 | `config migrate` | Migrate Python nanobot config to nanobot-rs format |
 | `setup` | Interactive configuration wizard |
 | `status` | Show current configuration and system status |
-| `daemon start/stop/restart/status` | Native daemon management with PID file and signal handling |
+| `daemon start/stop/restart/status` | Native Unix daemon: double-fork, PID file (flock), SIGTERM/SIGINT/SIGHUP, log rotation |
 
 ## Crates
 

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -1,55 +1,108 @@
-# Sprint 1: Gateway + Agent Loop Integration
+# Sprint 2: Native Daemon — Pingora-Inspired Service Architecture
 
-## Sprint 1 Completion Summary
+## Sprint 2 Status: In Progress
 
-**Status**: Completed
-**Merged via**: `feat/agent-a` → `feat/agent-b` → `feat/agent-c` → `feat/cc-feat` → `main`
-**Cleanup**: All Sprint 1 feature branches deleted (local + remote), agent context files removed.
+**Goal**: Implement native daemon mode for nanobot-rs, inspired by Cloudflare Pingora's Server/Service lifecycle management.
 
-### Deliverables Shipped
-- **ChannelManager** with start/stop per-channel adapters, graceful shutdown, inbound/outbound message flow
-- **AgentLoop** with session history, context building, LLM dispatch, tool call handling, and bus integration
-- **Provider layer** with OpenAI-compat and Anthropic backends, retry with exponential backoff, circuit breaker
-- **Tool registry** with dispatch, skill dependency resolution, hot-reload, and caching
-- **Telegram/Discord channels** with command handlers (`/help`, `/status`, `/validate`, `/settings`, `/history`, `/menu`)
-- **HTTP API** with OpenAI-compatible endpoints, SSE streaming, CORS, request ID middleware
-- **Config migration** from Python nanobot YAML with validation and dry-run
-- **Health checks** with liveness/readiness endpoints and component status events
-- **Cron scheduler** with priority, timeout spawning, structured logging
+**Reference Architecture**: https://github.com/cloudflare/pingora — Server::new → bootstrap → add_service → run_forever pattern. Key modules: server/mod.rs, server/daemon.rs, services/background.rs, server/transfer_fd.rs.
 
-## Sprint Contract (Pass/Fail Criteria)
+## Why Pingora?
 
-### Agent A: Gateway Wiring Specialist
-**Target**: `crates/nanobot-channels/src/manager.rs`, `src/commands/gateway.rs`
-**Pass criteria**:
-- [x] ChannelManager can start/stop individual channel adapters
-- [x] Gateway command loads config from ~/.nanobot-rs/config.yaml
-- [x] InboundMessage flows from channel → bus → (available for consumption)
-- [x] OutboundMessage flows from bus → channel → platform
-- [x] Graceful shutdown on SIGINT/SIGTERM
-- [x] All existing tests still pass
-- [x] New integration test: mock channel → bus → verify message delivery
-**Result**: PASS
+Pingora solves exactly our problem: a Rust async server that needs to run as a proper Unix daemon with:
+- PID file management
+- Signal handling (SIGTERM/SIGINT/SIGHUP)
+- Graceful shutdown with timeout
+- Background service management
+- Zero-downtime upgrade via FD passing (future scope)
 
-### Agent B: Agent Loop Specialist
-**Target**: `crates/nanobot-agent/src/`
-**Pass criteria**:
-- [x] AgentLoop consumes InboundMessage from bus
-- [x] ContextBuilder builds prompt with session history + system prompt + tools
-- [x] AgentRunner calls LLM provider and gets response
-- [x] Tool calls are dispatched and results collected
-- [x] Final text response published as OutboundMessage on bus
-- [x] All existing tests still pass
-- [x] New unit tests for each step
-**Result**: PASS
+## Closed-Loop Development Workflow
 
-### Agent C: Provider + Tool Integration Specialist
-**Target**: `crates/nanobot-providers/src/`, `crates/nanobot-tools/src/`
-**Pass criteria**:
-- [x] OpenAI-compatible provider handles chat completions with tool calls
-- [x] Anthropic provider handles messages API with tool_use blocks
-- [x] Tool registry can register and dispatch tools by name
-- [x] Rate limiting (429) with exponential backoff
-- [x] All existing tests still pass
-- [x] New tests for provider retry logic and tool dispatch
-**Result**: PASS
+This sprint uses a single CC agent running a complete closed loop:
+
+```
+[Explore] → [Plan] → [Implement] → [Verify] → [Commit] → [PR]
+     ↑                                                    |
+     └────────── If verify fails, loop back ──────────────┘
+```
+
+### Phase 1: Explore (understand before writing)
+- Read Pingora's server/daemon.rs, services/mod.rs, services/background.rs
+- Read current nanobot-rs gateway.rs, main.rs, heartbeat crate
+- Understand the gap: what's missing for daemon mode
+
+### Phase 2: Plan (design before coding)
+- Design nanobot-daemon crate structure
+- Define DaemonConfig schema
+- Map Pingora patterns to nanobot-rs architecture
+- Write plan to docs/plan-daemon.md
+
+### Phase 3: Implement (code)
+- Create nanobot-daemon crate
+- Implement: daemonize, pid_file, signal, logging modules
+- Integrate into main.rs CLI (add daemon subcommand)
+- Integrate into gateway.rs (replace ctrl_c with signal handler)
+- Add DaemonConfig to config schema
+
+### Phase 4: Verify (test everything)
+- cargo test --workspace (all existing tests pass)
+- cargo clippy --workspace (0 warnings)
+- Manual test: daemon start/stop/restart/status
+- Manual test: signal handling (SIGTERM graceful shutdown)
+- Manual test: PID file lifecycle
+
+## Deliverables
+
+### New Crate: nanobot-daemon
+```
+crates/nanobot-daemon/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs          # Public API
+│   ├── daemonize.rs    # Unix double-fork (Pingora pattern)
+│   ├── pid_file.rs     # PID file management with flock
+│   ├── signal.rs       # SIGTERM/SIGINT/SIGHUP handling
+│   └── logging.rs      # File logging with tracing-appender
+```
+
+### Modified Files
+- `src/main.rs` — add `daemon` subcommand (start/stop/restart/status)
+- `src/commands/gateway.rs` — replace ctrl_c with signal handler, add PID file lifecycle
+- `src/commands/serve.rs` — same signal/PID treatment
+- `crates/nanobot-config/src/schema.rs` — add DaemonConfig struct
+- `Cargo.toml` — add workspace member + dependencies
+
+### Config Addition
+```yaml
+daemon:
+  enabled: false
+  pid_file: ~/.nanobot-rs/nanobot-rs.pid
+  log_dir: ~/.nanobot-rs/logs
+  working_directory: /
+```
+
+## Pingora Patterns to Apply
+
+1. **Server facade** — `Server::new(opt).bootstrap().add_service(svc).run_forever()` — adapt for nanobot-rs gateway
+2. **Service trait** — each long-running component (channels, heartbeat, api) as a named Service
+3. **Shutdown broadcast** — tokio watch channel for shutdown signal propagation (we already have MessageBus, extend it)
+4. **Daemonize** — Pingora uses `daemonize` crate, double-fork + PID file + stderr redirect
+5. **Execution phases** — Setup → Bootstrap → Running → GracefulShutdown → Terminated
+6. **Grace period** — configurable timeout for in-flight requests to complete
+
+## Out of Scope (Future Sprints)
+- Zero-downtime upgrade via FD passing (Sprint 3)
+- Hot config reload via SIGHUP (Sprint 3)
+- Systemd service file generation
+- Multi-process architecture
+
+## Pass/Fail Criteria
+- [ ] `cargo test --workspace` passes (0 failures)
+- [ ] `cargo clippy --workspace` passes (0 warnings)
+- [ ] `nanobot-rs daemon start` backgrounds the process with PID file
+- [ ] `nanobot-rs daemon stop` sends SIGTERM, process exits gracefully
+- [ ] `nanobot-rs daemon status` shows PID and process state
+- [ ] `nanobot-rs daemon restart` = stop + start
+- [ ] SIGTERM triggers graceful shutdown (channels drain, API completes in-flight)
+- [ ] PID file cleaned up on exit (normal and signal)
+- [ ] Config `daemon.enabled: true` makes gateway auto-daemonize without subcommand
+- [ ] Doc comments on all pub functions

--- a/crates/nanobot-agent/src/compaction.rs
+++ b/crates/nanobot-agent/src/compaction.rs
@@ -87,7 +87,10 @@ pub struct CompactionResult {
 /// For the `Summarize` strategy, older messages are replaced with a single
 /// system message containing a structured summary. For `Truncate`, older
 /// messages are simply dropped.
-pub fn compact_session(session: &mut Session, config: &CompactionConfig) -> Result<CompactionResult> {
+pub fn compact_session(
+    session: &mut Session,
+    config: &CompactionConfig,
+) -> Result<CompactionResult> {
     let tokens_before = session.estimated_tokens();
     let messages_before = session.messages.len();
 
@@ -128,10 +131,7 @@ pub fn compact_session(session: &mut Session, config: &CompactionConfig) -> Resu
 }
 
 /// Summarize older messages into a compact system message.
-fn compact_summarize(
-    session: &mut Session,
-    config: &CompactionConfig,
-) -> Result<CompactionResult> {
+fn compact_summarize(session: &mut Session, config: &CompactionConfig) -> Result<CompactionResult> {
     let messages_before = session.messages.len();
     let tokens_before = session.estimated_tokens();
 
@@ -205,7 +205,11 @@ fn compact_summarize(
     let tokens_after = session.estimated_tokens();
     info!(
         "Compacted session '{}': {} → {} messages, ~{} → ~{} estimated tokens",
-        session.key, messages_before, session.messages.len(), tokens_before, tokens_after
+        session.key,
+        messages_before,
+        session.messages.len(),
+        tokens_before,
+        tokens_after
     );
 
     Ok(CompactionResult {
@@ -218,10 +222,7 @@ fn compact_summarize(
 }
 
 /// Truncate older messages, keeping only recent ones.
-fn compact_truncate(
-    session: &mut Session,
-    config: &CompactionConfig,
-) -> Result<CompactionResult> {
+fn compact_truncate(session: &mut Session, config: &CompactionConfig) -> Result<CompactionResult> {
     let messages_before = session.messages.len();
     let tokens_before = session.estimated_tokens();
 
@@ -313,8 +314,12 @@ mod tests {
         let mut session = Session::new("test:compact".to_string());
         session.add_system_message("You are a helpful assistant.".to_string());
         for i in 0..count {
-            session.add_user_message(format!("User message number {} with some content to add tokens", i));
-            session.add_assistant_message(format!("Assistant response number {} with some detail", i));
+            session.add_user_message(format!(
+                "User message number {} with some content to add tokens",
+                i
+            ));
+            session
+                .add_assistant_message(format!("Assistant response number {} with some detail", i));
         }
         session
     }
@@ -332,7 +337,10 @@ mod tests {
     fn test_compaction_config_threshold() {
         let config = CompactionConfig::default();
         let threshold = config.threshold_tokens();
-        assert_eq!(threshold, (DEFAULT_CONTEXT_WINDOW_TOKENS as f64 * COMPACTION_THRESHOLD_RATIO) as usize);
+        assert_eq!(
+            threshold,
+            (DEFAULT_CONTEXT_WINDOW_TOKENS as f64 * COMPACTION_THRESHOLD_RATIO) as usize
+        );
     }
 
     #[test]
@@ -488,7 +496,9 @@ mod tests {
         let mut session = Session::new("test:notes_count".to_string());
         session.add_system_message("System".to_string());
         session.add_user_message("What database should we use?".to_string());
-        session.add_assistant_message("We decided to use PostgreSQL for the backend. You should add tests.".to_string());
+        session.add_assistant_message(
+            "We decided to use PostgreSQL for the backend. You should add tests.".to_string(),
+        );
         session.add_user_message("How do we handle migrations?".to_string());
         session.add_assistant_message("Let's use sqlx for migrations.".to_string());
         // Add enough to trigger compaction
@@ -538,7 +548,9 @@ mod tests {
         assert!(
             notes_after_second <= notes_after_first + r2.notes_extracted,
             "notes should be deduped, not accumulated: first={}, second={}, extracted={}",
-            notes_after_first, notes_after_second, r2.notes_extracted,
+            notes_after_first,
+            notes_after_second,
+            r2.notes_extracted,
         );
     }
 

--- a/crates/nanobot-agent/src/context.rs
+++ b/crates/nanobot-agent/src/context.rs
@@ -96,10 +96,10 @@ impl<'a> ContextBuilder<'a> {
 mod tests {
     use super::*;
     use nanobot_bus::events::InboundMessage;
+    use nanobot_config::Config;
     use nanobot_core::{MessageType, Platform};
     use nanobot_session::Session;
     use nanobot_tools::ToolRegistry;
-    use nanobot_config::Config;
 
     fn make_inbound() -> InboundMessage {
         InboundMessage {
@@ -167,8 +167,12 @@ mod tests {
         struct DummyTool;
         #[async_trait]
         impl Tool for DummyTool {
-            fn name(&self) -> &str { "dummy_tool" }
-            fn description(&self) -> &str { "A test tool" }
+            fn name(&self) -> &str {
+                "dummy_tool"
+            }
+            fn description(&self) -> &str {
+                "A test tool"
+            }
             fn parameters_schema(&self) -> serde_json::Value {
                 serde_json::json!({"type": "object"})
             }
@@ -259,8 +263,12 @@ mod tests {
         struct AnotherTool;
         #[async_trait]
         impl Tool for AnotherTool {
-            fn name(&self) -> &str { "my_tool" }
-            fn description(&self) -> &str { "tool" }
+            fn name(&self) -> &str {
+                "my_tool"
+            }
+            fn description(&self) -> &str {
+                "tool"
+            }
             fn parameters_schema(&self) -> serde_json::Value {
                 serde_json::json!({"type": "object"})
             }

--- a/crates/nanobot-agent/src/context_budget.rs
+++ b/crates/nanobot-agent/src/context_budget.rs
@@ -175,7 +175,10 @@ impl ContextBudget {
 
     /// Estimate total tokens for a slice of messages.
     pub fn estimate_messages_tokens(messages: &[SessionEntry]) -> usize {
-        messages.iter().map(|m| Self::estimate_tokens(&m.content)).sum()
+        messages
+            .iter()
+            .map(|m| Self::estimate_tokens(&m.content))
+            .sum()
     }
 
     /// Check whether the given messages fit within the history budget.
@@ -259,8 +262,7 @@ pub fn prune_messages(
 
     // Step 2: collect recent messages (always kept)
     let recent_start = total.saturating_sub(keep_recent).max(start_idx);
-    let recent_messages: Vec<SessionEntry> =
-        messages[recent_start..].to_vec();
+    let recent_messages: Vec<SessionEntry> = messages[recent_start..].to_vec();
 
     // Step 3: collect messages with tool_calls from the older range
     let mut tool_call_messages: Vec<SessionEntry> = Vec::new();
@@ -392,7 +394,11 @@ mod tests {
         }
     }
 
-    fn make_entry_with_tool_call(role: MessageRole, content: &str, tool_name: &str) -> SessionEntry {
+    fn make_entry_with_tool_call(
+        role: MessageRole,
+        content: &str,
+        tool_name: &str,
+    ) -> SessionEntry {
         SessionEntry {
             role,
             content: content.to_string(),
@@ -546,7 +552,7 @@ mod tests {
     #[test]
     fn test_estimate_messages_tokens() {
         let messages = vec![
-            make_entry(MessageRole::User, &"a".repeat(40)),  // 10 tokens
+            make_entry(MessageRole::User, &"a".repeat(40)), // 10 tokens
             make_entry(MessageRole::Assistant, &"b".repeat(80)), // 20 tokens
         ];
         assert_eq!(ContextBudget::estimate_messages_tokens(&messages), 30);
@@ -636,10 +642,10 @@ mod tests {
     fn test_prune_preserves_system_message() {
         let messages = vec![
             make_entry(MessageRole::System, "system prompt"),
-            make_entry(MessageRole::User, &"a".repeat(100)),   // 25 tokens
-            make_entry(MessageRole::User, &"b".repeat(100)),   // 25 tokens
-            make_entry(MessageRole::User, &"c".repeat(100)),   // 25 tokens
-            make_entry(MessageRole::User, &"d".repeat(100)),   // 25 tokens
+            make_entry(MessageRole::User, &"a".repeat(100)), // 25 tokens
+            make_entry(MessageRole::User, &"b".repeat(100)), // 25 tokens
+            make_entry(MessageRole::User, &"c".repeat(100)), // 25 tokens
+            make_entry(MessageRole::User, &"d".repeat(100)), // 25 tokens
         ];
         // Budget only fits system + 1 message
         let result = prune_messages(&messages, 30, 1);
@@ -652,7 +658,15 @@ mod tests {
     #[test]
     fn test_prune_keeps_recent_messages() {
         let messages: Vec<SessionEntry> = (0..10)
-            .map(|i| make_entry(MessageRole::User, &format!("message {} with enough text to add tokens abcdefghijklmnop", i)))
+            .map(|i| {
+                make_entry(
+                    MessageRole::User,
+                    &format!(
+                        "message {} with enough text to add tokens abcdefghijklmnop",
+                        i
+                    ),
+                )
+            })
             .collect();
 
         // Budget fits only 3 messages, keep_recent=2
@@ -671,11 +685,11 @@ mod tests {
     fn test_prune_preserves_tool_call_messages() {
         let messages = vec![
             make_entry(MessageRole::System, "system"),
-            make_entry(MessageRole::User, &"a".repeat(40)),          // 10 tokens
+            make_entry(MessageRole::User, &"a".repeat(40)), // 10 tokens
             make_entry_with_tool_call(MessageRole::Assistant, "calling tool", "search"), // ~3 tokens
-            make_entry(MessageRole::Tool, "tool result"),            // ~3 tokens
-            make_entry(MessageRole::User, &"e".repeat(40)),          // 10 tokens
-            make_entry(MessageRole::Assistant, "final response"),    // ~4 tokens
+            make_entry(MessageRole::Tool, "tool result"), // ~3 tokens
+            make_entry(MessageRole::User, &"e".repeat(40)), // 10 tokens
+            make_entry(MessageRole::Assistant, "final response"), // ~4 tokens
         ];
 
         // Budget: only ~20 tokens, keep_recent=2
@@ -683,7 +697,10 @@ mod tests {
         let result = prune_messages(&messages, 20, 2);
 
         let has_tool_call = result.kept.iter().any(|m| m.tool_calls.is_some());
-        assert!(has_tool_call, "Tool-call messages should be preserved during pruning");
+        assert!(
+            has_tool_call,
+            "Tool-call messages should be preserved during pruning"
+        );
     }
 
     #[test]
@@ -692,17 +709,20 @@ mod tests {
             make_entry(MessageRole::System, "system"),
             make_entry_with_tool_call(
                 MessageRole::Assistant,
-                &"x".repeat(200),  // 50 tokens — too large
+                &"x".repeat(200), // 50 tokens — too large
                 "big_tool",
             ),
-            make_entry(MessageRole::User, "recent"),  // ~2 tokens
+            make_entry(MessageRole::User, "recent"), // ~2 tokens
         ];
 
         // Budget too small for tool_call, keep_recent=1
         let result = prune_messages(&messages, 5, 1);
 
         let has_tool_call = result.kept.iter().any(|m| m.tool_calls.is_some());
-        assert!(!has_tool_call, "Tool-call should be dropped when budget is too small");
+        assert!(
+            !has_tool_call,
+            "Tool-call should be dropped when budget is too small"
+        );
     }
 
     // ─── prune_messages: result correctness ─────────────────────

--- a/crates/nanobot-agent/src/heartbeat.rs
+++ b/crates/nanobot-agent/src/heartbeat.rs
@@ -71,10 +71,7 @@ impl HealthCheck for ProviderHealthCheck {
             HealthCheckResult {
                 component: "provider".to_string(),
                 status: CheckStatus::Unhealthy,
-                message: format!(
-                    "providers unavailable: {}",
-                    unhealthy.join(", ")
-                ),
+                message: format!("providers unavailable: {}", unhealthy.join(", ")),
                 timestamp: chrono::Local::now(),
             }
         }
@@ -156,9 +153,7 @@ impl ChannelHealthCheck {
     pub fn empty() -> Self {
         Self {
             channel_names: Vec::new(),
-            connected: Arc::new(parking_lot::RwLock::new(
-                std::collections::HashSet::new(),
-            )),
+            connected: Arc::new(parking_lot::RwLock::new(std::collections::HashSet::new())),
         }
     }
 }
@@ -423,8 +418,8 @@ impl ConfigStoreHealthCheck {
     pub fn from_default_paths() -> Self {
         let config_path = nanobot_config::paths::get_config_path()
             .unwrap_or_else(|_| std::path::PathBuf::from("/dev/null"));
-        let data_dir = nanobot_config::paths::get_data_dir()
-            .unwrap_or_else(|_| std::env::temp_dir());
+        let data_dir =
+            nanobot_config::paths::get_data_dir().unwrap_or_else(|_| std::env::temp_dir());
         Self::new(config_path, data_dir)
     }
 }
@@ -439,9 +434,7 @@ impl HealthCheck for ConfigStoreHealthCheck {
         let mut issues = Vec::new();
 
         // Check config file readability
-        if self.config_path.exists()
-            && std::fs::read_to_string(&self.config_path).is_err()
-        {
+        if self.config_path.exists() && std::fs::read_to_string(&self.config_path).is_err() {
             issues.push(format!(
                 "config file {} is not readable",
                 self.config_path.display()
@@ -470,7 +463,11 @@ impl HealthCheck for ConfigStoreHealthCheck {
                 status: CheckStatus::Healthy,
                 message: format!(
                     "config: {}, data_dir: {}",
-                    if self.config_path.exists() { "present" } else { "default" },
+                    if self.config_path.exists() {
+                        "present"
+                    } else {
+                        "default"
+                    },
                     self.data_dir.display()
                 ),
                 timestamp: chrono::Local::now(),
@@ -645,10 +642,7 @@ impl HealthCheck for ReadinessCheck {
             HealthCheckResult {
                 component: "readiness".to_string(),
                 status: CheckStatus::Unhealthy,
-                message: format!(
-                    "missing providers: {}",
-                    missing.join(", ")
-                ),
+                message: format!("missing providers: {}", missing.join(", ")),
                 timestamp: chrono::Local::now(),
             }
         }
@@ -698,16 +692,14 @@ impl HealthCheck for DeepConfigStoreHealthCheck {
                             if let Some(agent) = parsed.get("agent") {
                                 if agent.get("model").is_none() {
                                     // model is optional — warn but not error
-                                    issues.push("agent.model not set (will use default)".to_string());
+                                    issues
+                                        .push("agent.model not set (will use default)".to_string());
                                 }
                             }
                             // If no agent section at all, that's acceptable (defaults)
                         }
                         Err(e) => {
-                            issues.push(format!(
-                                "config YAML parse error: {}",
-                                e
-                            ));
+                            issues.push(format!("config YAML parse error: {}", e));
                         }
                     }
                 }
@@ -751,7 +743,11 @@ impl HealthCheck for DeepConfigStoreHealthCheck {
                 status: CheckStatus::Healthy,
                 message: format!(
                     "config: {}, data_dir: {}",
-                    if self.config_path.exists() { "present, valid" } else { "default" },
+                    if self.config_path.exists() {
+                        "present, valid"
+                    } else {
+                        "default"
+                    },
                     self.data_dir.display()
                 ),
                 timestamp: chrono::Local::now(),
@@ -760,8 +756,10 @@ impl HealthCheck for DeepConfigStoreHealthCheck {
             // Distinguish between fatal issues (parse errors, not writable)
             // and warnings (missing optional keys)
             let has_fatal = issues.iter().any(|i| {
-                i.contains("not readable") || i.contains("not writable")
-                    || i.contains("parse error") || i.contains("does not exist")
+                i.contains("not readable")
+                    || i.contains("not writable")
+                    || i.contains("parse error")
+                    || i.contains("does not exist")
             });
             HealthCheckResult {
                 component: "config_store".to_string(),
@@ -810,8 +808,7 @@ mod tests {
     #[tokio::test]
     async fn test_session_store_healthy() {
         let dir = tempfile::tempdir().unwrap();
-        let mgr =
-            nanobot_session::SessionManager::new(dir.path().to_path_buf()).unwrap();
+        let mgr = nanobot_session::SessionManager::new(dir.path().to_path_buf()).unwrap();
         let check = SessionStoreHealthCheck::new(mgr);
         let result = check.report_health().await;
 
@@ -823,8 +820,7 @@ mod tests {
     #[tokio::test]
     async fn test_session_store_with_sessions() {
         let dir = tempfile::tempdir().unwrap();
-        let mgr =
-            nanobot_session::SessionManager::new(dir.path().to_path_buf()).unwrap();
+        let mgr = nanobot_session::SessionManager::new(dir.path().to_path_buf()).unwrap();
         mgr.get_or_create("test:a", None);
         mgr.get_or_create("test:b", None);
 
@@ -838,8 +834,7 @@ mod tests {
     #[tokio::test]
     async fn test_session_store_name() {
         let dir = tempfile::tempdir().unwrap();
-        let mgr =
-            nanobot_session::SessionManager::new(dir.path().to_path_buf()).unwrap();
+        let mgr = nanobot_session::SessionManager::new(dir.path().to_path_buf()).unwrap();
         let check = SessionStoreHealthCheck::new(mgr);
         assert_eq!(check.component_name(), "session_store");
     }
@@ -857,12 +852,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_channel_check_all_connected() {
-        let connected = Arc::new(parking_lot::RwLock::new(
-            std::collections::HashSet::from([
-                "telegram".to_string(),
-                "discord".to_string(),
-            ]),
-        ));
+        let connected = Arc::new(parking_lot::RwLock::new(std::collections::HashSet::from([
+            "telegram".to_string(),
+            "discord".to_string(),
+        ])));
         let check = ChannelHealthCheck::new(
             vec!["telegram".to_string(), "discord".to_string()],
             connected,
@@ -875,9 +868,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_channel_check_partial_disconnection() {
-        let connected = Arc::new(parking_lot::RwLock::new(
-            std::collections::HashSet::from(["telegram".to_string()]),
-        ));
+        let connected = Arc::new(parking_lot::RwLock::new(std::collections::HashSet::from([
+            "telegram".to_string(),
+        ])));
         let check = ChannelHealthCheck::new(
             vec!["telegram".to_string(), "discord".to_string()],
             connected,
@@ -891,13 +884,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_channel_check_all_disconnected() {
-        let connected = Arc::new(parking_lot::RwLock::new(
-            std::collections::HashSet::new(),
-        ));
-        let check = ChannelHealthCheck::new(
-            vec!["telegram".to_string()],
-            connected,
-        );
+        let connected = Arc::new(parking_lot::RwLock::new(std::collections::HashSet::new()));
+        let check = ChannelHealthCheck::new(vec!["telegram".to_string()], connected);
         let result = check.report_health().await;
 
         assert_eq!(result.status, CheckStatus::Unhealthy);
@@ -908,10 +896,7 @@ mod tests {
     async fn test_channel_check_dynamic_connection() {
         let connected: Arc<parking_lot::RwLock<std::collections::HashSet<String>>> =
             Arc::new(parking_lot::RwLock::new(std::collections::HashSet::new()));
-        let check = ChannelHealthCheck::new(
-            vec!["ws".to_string()],
-            connected.clone(),
-        );
+        let check = ChannelHealthCheck::new(vec!["ws".to_string()], connected.clone());
 
         // Initially disconnected
         let result = check.report_health().await;
@@ -992,8 +977,12 @@ mod tests {
         struct DummyTool;
         #[async_trait]
         impl Tool for DummyTool {
-            fn name(&self) -> &str { "test_tool" }
-            fn description(&self) -> &str { "A test tool" }
+            fn name(&self) -> &str {
+                "test_tool"
+            }
+            fn description(&self) -> &str {
+                "A test tool"
+            }
             fn parameters_schema(&self) -> serde_json::Value {
                 serde_json::json!({"type": "object"})
             }
@@ -1119,17 +1108,28 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("config.yaml");
         std::fs::write(&config_path, "test").unwrap();
-        std::fs::set_permissions(&config_path, std::os::unix::fs::PermissionsExt::from_mode(0o000)).unwrap();
+        std::fs::set_permissions(
+            &config_path,
+            std::os::unix::fs::PermissionsExt::from_mode(0o000),
+        )
+        .unwrap();
 
         let check = ConfigStoreHealthCheck::new(config_path.clone(), dir.path().to_path_buf());
         let result = check.report_health().await;
 
         // On some systems running as root, the permission restriction doesn't apply
         // so we accept either Unhealthy or Healthy
-        assert!(matches!(result.status, CheckStatus::Unhealthy | CheckStatus::Healthy));
+        assert!(matches!(
+            result.status,
+            CheckStatus::Unhealthy | CheckStatus::Healthy
+        ));
 
         // Restore permissions for cleanup
-        std::fs::set_permissions(&config_path, std::os::unix::fs::PermissionsExt::from_mode(0o644)).ok();
+        std::fs::set_permissions(
+            &config_path,
+            std::os::unix::fs::PermissionsExt::from_mode(0o644),
+        )
+        .ok();
     }
 
     #[tokio::test]
@@ -1137,28 +1137,34 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let data_dir = dir.path().join("readonly");
         std::fs::create_dir_all(&data_dir).unwrap();
-        std::fs::set_permissions(&data_dir, std::os::unix::fs::PermissionsExt::from_mode(0o444)).unwrap();
+        std::fs::set_permissions(
+            &data_dir,
+            std::os::unix::fs::PermissionsExt::from_mode(0o444),
+        )
+        .unwrap();
 
-        let check = ConfigStoreHealthCheck::new(
-            dir.path().join("config.yaml"),
-            data_dir.clone(),
-        );
+        let check = ConfigStoreHealthCheck::new(dir.path().join("config.yaml"), data_dir.clone());
         let result = check.report_health().await;
 
         // On some systems running as root, the permission restriction doesn't apply
-        assert!(matches!(result.status, CheckStatus::Unhealthy | CheckStatus::Healthy));
+        assert!(matches!(
+            result.status,
+            CheckStatus::Unhealthy | CheckStatus::Healthy
+        ));
 
         // Restore permissions for cleanup
-        std::fs::set_permissions(&data_dir, std::os::unix::fs::PermissionsExt::from_mode(0o755)).ok();
+        std::fs::set_permissions(
+            &data_dir,
+            std::os::unix::fs::PermissionsExt::from_mode(0o755),
+        )
+        .ok();
     }
 
     #[tokio::test]
     async fn test_config_store_name() {
         let dir = tempfile::tempdir().unwrap();
-        let check = ConfigStoreHealthCheck::new(
-            dir.path().join("config.yaml"),
-            dir.path().to_path_buf(),
-        );
+        let check =
+            ConfigStoreHealthCheck::new(dir.path().join("config.yaml"), dir.path().to_path_buf());
         assert_eq!(check.component_name(), "config_store");
     }
 
@@ -1273,7 +1279,9 @@ mod tests {
 
     #[async_trait]
     impl nanobot_providers::base::LlmProvider for MockProviderForReadiness {
-        fn name(&self) -> &str { "mock" }
+        fn name(&self) -> &str {
+            "mock"
+        }
         async fn complete(
             &self,
             _req: nanobot_providers::base::CompletionRequest,
@@ -1298,7 +1306,9 @@ mod tests {
             };
             Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
         }
-        fn supports_model(&self, _model: &str) -> bool { true }
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
     }
 
     // === DeepConfigStoreHealthCheck ===
@@ -1360,18 +1370,26 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let data_dir = dir.path().join("readonly");
         std::fs::create_dir_all(&data_dir).unwrap();
-        std::fs::set_permissions(&data_dir, std::os::unix::fs::PermissionsExt::from_mode(0o444))
-            .unwrap();
+        std::fs::set_permissions(
+            &data_dir,
+            std::os::unix::fs::PermissionsExt::from_mode(0o444),
+        )
+        .unwrap();
 
-        let check = DeepConfigStoreHealthCheck::new(
-            dir.path().join("config.yaml"),
-            data_dir.clone(),
-        );
+        let check =
+            DeepConfigStoreHealthCheck::new(dir.path().join("config.yaml"), data_dir.clone());
         let result = check.report_health().await;
 
-        assert!(matches!(result.status, CheckStatus::Unhealthy | CheckStatus::Healthy));
+        assert!(matches!(
+            result.status,
+            CheckStatus::Unhealthy | CheckStatus::Healthy
+        ));
 
-        std::fs::set_permissions(&data_dir, std::os::unix::fs::PermissionsExt::from_mode(0o755)).ok();
+        std::fs::set_permissions(
+            &data_dir,
+            std::os::unix::fs::PermissionsExt::from_mode(0o755),
+        )
+        .ok();
     }
 
     #[tokio::test]
@@ -1379,10 +1397,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing_dir = dir.path().join("does_not_exist");
 
-        let check = DeepConfigStoreHealthCheck::new(
-            dir.path().join("config.yaml"),
-            missing_dir,
-        );
+        let check = DeepConfigStoreHealthCheck::new(dir.path().join("config.yaml"), missing_dir);
         let result = check.report_health().await;
 
         assert_eq!(result.status, CheckStatus::Unhealthy);
@@ -1414,14 +1429,9 @@ mod tests {
         let channel_check = ChannelHealthCheck::empty();
         let bus_check = BusHealthCheck::new(bus);
         let tool_check = ToolRegistryHealthCheck::new(nanobot_tools::ToolRegistry::new());
-        let agent_check = AgentLoopHealthCheck::new(
-            Arc::new(parking_lot::RwLock::new(None)),
-            60,
-        );
-        let config_check = ConfigStoreHealthCheck::new(
-            dir.path().join("config.yaml"),
-            dir.path().to_path_buf(),
-        );
+        let agent_check = AgentLoopHealthCheck::new(Arc::new(parking_lot::RwLock::new(None)), 60);
+        let config_check =
+            ConfigStoreHealthCheck::new(dir.path().join("config.yaml"), dir.path().to_path_buf());
 
         let checks: Vec<&dyn HealthCheck> = vec![
             &provider_check,
@@ -1487,8 +1497,9 @@ mod tests {
     async fn test_mixed_checks_with_heartbeat_service() {
         let dir = tempfile::tempdir().unwrap();
         let config = nanobot_config::Config::default();
-        let svc = nanobot_heartbeat::HeartbeatService::with_data_dir(config, dir.path().to_path_buf())
-            .with_failures_before_restart(3);
+        let svc =
+            nanobot_heartbeat::HeartbeatService::with_data_dir(config, dir.path().to_path_buf())
+                .with_failures_before_restart(3);
 
         // Register a healthy check
         svc.register_check(std::sync::Arc::new(SessionStoreHealthCheck::new(

--- a/crates/nanobot-agent/src/loop_mod.rs
+++ b/crates/nanobot-agent/src/loop_mod.rs
@@ -182,7 +182,10 @@ impl AgentLoop {
                     }
                 }
                 Err(e) => {
-                    warn!("Context compaction failed for session {}: {}", session_key, e);
+                    warn!(
+                        "Context compaction failed for session {}: {}",
+                        session_key, e
+                    );
                 }
             }
         }
@@ -247,10 +250,8 @@ impl AgentLoop {
                 session.add_assistant_message(result.content.clone());
 
                 // Auto-extract structured notes from the response
-                let extracted = NotesManager::extract_notes_from_response(
-                    &mut session,
-                    &result.content,
-                );
+                let extracted =
+                    NotesManager::extract_notes_from_response(&mut session, &result.content);
                 if extracted > 0 {
                     info!(
                         "Auto-extracted {} notes from agent response in session {}",
@@ -386,8 +387,8 @@ impl AgentLoop {
     /// check loop. Returns a [`HeartbeatHandle`] that can be used to stop
     /// the service.
     async fn spawn_heartbeat(&self) -> Result<HeartbeatHandle> {
-        let data_dir = nanobot_config::paths::get_data_dir()
-            .unwrap_or_else(|_| std::env::temp_dir());
+        let data_dir =
+            nanobot_config::paths::get_data_dir().unwrap_or_else(|_| std::env::temp_dir());
 
         let config_clone = (*self.config).clone();
         let mut svc = HeartbeatService::with_data_dir(config_clone, data_dir);
@@ -404,9 +405,7 @@ impl AgentLoop {
             self.configured_channel_names(),
             self.connected_channels.clone(),
         )));
-        svc.register_check(Arc::new(BusHealthCheck::new(
-            (*self.bus).clone(),
-        )));
+        svc.register_check(Arc::new(BusHealthCheck::new((*self.bus).clone())));
         svc.register_check(Arc::new(ToolRegistryHealthCheck::new(
             (*self.tool_registry).clone(),
         )));
@@ -487,8 +486,7 @@ mod tests {
         let config = Config::default();
         let bus = MessageBus::new();
         let session_dir = tempfile::tempdir().unwrap();
-        let session_manager =
-            SessionManager::new(session_dir.path().to_path_buf()).unwrap();
+        let session_manager = SessionManager::new(session_dir.path().to_path_buf()).unwrap();
         let provider_registry = ProviderRegistry::new();
         let tool_registry = ToolRegistry::new();
         AgentLoop::new(
@@ -548,8 +546,7 @@ mod tests {
         });
         let bus = MessageBus::new();
         let session_dir = tempfile::tempdir().unwrap();
-        let session_manager =
-            SessionManager::new(session_dir.path().to_path_buf()).unwrap();
+        let session_manager = SessionManager::new(session_dir.path().to_path_buf()).unwrap();
         let al = AgentLoop::new(
             config,
             bus,
@@ -579,8 +576,7 @@ mod tests {
         });
         let bus = MessageBus::new();
         let session_dir = tempfile::tempdir().unwrap();
-        let session_manager =
-            SessionManager::new(session_dir.path().to_path_buf()).unwrap();
+        let session_manager = SessionManager::new(session_dir.path().to_path_buf()).unwrap();
         let al = AgentLoop::new(
             config,
             bus,
@@ -624,8 +620,7 @@ mod tests {
         let bus = MessageBus::new();
         let session_dir = tempfile::tempdir().unwrap();
         let data_dir = tempfile::tempdir().unwrap();
-        let session_manager =
-            SessionManager::new(session_dir.path().to_path_buf()).unwrap();
+        let session_manager = SessionManager::new(session_dir.path().to_path_buf()).unwrap();
         let provider_registry = ProviderRegistry::new();
         let tool_registry = ToolRegistry::new();
 
@@ -670,9 +665,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut config = Config::default();
         config.heartbeat.interval_secs = 30;
-        let svc = Arc::new(
-            HeartbeatService::with_data_dir(config, dir.path().to_path_buf())
-        );
+        let svc = Arc::new(HeartbeatService::with_data_dir(
+            config,
+            dir.path().to_path_buf(),
+        ));
         let running = Arc::new(RwLock::new(true));
         let svc_clone = Arc::clone(&svc);
 

--- a/crates/nanobot-agent/src/notes.rs
+++ b/crates/nanobot-agent/src/notes.rs
@@ -205,8 +205,8 @@ impl NotesStore {
             session_key
         );
 
-        let json = serde_json::to_string_pretty(notes)
-            .with_context(|| "Failed to serialize notes")?;
+        let json =
+            serde_json::to_string_pretty(notes).with_context(|| "Failed to serialize notes")?;
 
         let tmp_path = path.with_extension("notes.tmp");
         std::fs::write(&tmp_path, &json)
@@ -549,8 +549,13 @@ impl NotesManager {
         }
 
         // Remove stale compaction notes from a prior compaction cycle
-        let stale_titles = ["_compacted", "_compact_summary", "_compact_actions",
-            "_compact_decisions", "_compact_questions"];
+        let stale_titles = [
+            "_compacted",
+            "_compact_summary",
+            "_compact_actions",
+            "_compact_decisions",
+            "_compact_questions",
+        ];
         for title in &stale_titles {
             session.delete_note(title);
         }
@@ -649,7 +654,10 @@ impl NotesManager {
 /// so they don't accumulate across multiple compactions.
 ///
 /// Returns the number of notes created.
-pub fn extract_compaction_notes(session: &mut Session, old_messages: &[nanobot_session::SessionEntry]) -> usize {
+pub fn extract_compaction_notes(
+    session: &mut Session,
+    old_messages: &[nanobot_session::SessionEntry],
+) -> usize {
     // Remove any stale compaction notes from prior compaction cycles.
     let compaction_titles = [
         "_compaction_summary",
@@ -673,10 +681,7 @@ pub fn extract_compaction_notes(session: &mut Session, old_messages: &[nanobot_s
         .collect();
 
     if !topics.is_empty() {
-        let summary = format!(
-            "Discussed: {}",
-            topics.join("; ")
-        );
+        let summary = format!("Discussed: {}", topics.join("; "));
         if let Err(e) = NotesManager::save_structured_note(
             session,
             "_compaction_summary".to_string(),
@@ -691,7 +696,14 @@ pub fn extract_compaction_notes(session: &mut Session, old_messages: &[nanobot_s
     }
 
     // 2) Action items — lines containing "need to", "should", "TODO", "must"
-    let action_patterns = ["need to", "should", "todo", "must", "follow up", "action item"];
+    let action_patterns = [
+        "need to",
+        "should",
+        "todo",
+        "must",
+        "follow up",
+        "action item",
+    ];
     let action_items: Vec<String> = old_messages
         .iter()
         .filter(|m| m.role == nanobot_core::MessageRole::Assistant)
@@ -720,10 +732,20 @@ pub fn extract_compaction_notes(session: &mut Session, old_messages: &[nanobot_s
     }
 
     // 3) Decisions — lines containing "decided", "chose", "will use", "agreed"
-    let decision_patterns = ["decided", "chose", "will use", "agreed", "going with", "let's use"];
+    let decision_patterns = [
+        "decided",
+        "chose",
+        "will use",
+        "agreed",
+        "going with",
+        "let's use",
+    ];
     let decisions: Vec<String> = old_messages
         .iter()
-        .filter(|m| m.role == nanobot_core::MessageRole::Assistant || m.role == nanobot_core::MessageRole::User)
+        .filter(|m| {
+            m.role == nanobot_core::MessageRole::Assistant
+                || m.role == nanobot_core::MessageRole::User
+        })
         .flat_map(|m| m.content.lines())
         .filter(|line| {
             let lower = line.to_lowercase();
@@ -833,9 +855,18 @@ mod tests {
     #[test]
     fn test_note_format_from_tag() {
         assert_eq!(NoteFormat::from_tag("summary"), Some(NoteFormat::Summary));
-        assert_eq!(NoteFormat::from_tag("action_items"), Some(NoteFormat::ActionItems));
-        assert_eq!(NoteFormat::from_tag("decisions"), Some(NoteFormat::Decisions));
-        assert_eq!(NoteFormat::from_tag("open_questions"), Some(NoteFormat::OpenQuestions));
+        assert_eq!(
+            NoteFormat::from_tag("action_items"),
+            Some(NoteFormat::ActionItems)
+        );
+        assert_eq!(
+            NoteFormat::from_tag("decisions"),
+            Some(NoteFormat::Decisions)
+        );
+        assert_eq!(
+            NoteFormat::from_tag("open_questions"),
+            Some(NoteFormat::OpenQuestions)
+        );
         assert_eq!(NoteFormat::from_tag("unknown"), None);
         assert_eq!(NoteFormat::from_tag(""), None);
     }
@@ -886,10 +917,20 @@ mod tests {
     #[test]
     fn test_save_multiple_notes() {
         let mut session = make_session();
-        NotesManager::save_note(&mut session, "note1".to_string(), "First note".to_string(), vec![])
-            .unwrap();
-        NotesManager::save_note(&mut session, "note2".to_string(), "Second note".to_string(), vec![])
-            .unwrap();
+        NotesManager::save_note(
+            &mut session,
+            "note1".to_string(),
+            "First note".to_string(),
+            vec![],
+        )
+        .unwrap();
+        NotesManager::save_note(
+            &mut session,
+            "note2".to_string(),
+            "Second note".to_string(),
+            vec![],
+        )
+        .unwrap();
 
         let notes = NotesManager::load_notes(&session);
         assert_eq!(notes.len(), 2);
@@ -898,10 +939,20 @@ mod tests {
     #[test]
     fn test_update_existing_note() {
         let mut session = make_session();
-        NotesManager::save_note(&mut session, "key1".to_string(), "Original".to_string(), vec![])
-            .unwrap();
-        NotesManager::save_note(&mut session, "key1".to_string(), "Updated".to_string(), vec![])
-            .unwrap();
+        NotesManager::save_note(
+            &mut session,
+            "key1".to_string(),
+            "Original".to_string(),
+            vec![],
+        )
+        .unwrap();
+        NotesManager::save_note(
+            &mut session,
+            "key1".to_string(),
+            "Updated".to_string(),
+            vec![],
+        )
+        .unwrap();
 
         let notes = NotesManager::load_notes(&session);
         assert_eq!(notes.len(), 1);
@@ -954,8 +1005,13 @@ mod tests {
             vec!["tech".to_string()],
         )
         .unwrap();
-        NotesManager::save_note(&mut session, "style".to_string(), "Concise".to_string(), vec![])
-            .unwrap();
+        NotesManager::save_note(
+            &mut session,
+            "style".to_string(),
+            "Concise".to_string(),
+            vec![],
+        )
+        .unwrap();
 
         let ctx = NotesManager::format_notes_context(&session).unwrap();
         assert!(ctx.contains("## Session Notes"));
@@ -970,12 +1026,27 @@ mod tests {
     #[test]
     fn test_notes_by_tag() {
         let mut session = make_session();
-        NotesManager::save_note(&mut session, "n1".to_string(), "First".to_string(), vec!["cat_a".to_string()])
-            .unwrap();
-        NotesManager::save_note(&mut session, "n2".to_string(), "Second".to_string(), vec!["cat_b".to_string()])
-            .unwrap();
-        NotesManager::save_note(&mut session, "n3".to_string(), "Third".to_string(), vec!["cat_a".to_string()])
-            .unwrap();
+        NotesManager::save_note(
+            &mut session,
+            "n1".to_string(),
+            "First".to_string(),
+            vec!["cat_a".to_string()],
+        )
+        .unwrap();
+        NotesManager::save_note(
+            &mut session,
+            "n2".to_string(),
+            "Second".to_string(),
+            vec!["cat_b".to_string()],
+        )
+        .unwrap();
+        NotesManager::save_note(
+            &mut session,
+            "n3".to_string(),
+            "Third".to_string(),
+            vec!["cat_a".to_string()],
+        )
+        .unwrap();
 
         let cat_a = NotesManager::notes_by_tag(&session, "cat_a");
         assert_eq!(cat_a.len(), 2);
@@ -1070,9 +1141,18 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(NotesManager::notes_by_format(&session, NoteFormat::Summary).len(), 1);
-        assert_eq!(NotesManager::notes_by_format(&session, NoteFormat::ActionItems).len(), 1);
-        assert_eq!(NotesManager::notes_by_format(&session, NoteFormat::Decisions).len(), 0);
+        assert_eq!(
+            NotesManager::notes_by_format(&session, NoteFormat::Summary).len(),
+            1
+        );
+        assert_eq!(
+            NotesManager::notes_by_format(&session, NoteFormat::ActionItems).len(),
+            1
+        );
+        assert_eq!(
+            NotesManager::notes_by_format(&session, NoteFormat::Decisions).len(),
+            0
+        );
     }
 
     #[test]
@@ -1285,13 +1365,12 @@ mod tests {
     #[test]
     fn test_extract_compaction_notes_action_items() {
         let mut session = make_session();
-        let messages = vec![
-            nanobot_session::SessionEntry {
-                role: nanobot_core::MessageRole::Assistant,
-                content: "You should add tests for the API layer. We need to handle errors.".to_string(),
-                ..Default::default()
-            },
-        ];
+        let messages = vec![nanobot_session::SessionEntry {
+            role: nanobot_core::MessageRole::Assistant,
+            content: "You should add tests for the API layer. We need to handle errors."
+                .to_string(),
+            ..Default::default()
+        }];
 
         let count = extract_compaction_notes(&mut session, &messages);
         assert!(count >= 1);
@@ -1304,13 +1383,11 @@ mod tests {
     #[test]
     fn test_extract_compaction_notes_decisions() {
         let mut session = make_session();
-        let messages = vec![
-            nanobot_session::SessionEntry {
-                role: nanobot_core::MessageRole::Assistant,
-                content: "We decided to use Rust for the backend.".to_string(),
-                ..Default::default()
-            },
-        ];
+        let messages = vec![nanobot_session::SessionEntry {
+            role: nanobot_core::MessageRole::Assistant,
+            content: "We decided to use Rust for the backend.".to_string(),
+            ..Default::default()
+        }];
 
         let count = extract_compaction_notes(&mut session, &messages);
         assert!(count >= 1);
@@ -1438,8 +1515,16 @@ mod tests {
         let store = NotesStore::new(tmp.path().to_path_buf()).unwrap();
 
         let notes = vec![
-            Note::new("Architecture".into(), "Use microservices".into(), vec!["design".into()]),
-            Note::new("Language".into(), "Rust".into(), vec!["tech".into(), "backend".into()]),
+            Note::new(
+                "Architecture".into(),
+                "Use microservices".into(),
+                vec!["design".into()],
+            ),
+            Note::new(
+                "Language".into(),
+                "Rust".into(),
+                vec!["tech".into(), "backend".into()],
+            ),
         ];
 
         store.save("session:abc", &notes).unwrap();
@@ -1546,11 +1631,38 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let store = NotesStore::new(tmp.path().to_path_buf()).unwrap();
 
-        store.save("session:a", &[Note::new("A".into(), "content A".into(), vec!["alpha".into()])]).unwrap();
-        store.save("session:b", &[Note::new("B".into(), "content B".into(), vec!["beta".into()])]).unwrap();
+        store
+            .save(
+                "session:a",
+                &[Note::new(
+                    "A".into(),
+                    "content A".into(),
+                    vec!["alpha".into()],
+                )],
+            )
+            .unwrap();
+        store
+            .save(
+                "session:b",
+                &[Note::new(
+                    "B".into(),
+                    "content B".into(),
+                    vec!["beta".into()],
+                )],
+            )
+            .unwrap();
 
         // Modify session A
-        store.save("session:a", &[Note::new("A-mod".into(), "new content".into(), vec!["alpha".into()])]).unwrap();
+        store
+            .save(
+                "session:a",
+                &[Note::new(
+                    "A-mod".into(),
+                    "new content".into(),
+                    vec!["alpha".into()],
+                )],
+            )
+            .unwrap();
 
         // Session B should be unaffected
         let b_notes = store.load("session:b");
@@ -1661,7 +1773,7 @@ mod tests {
         let config = NoteCompactionConfig::new(20, 10);
         let removed = NotesManager::compact_with_config(&mut session, &config);
         assert_eq!(removed, 20); // 30 - 10 kept
-        // Should have: 1 compacted summary + 10 recent = 11
+                                 // Should have: 1 compacted summary + 10 recent = 11
         assert_eq!(session.notes.len(), 11);
 
         // The compacted note should be first
@@ -1678,15 +1790,27 @@ mod tests {
         let mut session = make_session();
         // Add 10 summary notes
         for i in 0..10 {
-            session.save_note(format!("summary_{}", i), format!("summary {}", i), vec!["summary".into()]);
+            session.save_note(
+                format!("summary_{}", i),
+                format!("summary {}", i),
+                vec!["summary".into()],
+            );
         }
         // Add 5 action notes
         for i in 0..5 {
-            session.save_note(format!("action_{}", i), format!("action {}", i), vec!["action_items".into()]);
+            session.save_note(
+                format!("action_{}", i),
+                format!("action {}", i),
+                vec!["action_items".into()],
+            );
         }
         // Add 10 uncategorized
         for i in 0..10 {
-            session.save_note(format!("misc_{}", i), format!("misc {}", i), vec!["other".into()]);
+            session.save_note(
+                format!("misc_{}", i),
+                format!("misc {}", i),
+                vec!["other".into()],
+            );
         }
         // Total: 25 notes, threshold 15, keep 5 recent
 
@@ -1706,7 +1830,11 @@ mod tests {
     fn test_compact_with_config_removes_stale_compaction() {
         let mut session = make_session();
         // Add a stale _compacted note
-        session.save_note("_compacted".into(), "old compaction".into(), vec!["_system".into()]);
+        session.save_note(
+            "_compacted".into(),
+            "old compaction".into(),
+            vec!["_system".into()],
+        );
         // Add enough notes to trigger compaction
         for i in 0..20 {
             session.save_note(format!("n{}", i), format!("note {}", i), vec![]);
@@ -1719,7 +1847,11 @@ mod tests {
         assert_eq!(removed, 16);
 
         // Should only have 1 _compacted note (the new one)
-        let compacted_count = session.notes.iter().filter(|n| n.title == "_compacted").count();
+        let compacted_count = session
+            .notes
+            .iter()
+            .filter(|n| n.title == "_compacted")
+            .count();
         assert_eq!(compacted_count, 1);
         assert!(session.notes[0].content.contains("Compacted 16 notes"));
     }
@@ -1797,7 +1929,8 @@ mod tests {
                 format!("content {}", i),
                 format,
                 vec![],
-            ).unwrap();
+            )
+            .unwrap();
         }
         assert_eq!(session.notes.len(), 30);
 
@@ -1829,14 +1962,29 @@ mod tests {
 
         let mut session = make_session();
         NotesManager::save_structured_note(
-            &mut session, "s1".into(), "Summary 1".into(), NoteFormat::Summary, vec![],
-        ).unwrap();
+            &mut session,
+            "s1".into(),
+            "Summary 1".into(),
+            NoteFormat::Summary,
+            vec![],
+        )
+        .unwrap();
         NotesManager::save_structured_note(
-            &mut session, "a1".into(), "Action 1".into(), NoteFormat::ActionItems, vec!["urgent".into()],
-        ).unwrap();
+            &mut session,
+            "a1".into(),
+            "Action 1".into(),
+            NoteFormat::ActionItems,
+            vec!["urgent".into()],
+        )
+        .unwrap();
         NotesManager::save_structured_note(
-            &mut session, "d1".into(), "Decision 1".into(), NoteFormat::Decisions, vec![],
-        ).unwrap();
+            &mut session,
+            "d1".into(),
+            "Decision 1".into(),
+            NoteFormat::Decisions,
+            vec![],
+        )
+        .unwrap();
 
         NotesManager::persist_to_store(&store, &session).unwrap();
 
@@ -1869,7 +2017,11 @@ mod tests {
 
         // Instance 1 saves
         let store1 = NotesStore::new(tmp.path().to_path_buf()).unwrap();
-        let notes = vec![Note::new("persistent".into(), "survives restart".into(), vec!["tag".into()])];
+        let notes = vec![Note::new(
+            "persistent".into(),
+            "survives restart".into(),
+            vec!["tag".into()],
+        )];
         store1.save("session:test", &notes).unwrap();
         drop(store1);
 

--- a/crates/nanobot-agent/src/skills.rs
+++ b/crates/nanobot-agent/src/skills.rs
@@ -93,7 +93,10 @@ impl SkillsLoader {
     /// Recursively walks `skills_dir` and loads every `.md` file.
     pub fn load_all(&mut self) -> Result<Vec<Skill>> {
         if !self.skills_dir.exists() {
-            debug!("Skills directory does not exist: {}", self.skills_dir.display());
+            debug!(
+                "Skills directory does not exist: {}",
+                self.skills_dir.display()
+            );
             return Ok(Vec::new());
         }
 
@@ -148,14 +151,15 @@ impl SkillsLoader {
             let md_files = collect_md_files(&self.skills_dir)?;
             for path in md_files {
                 // Try to load and see if it's already known by source_path.
-                let already_known = self
-                    .skills
-                    .values()
-                    .any(|s| s.source_path == path);
+                let already_known = self.skills.values().any(|s| s.source_path == path);
 
                 if !already_known {
                     if let Ok(skill) = Self::load_skill_file(&path) {
-                        info!("Discovered new skill '{}' at {}", skill.name, path.display());
+                        info!(
+                            "Discovered new skill '{}' at {}",
+                            skill.name,
+                            path.display()
+                        );
                         reloaded.push(skill.name.clone());
                         self.skills.insert(skill.name.clone(), skill);
                     }
@@ -232,7 +236,9 @@ impl SkillsLoader {
     /// Each skill becomes a function the LLM can call. The function's
     /// description is the skill's description, and its parameters come
     /// from the skill's `parameters` field.
-    pub fn skills_to_function_definitions(skills: &[Skill]) -> Vec<nanobot_core::FunctionDefinition> {
+    pub fn skills_to_function_definitions(
+        skills: &[Skill],
+    ) -> Vec<nanobot_core::FunctionDefinition> {
         skills
             .iter()
             .map(|skill| {
@@ -284,8 +290,8 @@ fn collect_md_files(dir: &Path) -> Result<Vec<PathBuf>> {
 }
 
 fn walk_dir(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    let entries = std::fs::read_dir(dir)
-        .with_context(|| format!("Failed to read dir: {}", dir.display()))?;
+    let entries =
+        std::fs::read_dir(dir).with_context(|| format!("Failed to read dir: {}", dir.display()))?;
 
     for entry in entries {
         let entry = entry.context("Failed to read dir entry")?;
@@ -303,9 +309,7 @@ fn walk_dir(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
 
 /// Get the modification time of a file (if available).
 fn file_mtime(path: &Path) -> Option<std::time::SystemTime> {
-    std::fs::metadata(path)
-        .ok()
-        .and_then(|m| m.modified().ok())
+    std::fs::metadata(path).ok().and_then(|m| m.modified().ok())
 }
 
 /// Parse the `parameters` field from frontmatter.
@@ -336,10 +340,7 @@ fn parse_parameters(frontmatter: &serde_yaml::Value) -> Vec<SkillParameter> {
                     .and_then(|d| d.as_str())
                     .unwrap_or("")
                     .to_string();
-                let required = v
-                    .get("required")
-                    .and_then(|r| r.as_bool())
-                    .unwrap_or(false);
+                let required = v.get("required").and_then(|r| r.as_bool()).unwrap_or(false);
                 Some(SkillParameter {
                     name,
                     description,
@@ -442,7 +443,10 @@ mod tests {
         let input = "---\nname: deploy\ndescription: Deploy the app\nparameters:\n  - name: env\n    description: Target environment\n    required: true\ntags:\n  - deploy\n  - cicd\n---\nDeploy to {env}.";
         let (fm, body) = parse_frontmatter(input).unwrap();
         assert_eq!(fm.get("name").unwrap().as_str(), Some("deploy"));
-        assert_eq!(fm.get("description").unwrap().as_str(), Some("Deploy the app"));
+        assert_eq!(
+            fm.get("description").unwrap().as_str(),
+            Some("Deploy the app")
+        );
         let params = fm.get("parameters").unwrap().as_sequence().unwrap();
         assert_eq!(params.len(), 1);
         assert_eq!(body.trim(), "Deploy to {env}.");
@@ -647,7 +651,11 @@ parameters:
     #[test]
     fn test_load_all_name_from_file_stem_when_missing() {
         let tmp = tempfile::tempdir().unwrap();
-        write_skill(tmp.path(), "my_awesome_skill.md", "---\n---\nNo name in frontmatter.");
+        write_skill(
+            tmp.path(),
+            "my_awesome_skill.md",
+            "---\n---\nNo name in frontmatter.",
+        );
 
         let mut loader = SkillsLoader::new(tmp.path().to_path_buf());
         let skills = loader.load_all().unwrap();
@@ -658,7 +666,11 @@ parameters:
     #[test]
     fn test_load_all_no_frontmatter() {
         let tmp = tempfile::tempdir().unwrap();
-        write_skill(tmp.path(), "plain.md", "Just plain markdown, no frontmatter at all.");
+        write_skill(
+            tmp.path(),
+            "plain.md",
+            "Just plain markdown, no frontmatter at all.",
+        );
 
         let mut loader = SkillsLoader::new(tmp.path().to_path_buf());
         let skills = loader.load_all().unwrap();
@@ -739,7 +751,10 @@ parameters:
 
         let mut loader = SkillsLoader::new(tmp.path().to_path_buf());
         loader.load_all().unwrap();
-        assert_eq!(loader.skills().get("test").unwrap().instructions, "Original content.");
+        assert_eq!(
+            loader.skills().get("test").unwrap().instructions,
+            "Original content."
+        );
 
         // Modify the file (bump mtime).
         // On some systems, writes within the same second may have the same mtime,
@@ -754,7 +769,10 @@ parameters:
 
         let reloaded = loader.reload_changed().unwrap();
         assert_eq!(reloaded, vec!["test"]);
-        assert_eq!(loader.skills().get("test").unwrap().instructions, "Updated content.");
+        assert_eq!(
+            loader.skills().get("test").unwrap().instructions,
+            "Updated content."
+        );
     }
 
     #[test]
@@ -821,13 +839,11 @@ parameters:
             name: "deploy".to_string(),
             description: "Deploy the application".to_string(),
             instructions: String::new(),
-            parameters: vec![
-                SkillParameter {
-                    name: "env".to_string(),
-                    description: "Target environment".to_string(),
-                    required: true,
-                },
-            ],
+            parameters: vec![SkillParameter {
+                name: "env".to_string(),
+                description: "Target environment".to_string(),
+                required: true,
+            }],
             requires_bin: vec![],
             requires_env: vec![],
             tags: vec![],
@@ -838,7 +854,10 @@ parameters:
         let defs = SkillsLoader::skills_to_function_definitions(&skills);
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].name, "skill_deploy");
-        assert_eq!(defs[0].description.as_deref(), Some("Deploy the application"));
+        assert_eq!(
+            defs[0].description.as_deref(),
+            Some("Deploy the application")
+        );
 
         let params = defs[0].parameters.as_ref().unwrap();
         assert_eq!(params["required"].as_array().unwrap().len(), 1);

--- a/crates/nanobot-agent/src/subagent.rs
+++ b/crates/nanobot-agent/src/subagent.rs
@@ -140,7 +140,10 @@ pub enum TaskStatus {
 impl TaskStatus {
     /// Returns `true` if the task has reached a terminal state.
     pub fn is_terminal(&self) -> bool {
-        matches!(self, TaskStatus::Completed(_) | TaskStatus::Failed(_) | TaskStatus::Cancelled)
+        matches!(
+            self,
+            TaskStatus::Completed(_) | TaskStatus::Failed(_) | TaskStatus::Cancelled
+        )
     }
 }
 
@@ -570,11 +573,7 @@ impl SubAgentManager {
     /// Returns the final [`TaskStatus`], or `None` if the task ID is unknown.
     /// If `timeout` elapses before the task finishes, returns the current
     /// (non-terminal) status.
-    pub async fn wait_for(
-        &self,
-        id: &str,
-        timeout: Duration,
-    ) -> Option<TaskStatus> {
+    pub async fn wait_for(&self, id: &str, timeout: Duration) -> Option<TaskStatus> {
         // Snapshot the notify handle without holding the lock across the await.
         let notify = {
             let tasks = self.tasks.read().await;
@@ -790,11 +789,7 @@ impl SubAgentManager {
             task_config.agent.max_tokens = max_tokens;
         }
 
-        AgentRunner::new(
-            Arc::new(task_config),
-            self.providers.clone(),
-            tools.clone(),
-        )
+        AgentRunner::new(Arc::new(task_config), self.providers.clone(), tools.clone())
     }
 
     // ─── Inter-agent messaging ────────────────────────────────
@@ -825,7 +820,8 @@ impl SubAgentManager {
         let mut count = 0;
         for task in tasks.iter_mut() {
             if !task.status.is_terminal() {
-                task.mailbox.push(SubAgentMessage::new(from, content.clone()));
+                task.mailbox
+                    .push(SubAgentMessage::new(from, content.clone()));
                 count += 1;
             }
         }
@@ -875,12 +871,7 @@ impl SubAgentManager {
 
 #[async_trait]
 impl SubAgentSpawner for SubAgentManager {
-    async fn spawn(
-        &self,
-        name: &str,
-        prompt: &str,
-        context: Option<String>,
-    ) -> Result<String> {
+    async fn spawn(&self, name: &str, prompt: &str, context: Option<String>) -> Result<String> {
         // The shared `tasks` map is an Arc<RwLock<..>>, so cloning the manager
         // shell is cheap and shares the same underlying task list with any
         // existing Arc<Self> the caller may already hold.
@@ -909,7 +900,9 @@ impl SubAgentSpawner for SubAgentManager {
             tasks: self.tasks.clone(),
             manager_config: self.manager_config.clone(),
         });
-        let handle = arc_self.spawn_single(name, prompt, context, timeout_secs).await?;
+        let handle = arc_self
+            .spawn_single(name, prompt, context, timeout_secs)
+            .await?;
         Ok(handle.id)
     }
 
@@ -1302,8 +1295,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_status_and_cancel() {
-        let mgr = Arc::new(make_manager_with_delayed("slow result", Duration::from_secs(5)));
-        let handle = mgr.spawn_single("slow-task", "take your time", None, None)
+        let mgr = Arc::new(make_manager_with_delayed(
+            "slow result",
+            Duration::from_secs(5),
+        ));
+        let handle = mgr
+            .spawn_single("slow-task", "take your time", None, None)
             .await
             .unwrap();
 
@@ -1326,7 +1323,8 @@ mod tests {
     #[tokio::test]
     async fn test_handle_completed() {
         let mgr = Arc::new(make_manager_with_mock(MockProvider::simple("done")));
-        let handle = mgr.spawn_single("fast-task", "quick work", None, None)
+        let handle = mgr
+            .spawn_single("fast-task", "quick work", None, None)
             .await
             .unwrap();
 
@@ -1349,7 +1347,12 @@ mod tests {
     async fn test_handle_with_context() {
         let mgr = Arc::new(make_manager_with_mock(MockProvider::simple("context ok")));
         let handle = mgr
-            .spawn_single("ctx-task", "use context", Some("extra info".to_string()), None)
+            .spawn_single(
+                "ctx-task",
+                "use context",
+                Some("extra info".to_string()),
+                None,
+            )
             .await
             .unwrap();
 
@@ -1456,10 +1459,13 @@ mod tests {
         // Actually use a very short timeout via direct construction
         let result = tokio::time::timeout(
             Duration::from_secs(5),
-            mgr.spawn_parallel(tasks, &ParallelSpawnConfig {
-                per_task_timeout_secs: 1, // 1s timeout, task takes 2s
-                ..Default::default()
-            }),
+            mgr.spawn_parallel(
+                tasks,
+                &ParallelSpawnConfig {
+                    per_task_timeout_secs: 1, // 1s timeout, task takes 2s
+                    ..Default::default()
+                },
+            ),
         )
         .await
         .unwrap()
@@ -1546,9 +1552,12 @@ mod tests {
         config.agent.model = "mock-model".to_string();
         config.agent.max_iterations = 5;
         let mut reg = ProviderRegistry::new();
-        reg.register("fail-second", FailOnSecond {
-            call_count: AtomicU32::new(0),
-        });
+        reg.register(
+            "fail-second",
+            FailOnSecond {
+                call_count: AtomicU32::new(0),
+            },
+        );
         reg.set_default("fail-second");
         let mgr = SubAgentManager::new(
             Arc::new(config),
@@ -1589,12 +1598,24 @@ mod tests {
         let summary = mgr.spawn_parallel(tasks, &spawn_config).await.unwrap();
 
         // One task should fail, others should succeed
-        assert_eq!(summary.failed, 1, "Expected 1 failure, got {}", summary.failed);
-        assert_eq!(summary.succeeded, 2, "Expected 2 successes, got {}", summary.succeeded);
+        assert_eq!(
+            summary.failed, 1,
+            "Expected 1 failure, got {}",
+            summary.failed
+        );
+        assert_eq!(
+            summary.succeeded, 2,
+            "Expected 2 successes, got {}",
+            summary.succeeded
+        );
 
         // The failed task should have error info
         let failed_result = summary.results.iter().find(|r| !r.success).unwrap();
-        assert!(failed_result.output.contains("error") || failed_result.output.contains("Error") || failed_result.output.contains("fail"));
+        assert!(
+            failed_result.output.contains("error")
+                || failed_result.output.contains("Error")
+                || failed_result.output.contains("fail")
+        );
     }
 
     #[tokio::test]
@@ -1615,12 +1636,15 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_secs(5),
-            mgr.spawn_parallel(tasks, &ParallelSpawnConfig {
-                max_concurrent: 3,
-                per_task_timeout_secs: 10,
-                total_timeout_secs: Some(1), // 1s total, each task takes 500ms
-                ..Default::default()
-            }),
+            mgr.spawn_parallel(
+                tasks,
+                &ParallelSpawnConfig {
+                    max_concurrent: 3,
+                    per_task_timeout_secs: 10,
+                    total_timeout_secs: Some(1), // 1s total, each task takes 500ms
+                    ..Default::default()
+                },
+            ),
         )
         .await
         .unwrap()
@@ -1759,8 +1783,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_task_status_from_for_spawn_status() {
-        assert_eq!(SpawnStatus::from(&TaskStatus::Pending), SpawnStatus::Running);
-        assert_eq!(SpawnStatus::from(&TaskStatus::Running), SpawnStatus::Running);
+        assert_eq!(
+            SpawnStatus::from(&TaskStatus::Pending),
+            SpawnStatus::Running
+        );
+        assert_eq!(
+            SpawnStatus::from(&TaskStatus::Running),
+            SpawnStatus::Running
+        );
         assert_eq!(
             SpawnStatus::from(&TaskStatus::Completed("ok".into())),
             SpawnStatus::Completed("ok".into())
@@ -1867,7 +1897,10 @@ mod tests {
         config.agent.model = "mock-model".to_string();
         config.agent.max_iterations = 5;
         let mut reg = ProviderRegistry::new();
-        reg.register("mock", DelayedProvider::new("result", Duration::from_secs(10)));
+        reg.register(
+            "mock",
+            DelayedProvider::new("result", Duration::from_secs(10)),
+        );
         reg.set_default("mock");
 
         let mgr = Arc::new(SubAgentManager::with_manager_config(
@@ -1900,7 +1933,8 @@ mod tests {
         // Provider takes 5 seconds, timeout is 100ms
         let mgr = Arc::new(make_manager_with_delayed("slow", Duration::from_secs(5)));
 
-        let handle = mgr.spawn_single("timed-task", "work", None, Some(1))
+        let handle = mgr
+            .spawn_single("timed-task", "work", None, Some(1))
             .await
             .unwrap();
 
@@ -1935,7 +1969,9 @@ mod tests {
         let mgr = make_manager_with_mock(MockProvider::simple("ok"));
         let id = mgr.spawn("worker", "test").await;
 
-        let sent = mgr.send_message(&id, "parent", "hello from parent".into()).await;
+        let sent = mgr
+            .send_message(&id, "parent", "hello from parent".into())
+            .await;
         assert!(sent);
         assert_eq!(mgr.mailbox_len(&id).await, 1);
     }
@@ -1997,7 +2033,9 @@ mod tests {
         // Complete one so it won't receive
         mgr.complete(&id3, "done".into()).await;
 
-        let received = mgr.broadcast_message("coordinator", "all hands".into()).await;
+        let received = mgr
+            .broadcast_message("coordinator", "all hands".into())
+            .await;
         assert_eq!(received, 2); // id3 is terminal
 
         assert_eq!(mgr.mailbox_len(&id1).await, 1);
@@ -2057,7 +2095,10 @@ mod tests {
 
         // Task should be tracked
         let status = spawner.status(&id).await.unwrap();
-        assert!(matches!(status, SpawnStatus::Running | SpawnStatus::Completed(_)));
+        assert!(matches!(
+            status,
+            SpawnStatus::Running | SpawnStatus::Completed(_)
+        ));
     }
 
     #[tokio::test]

--- a/crates/nanobot-agent/tests/pipeline_e2e.rs
+++ b/crates/nanobot-agent/tests/pipeline_e2e.rs
@@ -10,9 +10,7 @@ use nanobot_agent::AgentLoop;
 use nanobot_bus::events::{AgentEvent, InboundMessage};
 use nanobot_bus::MessageBus;
 use nanobot_config::Config;
-use nanobot_core::{
-    FunctionCall, MessageType, Platform, SessionSource, ToolCall, Usage,
-};
+use nanobot_core::{FunctionCall, MessageType, Platform, SessionSource, ToolCall, Usage};
 use nanobot_providers::base::{
     BoxStream, CompletionChunk, CompletionRequest, CompletionResponse, LlmProvider, ToolCallDelta,
 };
@@ -46,12 +44,16 @@ impl LlmProvider for MockProvider {
 
     async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
-        let resp = self.responses.get(idx).cloned().unwrap_or(CompletionResponse {
-            content: Some("default mock response".to_string()),
-            tool_calls: None,
-            usage: None,
-            finish_reason: None,
-        });
+        let resp = self
+            .responses
+            .get(idx)
+            .cloned()
+            .unwrap_or(CompletionResponse {
+                content: Some("default mock response".to_string()),
+                tool_calls: None,
+                usage: None,
+                finish_reason: None,
+            });
         Ok(resp)
     }
 
@@ -156,13 +158,7 @@ async fn test_pipeline_simple_response() {
     }]);
     let tools = make_tools();
 
-    let agent_loop = AgentLoop::new(
-        config,
-        bus.clone(),
-        session_manager,
-        providers,
-        tools,
-    );
+    let agent_loop = AgentLoop::new(config, bus.clone(), session_manager, providers, tools);
 
     // Take the outbound receiver before starting
     let mut outbound_rx = bus.consume_outbound().await.unwrap();
@@ -233,13 +229,7 @@ async fn test_pipeline_with_tool_call() {
 
     let tools = make_tools();
 
-    let agent_loop = AgentLoop::new(
-        config,
-        bus.clone(),
-        session_manager,
-        providers,
-        tools,
-    );
+    let agent_loop = AgentLoop::new(config, bus.clone(), session_manager, providers, tools);
 
     let mut outbound_rx = bus.consume_outbound().await.unwrap();
 
@@ -256,7 +246,10 @@ async fn test_pipeline_with_tool_call() {
         .unwrap()
         .unwrap();
 
-    assert_eq!(outbound.content, "Found several Rust files in the workspace.");
+    assert_eq!(
+        outbound.content,
+        "Found several Rust files in the workspace."
+    );
     assert_eq!(outbound.channel, Platform::Telegram);
 
     agent_handle.abort();
@@ -277,13 +270,7 @@ async fn test_pipeline_events_emitted() {
     }]);
     let tools = make_tools();
 
-    let agent_loop = AgentLoop::new(
-        config,
-        bus.clone(),
-        session_manager,
-        providers,
-        tools,
-    );
+    let agent_loop = AgentLoop::new(config, bus.clone(), session_manager, providers, tools);
 
     let mut events_rx = bus.subscribe_events();
     let mut outbound_rx = bus.consume_outbound().await.unwrap();
@@ -292,9 +279,7 @@ async fn test_pipeline_events_emitted() {
         agent_loop.run().await.unwrap();
     });
 
-    bus.publish_inbound(make_inbound("test"))
-        .await
-        .unwrap();
+    bus.publish_inbound(make_inbound("test")).await.unwrap();
 
     // Wait for completion
     let _outbound = tokio::time::timeout(std::time::Duration::from_secs(5), outbound_rx.recv())
@@ -344,13 +329,7 @@ async fn test_pipeline_multiple_messages() {
     ]);
 
     let tools = make_tools();
-    let agent_loop = AgentLoop::new(
-        config,
-        bus.clone(),
-        session_manager,
-        providers,
-        tools,
-    );
+    let agent_loop = AgentLoop::new(config, bus.clone(), session_manager, providers, tools);
 
     let mut outbound_rx = bus.consume_outbound().await.unwrap();
 
@@ -359,9 +338,7 @@ async fn test_pipeline_multiple_messages() {
     });
 
     // First message
-    bus.publish_inbound(make_inbound("msg1"))
-        .await
-        .unwrap();
+    bus.publish_inbound(make_inbound("msg1")).await.unwrap();
 
     let out1 = tokio::time::timeout(std::time::Duration::from_secs(5), outbound_rx.recv())
         .await
@@ -370,9 +347,7 @@ async fn test_pipeline_multiple_messages() {
     assert_eq!(out1.content, "First response");
 
     // Second message
-    bus.publish_inbound(make_inbound("msg2"))
-        .await
-        .unwrap();
+    bus.publish_inbound(make_inbound("msg2")).await.unwrap();
 
     let out2 = tokio::time::timeout(std::time::Duration::from_secs(5), outbound_rx.recv())
         .await
@@ -389,14 +364,21 @@ async fn test_pipeline_provider_error_handled() {
     struct FailingProvider;
     #[async_trait]
     impl LlmProvider for FailingProvider {
-        fn name(&self) -> &str { "failing" }
-        async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+        fn name(&self) -> &str {
+            "failing"
+        }
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> anyhow::Result<CompletionResponse> {
             anyhow::bail!("Provider unavailable")
         }
         async fn complete_stream(&self, _request: CompletionRequest) -> anyhow::Result<BoxStream> {
             anyhow::bail!("Provider unavailable")
         }
-        fn supports_model(&self, _model: &str) -> bool { true }
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
     }
 
     let config = make_config();
@@ -409,13 +391,7 @@ async fn test_pipeline_provider_error_handled() {
     providers.set_default("failing");
 
     let tools = make_tools();
-    let agent_loop = AgentLoop::new(
-        config,
-        bus.clone(),
-        session_manager,
-        providers,
-        tools,
-    );
+    let agent_loop = AgentLoop::new(config, bus.clone(), session_manager, providers, tools);
 
     let mut events_rx = bus.subscribe_events();
 
@@ -423,9 +399,7 @@ async fn test_pipeline_provider_error_handled() {
         agent_loop.run().await.unwrap();
     });
 
-    bus.publish_inbound(make_inbound("test"))
-        .await
-        .unwrap();
+    bus.publish_inbound(make_inbound("test")).await.unwrap();
 
     // Should get a Started event
     let started = tokio::time::timeout(std::time::Duration::from_secs(5), events_rx.recv())

--- a/crates/nanobot-api/src/server.rs
+++ b/crates/nanobot-api/src/server.rs
@@ -16,6 +16,7 @@
 //! The server listens for SIGINT / SIGTERM and drains in-flight SSE streams
 //! via a `CancellationToken` before exiting.
 
+use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
 use axum::{
     body::Body,
     extract::{DefaultBodyLimit, State},
@@ -26,7 +27,6 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
 use futures::stream::Stream;
 use futures::StreamExt;
 use nanobot_agent::AgentRunner;
@@ -80,8 +80,7 @@ fn build_cors_layer(config: &Config) -> CorsLayer {
     let origins = &config.api.allowed_origins;
 
     if origins.len() == 1 && origins[0] == "*" {
-        return CorsLayer::permissive()
-            .max_age(std::time::Duration::from_secs(3600));
+        return CorsLayer::permissive().max_age(std::time::Duration::from_secs(3600));
     }
 
     let parsed: Vec<HeaderValue> = origins
@@ -91,11 +90,7 @@ fn build_cors_layer(config: &Config) -> CorsLayer {
 
     CorsLayer::new()
         .allow_origin(AllowOrigin::list(parsed))
-        .allow_methods([
-            Method::GET,
-            Method::POST,
-            Method::OPTIONS,
-        ])
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers([AUTHORIZATION, CONTENT_TYPE])
         .max_age(std::time::Duration::from_secs(3600))
 }
@@ -195,7 +190,10 @@ impl ApiServer {
     /// connections and the server drains existing requests.
     pub async fn run(&self) -> anyhow::Result<()> {
         let app = self.router();
-        let host: std::net::IpAddr = self.host.parse().unwrap_or(std::net::IpAddr::from([0, 0, 0, 0]));
+        let host: std::net::IpAddr = self
+            .host
+            .parse()
+            .unwrap_or(std::net::IpAddr::from([0, 0, 0, 0]));
         let addr = std::net::SocketAddr::from((host, self.port));
         info!("API server listening on {}", addr);
 
@@ -328,10 +326,7 @@ struct ErrorDetail {
 /// If the client sends an `x-request-id` header it is preserved; otherwise a
 /// new UUID v4 is generated. The ID is set on the response header and injected
 /// into the current tracing span for structured log correlation.
-async fn request_id_middleware(
-    req: Request<Body>,
-    next: Next,
-) -> impl IntoResponse {
+async fn request_id_middleware(req: Request<Body>, next: Next) -> impl IntoResponse {
     let request_id = req
         .headers()
         .get("x-request-id")
@@ -355,10 +350,7 @@ async fn request_id_middleware(
 /// Request logging middleware — logs method, path, status code, and latency.
 /// Also intercepts 413 Payload Too Large responses and returns an OpenAI-format
 /// JSON error body instead of Axum's default plain text.
-async fn request_log_middleware(
-    req: Request<Body>,
-    next: Next,
-) -> impl IntoResponse {
+async fn request_log_middleware(req: Request<Body>, next: Next) -> impl IntoResponse {
     let method = req.method().clone();
     let path = req.uri().path().to_owned();
     let start = Instant::now();
@@ -441,18 +433,12 @@ fn validation_error(message: impl Into<String>, code: Option<String>) -> axum::r
 fn validate_request(req: &ChatCompletionRequest) -> Result<(), axum::response::Response> {
     // Model must be non-empty
     if req.model.trim().is_empty() {
-        return Err(validation_error(
-            "Model must be a non-empty string",
-            None,
-        ));
+        return Err(validation_error("Model must be a non-empty string", None));
     }
 
     // Messages must not be empty
     if req.messages.is_empty() {
-        return Err(validation_error(
-            "Messages must be a non-empty array",
-            None,
-        ));
+        return Err(validation_error("Messages must be a non-empty array", None));
     }
 
     // Validate each message has a recognized role and non-empty content
@@ -493,10 +479,7 @@ fn validate_request(req: &ChatCompletionRequest) -> Result<(), axum::response::R
     // Validate max_tokens
     if let Some(max_tokens) = req.max_tokens {
         if max_tokens == 0 {
-            return Err(validation_error(
-                "max_tokens must be greater than 0",
-                None,
-            ));
+            return Err(validation_error("max_tokens must be greater than 0", None));
         }
     }
 
@@ -509,7 +492,10 @@ async fn chat_completions(
     State(state): State<AppState>,
     Json(req): Json<ChatCompletionRequest>,
 ) -> impl IntoResponse {
-    debug!("Chat completion request for model: {} (stream: {})", req.model, req.stream);
+    debug!(
+        "Chat completion request for model: {} (stream: {})",
+        req.model, req.stream
+    );
 
     // Validate request
     if let Err(resp) = validate_request(&req) {
@@ -520,7 +506,10 @@ async fn chat_completions(
     if state.provider_registry.get_provider(&req.model).is_none() {
         let error = ErrorResponse {
             error: ErrorDetail {
-                message: format!("Model '{}' not found. Check available models at GET /v1/models.", req.model),
+                message: format!(
+                    "Model '{}' not found. Check available models at GET /v1/models.",
+                    req.model
+                ),
                 r#type: "invalid_request_error".to_string(),
                 code: Some("model_not_found".to_string()),
             },
@@ -602,7 +591,10 @@ async fn non_stream_completion(
             warn!("Agent error: {}", e);
             let msg = e.to_string();
             let (status, code) = if msg.contains("429") {
-                (StatusCode::TOO_MANY_REQUESTS, Some("rate_limit_exceeded".to_string()))
+                (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Some("rate_limit_exceeded".to_string()),
+                )
             } else {
                 (StatusCode::INTERNAL_SERVER_ERROR, None)
             };
@@ -646,18 +638,19 @@ async fn stream_completion(
     let stream_result = runner.run(system_prompt, messages).await;
     let cancel = state.cancel.clone();
 
-    let stream: Pin<Box<dyn Stream<Item = Result<Event, Infallible>> + Send>> =
-        match stream_result {
-            Ok(result) => {
-                let content = result.content;
-                let usage = result.usage;
-                let id = completion_id;
-                let mdl = model;
-                let cr = created;
+    let stream: Pin<Box<dyn Stream<Item = Result<Event, Infallible>> + Send>> = match stream_result
+    {
+        Ok(result) => {
+            let content = result.content;
+            let usage = result.usage;
+            let id = completion_id;
+            let mdl = model;
+            let cr = created;
 
-                let events = futures::stream::iter(vec![
-                    // Chunk 1: role announcement
-                    Ok(Event::default().data(serde_json::json!({
+            let events = futures::stream::iter(vec![
+                // Chunk 1: role announcement
+                Ok(Event::default().data(
+                    serde_json::json!({
                         "id": id,
                         "object": "chat.completion.chunk",
                         "created": cr,
@@ -667,9 +660,12 @@ async fn stream_completion(
                             "delta": {"role": "assistant"},
                             "finish_reason": null
                         }]
-                    }).to_string())),
-                    // Chunk 2: content
-                    Ok(Event::default().data(serde_json::json!({
+                    })
+                    .to_string(),
+                )),
+                // Chunk 2: content
+                Ok(Event::default().data(
+                    serde_json::json!({
                         "id": id,
                         "object": "chat.completion.chunk",
                         "created": cr,
@@ -680,9 +676,12 @@ async fn stream_completion(
                             "finish_reason": null
                         }],
                         "usage": null
-                    }).to_string())),
-                    // Chunk 3: stop with usage
-                    Ok(Event::default().data(serde_json::json!({
+                    })
+                    .to_string(),
+                )),
+                // Chunk 3: stop with usage
+                Ok(Event::default().data(
+                    serde_json::json!({
                         "id": id,
                         "object": "chat.completion.chunk",
                         "created": cr,
@@ -697,34 +696,35 @@ async fn stream_completion(
                             "completion_tokens": usage.completion_tokens.unwrap_or(0),
                             "total_tokens": usage.total_tokens.unwrap_or(0)
                         }
-                    }).to_string())),
-                ]);
+                    })
+                    .to_string(),
+                )),
+            ]);
 
-                // On graceful shutdown, emit [DONE] then terminate.
-                // take_until truncates when the cancel token fires; chain appends
-                // the [DONE] sentinel so clients receive a clean end-of-stream signal.
-                let done_event = futures::stream::once(async move {
-                    Ok(Event::default().data("[DONE]"))
+            // On graceful shutdown, emit [DONE] then terminate.
+            // take_until truncates when the cancel token fires; chain appends
+            // the [DONE] sentinel so clients receive a clean end-of-stream signal.
+            let done_event =
+                futures::stream::once(async move { Ok(Event::default().data("[DONE]")) });
+            let stream = events
+                .take_until(cancel.cancelled_owned())
+                .chain(done_event);
+            Box::pin(stream)
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            Box::pin(futures::stream::once(async move {
+                let error = serde_json::json!({
+                    "error": {
+                        "message": format!("Agent error: {}", msg),
+                        "type": "server_error",
+                        "code": null
+                    }
                 });
-                let stream = events
-                    .take_until(cancel.cancelled_owned())
-                    .chain(done_event);
-                Box::pin(stream)
-            }
-            Err(e) => {
-                let msg = e.to_string();
-                Box::pin(futures::stream::once(async move {
-                    let error = serde_json::json!({
-                        "error": {
-                            "message": format!("Agent error: {}", msg),
-                            "type": "server_error",
-                            "code": null
-                        }
-                    });
-                    Ok(Event::default().data(error.to_string()))
-                }))
-            }
-        };
+                Ok(Event::default().data(error.to_string()))
+            }))
+        }
+    };
 
     let sse = Sse::new(stream).keep_alive(KeepAlive::default());
     sse.into_response()
@@ -843,7 +843,11 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
     match snapshot.clone() {
         Some(snap) => {
             let status = if snap.healthy {
-                if snap.degraded { "degraded" } else { "healthy" }
+                if snap.degraded {
+                    "degraded"
+                } else {
+                    "healthy"
+                }
             } else {
                 "unhealthy"
             };
@@ -892,9 +896,7 @@ async fn ready(State(state): State<AppState>) -> impl IntoResponse {
     let snapshot = state.health_snapshot.read();
 
     match snapshot.clone() {
-        Some(snap) if snap.healthy => {
-            (StatusCode::OK, Json(serde_json::json!({ "ready": true })))
-        }
+        Some(snap) if snap.healthy => (StatusCode::OK, Json(serde_json::json!({ "ready": true }))),
         Some(snap) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(serde_json::json!({
@@ -921,7 +923,9 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
     use nanobot_core::Usage;
-    use nanobot_providers::base::{BoxStream, CompletionChunk, CompletionRequest, CompletionResponse, LlmProvider};
+    use nanobot_providers::base::{
+        BoxStream, CompletionChunk, CompletionRequest, CompletionResponse, LlmProvider,
+    };
     use tower::ServiceExt;
 
     /// Mock provider for testing.
@@ -929,7 +933,9 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LlmProvider for MockProvider {
-        fn name(&self) -> &str { "mock" }
+        fn name(&self) -> &str {
+            "mock"
+        }
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             Ok(CompletionResponse {
                 content: Some("Mock response".to_string()),
@@ -952,7 +958,9 @@ mod tests {
             };
             Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
         }
-        fn supports_model(&self, _model: &str) -> bool { true }
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
     }
 
     fn test_state() -> AppState {
@@ -1042,7 +1050,10 @@ mod tests {
     #[tokio::test]
     async fn test_health_endpoint_no_snapshot() {
         let app = test_router();
-        let req = Request::builder().uri("/health").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -1067,7 +1078,10 @@ mod tests {
             .route("/health", get(health))
             .with_state(state);
 
-        let req = Request::builder().uri("/health").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -1092,7 +1106,10 @@ mod tests {
             .route("/health", get(health))
             .with_state(state);
 
-        let req = Request::builder().uri("/health").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -1116,7 +1133,10 @@ mod tests {
             .route("/health", get(health))
             .with_state(state);
 
-        let req = Request::builder().uri("/health").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -1127,7 +1147,10 @@ mod tests {
     #[tokio::test]
     async fn test_ready_endpoint_no_snapshot() {
         let app = test_router();
-        let req = Request::builder().uri("/ready").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/ready")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -1146,11 +1169,12 @@ mod tests {
         }]);
         *state.health_snapshot.write() = Some(snap);
 
-        let app = Router::new()
-            .route("/ready", get(ready))
-            .with_state(state);
+        let app = Router::new().route("/ready", get(ready)).with_state(state);
 
-        let req = Request::builder().uri("/ready").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/ready")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -1169,11 +1193,12 @@ mod tests {
         }]);
         *state.health_snapshot.write() = Some(snap);
 
-        let app = Router::new()
-            .route("/ready", get(ready))
-            .with_state(state);
+        let app = Router::new().route("/ready", get(ready)).with_state(state);
 
-        let req = Request::builder().uri("/ready").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/ready")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -1187,7 +1212,10 @@ mod tests {
     #[tokio::test]
     async fn test_models_endpoint_basic() {
         let app = test_router();
-        let req = Request::builder().uri("/v1/models").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/v1/models")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -1199,16 +1227,28 @@ mod tests {
     #[tokio::test]
     async fn test_models_lists_registered_providers() {
         let app = router_with_provider();
-        let req = Request::builder().uri("/v1/models").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/v1/models")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let ids = v["data"].as_array().unwrap().iter()
+        let ids = v["data"]
+            .as_array()
+            .unwrap()
+            .iter()
             .filter_map(|m| m["id"].as_str().map(String::from))
             .collect::<Vec<_>>();
-        assert!(ids.contains(&"mock".to_string()), "Should list 'mock' provider");
-        assert!(ids.contains(&"mock-model".to_string()), "Should list agent model");
+        assert!(
+            ids.contains(&"mock".to_string()),
+            "Should list 'mock' provider"
+        );
+        assert!(
+            ids.contains(&"mock-model".to_string()),
+            "Should list agent model"
+        );
     }
 
     // ─── Chat completions: validation ───────────────────
@@ -1230,7 +1270,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(v["error"]["message"].as_str().unwrap().contains("No user message"));
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("No user message"));
     }
 
     #[tokio::test]
@@ -1267,7 +1310,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(v["error"]["message"].as_str().unwrap().contains("non-empty array"));
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("non-empty array"));
     }
 
     #[tokio::test]
@@ -1288,7 +1334,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(v["error"]["message"].as_str().unwrap().contains("Temperature"));
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Temperature"));
     }
 
     #[tokio::test]
@@ -1327,7 +1376,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(v["error"]["message"].as_str().unwrap().contains("max_tokens"));
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("max_tokens"));
     }
 
     #[tokio::test]
@@ -1347,7 +1399,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(v["error"]["message"].as_str().unwrap().contains("invalid role"));
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("invalid role"));
     }
 
     #[tokio::test]
@@ -1367,7 +1422,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(v["error"]["message"].as_str().unwrap().contains("empty content"));
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("empty content"));
     }
 
     #[tokio::test]
@@ -1412,7 +1470,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(v["error"]["message"].as_str().unwrap().contains("not found"));
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("not found"));
         assert_eq!(v["error"]["code"].as_str(), Some("model_not_found"));
     }
 
@@ -1472,8 +1533,17 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         // SSE responses use 200 with text/event-stream
         assert_eq!(resp.status(), StatusCode::OK);
-        let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
-        assert!(ct.contains("text/event-stream"), "Expected SSE content type, got: {}", ct);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("text/event-stream"),
+            "Expected SSE content type, got: {}",
+            ct
+        );
     }
 
     #[tokio::test]
@@ -1497,24 +1567,43 @@ mod tests {
 
         // Should contain 4 data events: role, content, stop, [DONE]
         let data_count = body_str.matches("data:").count();
-        assert_eq!(data_count, 4, "Expected 4 SSE data events, got {}: {}", data_count, body_str);
+        assert_eq!(
+            data_count, 4,
+            "Expected 4 SSE data events, got {}: {}",
+            data_count, body_str
+        );
 
         // First chunk should have role announcement
-        assert!(body_str.contains("\"role\":\"assistant\"") || body_str.contains("\"role\": \"assistant\""),
-            "First chunk should contain role announcement");
+        assert!(
+            body_str.contains("\"role\":\"assistant\"")
+                || body_str.contains("\"role\": \"assistant\""),
+            "First chunk should contain role announcement"
+        );
 
         // Should contain the mock response content
-        assert!(body_str.contains("Mock response"), "Should contain content in SSE body");
+        assert!(
+            body_str.contains("Mock response"),
+            "Should contain content in SSE body"
+        );
 
         // Should contain finish_reason stop
-        assert!(body_str.contains("\"finish_reason\":\"stop\"") || body_str.contains("\"finish_reason\": \"stop\""),
-            "Final chunk should contain finish_reason: stop");
+        assert!(
+            body_str.contains("\"finish_reason\":\"stop\"")
+                || body_str.contains("\"finish_reason\": \"stop\""),
+            "Final chunk should contain finish_reason: stop"
+        );
 
         // Should contain usage info
-        assert!(body_str.contains("\"prompt_tokens\""), "Final chunk should contain usage info");
+        assert!(
+            body_str.contains("\"prompt_tokens\""),
+            "Final chunk should contain usage info"
+        );
 
         // Should end with [DONE] sentinel
-        assert!(body_str.contains("data: [DONE]"), "SSE stream should end with [DONE] sentinel");
+        assert!(
+            body_str.contains("data: [DONE]"),
+            "SSE stream should end with [DONE] sentinel"
+        );
     }
 
     #[tokio::test]
@@ -1549,8 +1638,14 @@ mod tests {
         assert!(ids.len() >= 2, "Should have at least 2 chunks with IDs");
         // All IDs should be identical
         let first_id = &ids[0];
-        assert!(ids.iter().all(|id| id == first_id), "All SSE chunks should have the same ID");
-        assert!(first_id.starts_with("chatcmpl-"), "ID should start with chatcmpl-");
+        assert!(
+            ids.iter().all(|id| id == first_id),
+            "All SSE chunks should have the same ID"
+        );
+        assert!(
+            first_id.starts_with("chatcmpl-"),
+            "ID should start with chatcmpl-"
+        );
     }
 
     // ─── Auth: 401 tests ─────────────────────────────────
@@ -1615,7 +1710,10 @@ mod tests {
     async fn test_auth_health_needs_no_key() {
         // Health endpoint should work without auth even when api_key is set
         let app = router_with_auth();
-        let req = Request::builder().uri("/health").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
@@ -1624,7 +1722,10 @@ mod tests {
     async fn test_auth_models_needs_no_key() {
         // Models endpoint should work without auth (matches OpenAI behavior)
         let app = router_with_auth();
-        let req = Request::builder().uri("/v1/models").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/v1/models")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
@@ -1649,7 +1750,8 @@ mod tests {
         let session_manager = SessionManager::new(tmp.path().to_path_buf()).unwrap();
         let providers = ProviderRegistry::new();
         let tools = ToolRegistry::new();
-        let server = ApiServer::with_registries(config, bus, session_manager, providers, tools, Some(9090));
+        let server =
+            ApiServer::with_registries(config, bus, session_manager, providers, tools, Some(9090));
         let _router = server.router();
     }
 
@@ -1784,7 +1886,10 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         // No provider registered → model not found (404)
-        assert!(resp.status() == StatusCode::NOT_FOUND || resp.status() == StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(
+            resp.status() == StatusCode::NOT_FOUND
+                || resp.status() == StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 
     // ─── CORS configuration tests ──────────────────────────
@@ -1881,7 +1986,10 @@ mod tests {
             .uri("/health")
             .header("origin", "https://trusted.example.com")
             .header("access-control-request-method", "POST")
-            .header("access-control-request-headers", "content-type,authorization")
+            .header(
+                "access-control-request-headers",
+                "content-type,authorization",
+            )
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -1977,10 +2085,16 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
-        let rid = resp.headers().get("x-request-id").expect("response should have x-request-id");
+        let rid = resp
+            .headers()
+            .get("x-request-id")
+            .expect("response should have x-request-id");
         let rid_str = rid.to_str().unwrap();
         // Should be a valid UUID
-        assert!(uuid::Uuid::parse_str(rid_str).is_ok(), "Generated request ID should be a valid UUID");
+        assert!(
+            uuid::Uuid::parse_str(rid_str).is_ok(),
+            "Generated request ID should be a valid UUID"
+        );
     }
 
     #[tokio::test]
@@ -2018,7 +2132,10 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let rid = resp.headers().get("x-request-id").expect("response should have x-request-id");
+        let rid = resp
+            .headers()
+            .get("x-request-id")
+            .expect("response should have x-request-id");
         assert_eq!(rid.to_str().unwrap(), "my-custom-id-123");
     }
 
@@ -2165,13 +2282,7 @@ mod tests {
             tool_calls: None,
         }];
 
-        let resp = stream_completion(
-            state,
-            req,
-            "test".to_string(),
-            messages,
-        )
-        .await;
+        let resp = stream_completion(state, req, "test".to_string(), messages).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         let ct = resp
@@ -2192,7 +2303,10 @@ mod tests {
             "Expected 1 SSE event ([DONE]) when cancel is pre-triggered, got {}: {}",
             data_count, body_str
         );
-        assert!(body_str.contains("[DONE]"), "Should contain [DONE] sentinel");
+        assert!(
+            body_str.contains("[DONE]"),
+            "Should contain [DONE] sentinel"
+        );
     }
 
     #[tokio::test]
@@ -2220,13 +2334,7 @@ mod tests {
             tool_calls: None,
         }];
 
-        let resp = stream_completion(
-            state,
-            req,
-            "test".to_string(),
-            messages,
-        )
-        .await;
+        let resp = stream_completion(state, req, "test".to_string(), messages).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -2237,6 +2345,9 @@ mod tests {
             "Expected 4 SSE events (3 chunks + [DONE]) without cancellation, got {}: {}",
             data_count, body_str
         );
-        assert!(body_str.contains("[DONE]"), "Should contain [DONE] sentinel");
+        assert!(
+            body_str.contains("[DONE]"),
+            "Should contain [DONE] sentinel"
+        );
     }
 }

--- a/crates/nanobot-api/tests/http_integration.rs
+++ b/crates/nanobot-api/tests/http_integration.rs
@@ -10,7 +10,9 @@ use nanobot_api::ApiServer;
 use nanobot_bus::MessageBus;
 use nanobot_config::Config;
 use nanobot_core::Usage;
-use nanobot_providers::base::{BoxStream, CompletionChunk, CompletionRequest, CompletionResponse, LlmProvider};
+use nanobot_providers::base::{
+    BoxStream, CompletionChunk, CompletionRequest, CompletionResponse, LlmProvider,
+};
 use nanobot_providers::ProviderRegistry;
 use nanobot_session::SessionManager;
 use nanobot_tools::ToolRegistry;
@@ -21,7 +23,9 @@ struct MockProvider;
 
 #[async_trait::async_trait]
 impl LlmProvider for MockProvider {
-    fn name(&self) -> &str { "mock" }
+    fn name(&self) -> &str {
+        "mock"
+    }
     async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         Ok(CompletionResponse {
             content: Some("Mock integration response".to_string()),
@@ -44,7 +48,9 @@ impl LlmProvider for MockProvider {
         };
         Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
     }
-    fn supports_model(&self, _model: &str) -> bool { true }
+    fn supports_model(&self, _model: &str) -> bool {
+        true
+    }
 }
 
 fn make_app() -> axum::Router {
@@ -55,7 +61,8 @@ fn make_app() -> axum::Router {
     let providers = ProviderRegistry::new();
     let tools = ToolRegistry::new();
 
-    let server = ApiServer::with_registries(config, bus, session_manager, providers, tools, Some(8080));
+    let server =
+        ApiServer::with_registries(config, bus, session_manager, providers, tools, Some(8080));
     server.router()
 }
 
@@ -122,7 +129,10 @@ async fn test_list_models_with_provider() {
 
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let ids = v["data"].as_array().unwrap().iter()
+    let ids = v["data"]
+        .as_array()
+        .unwrap()
+        .iter()
         .filter_map(|m| m["id"].as_str().map(String::from))
         .collect::<Vec<_>>();
     assert!(ids.contains(&"mock".to_string()));
@@ -175,7 +185,10 @@ async fn test_chat_completions_empty_messages() {
 
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert!(v["error"]["message"].as_str().unwrap().contains("non-empty"));
+    assert!(v["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("non-empty"));
 }
 
 #[tokio::test]
@@ -196,7 +209,10 @@ async fn test_chat_completions_invalid_temperature() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert!(v["error"]["message"].as_str().unwrap().contains("Temperature"));
+    assert!(v["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("Temperature"));
 }
 
 #[tokio::test]
@@ -217,7 +233,10 @@ async fn test_chat_completions_zero_max_tokens() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert!(v["error"]["message"].as_str().unwrap().contains("max_tokens"));
+    assert!(v["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("max_tokens"));
 }
 
 #[tokio::test]
@@ -289,7 +308,10 @@ async fn test_chat_completions_success() {
     assert_eq!(v["object"], "chat.completion");
     assert_eq!(v["model"], "mock-model");
     assert_eq!(v["choices"][0]["message"]["role"], "assistant");
-    assert_eq!(v["choices"][0]["message"]["content"], "Mock integration response");
+    assert_eq!(
+        v["choices"][0]["message"]["content"],
+        "Mock integration response"
+    );
     assert_eq!(v["choices"][0]["finish_reason"], "stop");
     assert_eq!(v["usage"]["prompt_tokens"], 10);
     assert_eq!(v["usage"]["completion_tokens"], 6);
@@ -315,7 +337,12 @@ async fn test_chat_completions_streaming() {
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
     assert!(ct.contains("text/event-stream"));
 }
 
@@ -341,20 +368,32 @@ async fn test_chat_completions_streaming_three_chunks() {
 
     // Should have exactly 4 SSE data events: role, content, stop, [DONE]
     let data_count = body_str.matches("data:").count();
-    assert_eq!(data_count, 4, "Expected 4 SSE chunks, got {}: {}", data_count, body_str);
+    assert_eq!(
+        data_count, 4,
+        "Expected 4 SSE chunks, got {}: {}",
+        data_count, body_str
+    );
 
     // First chunk: role announcement
-    assert!(body_str.contains("\"role\":\"assistant\"") || body_str.contains("\"role\": \"assistant\""));
+    assert!(
+        body_str.contains("\"role\":\"assistant\"") || body_str.contains("\"role\": \"assistant\"")
+    );
 
     // Second chunk: content
     assert!(body_str.contains("Mock integration response"));
 
     // Third chunk: finish_reason + usage
-    assert!(body_str.contains("\"finish_reason\":\"stop\"") || body_str.contains("\"finish_reason\": \"stop\""));
+    assert!(
+        body_str.contains("\"finish_reason\":\"stop\"")
+            || body_str.contains("\"finish_reason\": \"stop\"")
+    );
     assert!(body_str.contains("\"prompt_tokens\""));
 
     // Fourth event: [DONE] sentinel
-    assert!(body_str.contains("data: [DONE]"), "SSE stream should end with [DONE]");
+    assert!(
+        body_str.contains("data: [DONE]"),
+        "SSE stream should end with [DONE]"
+    );
 }
 
 #[tokio::test]

--- a/crates/nanobot-bus/src/events.rs
+++ b/crates/nanobot-bus/src/events.rs
@@ -148,10 +148,7 @@ pub enum AgentEvent {
     },
 
     /// Heartbeat requests a component restart.
-    RestartRequested {
-        component: String,
-        reason: String,
-    },
+    RestartRequested { component: String, reason: String },
 
     /// Gateway is reconnecting (possibly with resume).
     GatewayReconnecting {
@@ -167,9 +164,7 @@ pub enum AgentEvent {
     },
 
     /// Gateway starting a fresh identify (old session lost).
-    GatewayReidentify {
-        platform: String,
-    },
+    GatewayReidentify { platform: String },
 
     /// Health status changed (transition between healthy/degraded/unhealthy).
     HealthStatusChanged {

--- a/crates/nanobot-channels/src/base.rs
+++ b/crates/nanobot-channels/src/base.rs
@@ -59,12 +59,7 @@ pub trait BaseChannel: Send + Sync {
     /// Send a reaction emoji to a message.
     ///
     /// Default no-op — platforms that don't support reactions can ignore this.
-    async fn send_reaction(
-        &self,
-        _chat_id: &str,
-        _message_id: &str,
-        _emoji: &str,
-    ) -> Result<()> {
+    async fn send_reaction(&self, _chat_id: &str, _message_id: &str, _emoji: &str) -> Result<()> {
         Ok(())
     }
 

--- a/crates/nanobot-channels/src/commands.rs
+++ b/crates/nanobot-channels/src/commands.rs
@@ -104,7 +104,10 @@ fn handle_help() -> String {
     let mut out = String::new();
     let _ = writeln!(out, "Available commands:\n");
     let _ = writeln!(out, "/help     - Show this help message");
-    let _ = writeln!(out, "/status   - Show bot status, channels, and config summary");
+    let _ = writeln!(
+        out,
+        "/status   - Show bot status, channels, and config summary"
+    );
     let _ = writeln!(out, "/validate - Validate config.yaml and show results");
     let _ = writeln!(out, "/settings - Toggle preferences (notifications, model)");
     let _ = writeln!(out, "/history  - Browse recent conversation history");
@@ -171,10 +174,7 @@ pub fn handle_menu_callback(action: &str) -> (String, Option<InlineKeyboardMarku
         ),
         "validate" => (handle_validate(), Some(menu_keyboard())),
         "cancel" => ("Menu closed.".to_string(), None),
-        _ => (
-            format!("Unknown action: {action}"),
-            Some(menu_keyboard()),
-        ),
+        _ => (format!("Unknown action: {action}"), Some(menu_keyboard())),
     }
 }
 
@@ -442,7 +442,6 @@ pub fn handle_history_page(page: usize) -> CommandResponse {
 
 /// Implementation that accepts an explicit data directory (for testability).
 fn handle_history_page_impl(page: usize, data_dir: &std::path::Path) -> CommandResponse {
-
     let mgr = match SessionManager::new(data_dir.to_path_buf()) {
         Ok(m) => m,
         Err(e) => return CommandResponse::text(format!("Session store error: {e}")),
@@ -1280,12 +1279,24 @@ heartbeat:
         assert_eq!(kb.inline_keyboard.len(), 2);
         // Row 1: Status, Help
         assert_eq!(kb.inline_keyboard[0].len(), 2);
-        assert_eq!(kb.inline_keyboard[0][0].callback_data, Some("menu:status".to_string()));
-        assert_eq!(kb.inline_keyboard[0][1].callback_data, Some("menu:help".to_string()));
+        assert_eq!(
+            kb.inline_keyboard[0][0].callback_data,
+            Some("menu:status".to_string())
+        );
+        assert_eq!(
+            kb.inline_keyboard[0][1].callback_data,
+            Some("menu:help".to_string())
+        );
         // Row 2: Validate Config, Cancel
         assert_eq!(kb.inline_keyboard[1].len(), 2);
-        assert_eq!(kb.inline_keyboard[1][0].callback_data, Some("menu:validate".to_string()));
-        assert_eq!(kb.inline_keyboard[1][1].callback_data, Some("menu:cancel".to_string()));
+        assert_eq!(
+            kb.inline_keyboard[1][0].callback_data,
+            Some("menu:validate".to_string())
+        );
+        assert_eq!(
+            kb.inline_keyboard[1][1].callback_data,
+            Some("menu:cancel".to_string())
+        );
     }
 
     #[test]
@@ -1510,10 +1521,7 @@ providers:
 
     #[test]
     fn test_handle_history_single_page() {
-        let keys: Vec<String> = vec![
-            "telegram:123".to_string(),
-            "discord:456".to_string(),
-        ];
+        let keys: Vec<String> = vec!["telegram:123".to_string(), "discord:456".to_string()];
         let resp = handle_history(&keys, 0);
         assert!(resp.text.contains("Sessions"));
         assert!(resp.text.contains("telegram:123"));
@@ -1523,9 +1531,7 @@ providers:
 
     #[test]
     fn test_handle_history_multi_page() {
-        let keys: Vec<String> = (0..12)
-            .map(|i| format!("session:{}", i))
-            .collect();
+        let keys: Vec<String> = (0..12).map(|i| format!("session:{}", i)).collect();
         let resp = handle_history(&keys, 0);
         assert!(resp.text.contains("page 1/"));
         assert!(resp.keyboard.is_some());
@@ -1537,9 +1543,7 @@ providers:
 
     #[test]
     fn test_handle_history_second_page() {
-        let keys: Vec<String> = (0..12)
-            .map(|i| format!("session:{}", i))
-            .collect();
+        let keys: Vec<String> = (0..12).map(|i| format!("session:{}", i)).collect();
         let resp = handle_history(&keys, 1);
         assert!(resp.text.contains("page 2/"));
         // Page 2 should show items 6-11 (0-indexed 5-11, but 1-indexed 6-12).
@@ -1565,11 +1569,7 @@ providers:
 
     #[test]
     fn test_handle_history_shows_index_numbers() {
-        let keys: Vec<String> = vec![
-            "alpha".to_string(),
-            "beta".to_string(),
-            "gamma".to_string(),
-        ];
+        let keys: Vec<String> = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
         let resp = handle_history(&keys, 0);
         assert!(resp.text.contains("1. alpha"));
         assert!(resp.text.contains("2. beta"));
@@ -1727,9 +1727,7 @@ agent:
 
     #[test]
     fn test_rebuild_callback_data_with_payload() {
-        use crate::platforms::telegram::{
-            rebuild_callback_data, CallbackAction, CallbackContext,
-        };
+        use crate::platforms::telegram::{rebuild_callback_data, CallbackAction, CallbackContext};
         let ctx = CallbackContext {
             chat_id: "123".to_string(),
             message_id: "456".to_string(),
@@ -1746,9 +1744,7 @@ agent:
 
     #[test]
     fn test_rebuild_callback_data_without_payload() {
-        use crate::platforms::telegram::{
-            rebuild_callback_data, CallbackAction, CallbackContext,
-        };
+        use crate::platforms::telegram::{rebuild_callback_data, CallbackAction, CallbackContext};
         let ctx = CallbackContext {
             chat_id: "123".to_string(),
             message_id: "456".to_string(),

--- a/crates/nanobot-channels/src/platforms/discord.rs
+++ b/crates/nanobot-channels/src/platforms/discord.rs
@@ -109,8 +109,7 @@ mod intents {
     /// MESSAGE_CONTENT = 1 << 15
     pub const MESSAGE_CONTENT: i64 = 1 << 15;
     /// Combined intents for a text-based bot.
-    pub const TEXT_BOT: i64 =
-        GUILD_MESSAGES | DIRECT_MESSAGES | MESSAGE_CONTENT;
+    pub const TEXT_BOT: i64 = GUILD_MESSAGES | DIRECT_MESSAGES | MESSAGE_CONTENT;
 }
 
 /// A generic Gateway payload.
@@ -317,8 +316,7 @@ impl DiscordChannel {
         match &proxy_url {
             Some(url) => {
                 info!("Discord HTTP client using proxy: {}", url);
-                let proxy = reqwest::Proxy::all(url)
-                    .expect("Failed to create proxy from env var");
+                let proxy = reqwest::Proxy::all(url).expect("Failed to create proxy from env var");
                 reqwest::Client::builder()
                     .proxy(proxy)
                     .build()
@@ -455,10 +453,7 @@ impl DiscordChannel {
                 debug!("Discord read receipt sent");
             }
             Ok(r) => {
-                debug!(
-                    "Discord read receipt non-204 status: {}",
-                    r.status()
-                );
+                debug!("Discord read receipt non-204 status: {}", r.status());
             }
             Err(e) => {
                 debug!("Discord read receipt request failed: {e}");
@@ -692,7 +687,10 @@ impl DiscordChannel {
                 error!("Failed to send IDENTIFY: {}", e);
                 return SessionOutcome::ResumableDisconnect;
             }
-            info!("Discord Gateway IDENTIFY sent (intents: {})", intents::TEXT_BOT);
+            info!(
+                "Discord Gateway IDENTIFY sent (intents: {})",
+                intents::TEXT_BOT
+            );
             Self::emit_gateway_event(
                 event_tx,
                 AgentEvent::GatewayReidentify {
@@ -1016,10 +1014,7 @@ impl BaseChannel for DiscordChannel {
                 auth_header: format!("Bot {token}"),
             };
             tokio::spawn(async move {
-                Self::run_gateway(
-                    token, handler, running, event_tx, gateway_url, rest,
-                )
-                .await;
+                Self::run_gateway(token, handler, running, event_tx, gateway_url, rest).await;
             });
             info!("Discord Gateway listener spawned");
         }
@@ -1141,16 +1136,9 @@ impl BaseChannel for DiscordChannel {
         })
     }
 
-    async fn send_reaction(
-        &self,
-        chat_id: &str,
-        message_id: &str,
-        emoji: &str,
-    ) -> Result<()> {
+    async fn send_reaction(&self, chat_id: &str, message_id: &str, emoji: &str) -> Result<()> {
         let encoded = percent_encode_emoji(emoji);
-        let path = format!(
-            "/channels/{chat_id}/messages/{message_id}/reactions/{encoded}/@me"
-        );
+        let path = format!("/channels/{chat_id}/messages/{message_id}/reactions/{encoded}/@me");
         let url = format!("{}{}", self.api_base(), path);
         let mut req = self.client.put(&url);
         if let Some(auth) = self.auth_header() {
@@ -1252,11 +1240,7 @@ impl DiscordChannel {
     ///
     /// Uses `DELETE /channels/{channel_id}/messages/{message_id}`.
     /// Only the bot's own messages can be deleted (unless has MANAGE_MESSAGES).
-    pub async fn delete_message(
-        &self,
-        channel_id: &str,
-        message_id: &str,
-    ) -> Result<SendResult> {
+    pub async fn delete_message(&self, channel_id: &str, message_id: &str) -> Result<SendResult> {
         debug!(
             "Deleting Discord message {} in channel {}",
             message_id, channel_id
@@ -1516,7 +1500,10 @@ mod tests {
         };
         let json = serde_json::to_value(&body).unwrap();
         assert_eq!(json["content"], "");
-        assert_eq!(json["embed"]["image"]["url"], "https://example.com/new_img.png");
+        assert_eq!(
+            json["embed"]["image"]["url"],
+            "https://example.com/new_img.png"
+        );
         assert_eq!(json["embed"]["description"], "updated caption");
     }
 
@@ -1588,7 +1575,8 @@ mod tests {
 
     #[test]
     fn test_make_error_result_service_unavailable() {
-        let result = DiscordChannel::make_error_result(StatusCode::SERVICE_UNAVAILABLE, "overloaded");
+        let result =
+            DiscordChannel::make_error_result(StatusCode::SERVICE_UNAVAILABLE, "overloaded");
         assert!(!result.success);
         assert!(result.retryable);
     }
@@ -1710,11 +1698,13 @@ mod tests {
     #[test]
     fn test_backoff_sequence() {
         let mut backoff = 1u64;
-        let sequence: Vec<u64> = (0..10).map(|_| {
-            let current = backoff;
-            backoff = next_backoff(backoff);
-            current
-        }).collect();
+        let sequence: Vec<u64> = (0..10)
+            .map(|_| {
+                let current = backoff;
+                backoff = next_backoff(backoff);
+                current
+            })
+            .collect();
         assert_eq!(sequence, vec![1, 2, 4, 8, 16, 32, 60, 60, 60, 60]);
     }
 
@@ -1725,9 +1715,18 @@ mod tests {
     #[test]
     fn test_session_outcome_variants() {
         // Verify all variants exist and can be compared
-        assert_eq!(SessionOutcome::ResumableDisconnect, SessionOutcome::ResumableDisconnect);
-        assert_eq!(SessionOutcome::InvalidSessionResumable, SessionOutcome::InvalidSessionResumable);
-        assert_eq!(SessionOutcome::InvalidSessionNotResumable, SessionOutcome::InvalidSessionNotResumable);
+        assert_eq!(
+            SessionOutcome::ResumableDisconnect,
+            SessionOutcome::ResumableDisconnect
+        );
+        assert_eq!(
+            SessionOutcome::InvalidSessionResumable,
+            SessionOutcome::InvalidSessionResumable
+        );
+        assert_eq!(
+            SessionOutcome::InvalidSessionNotResumable,
+            SessionOutcome::InvalidSessionNotResumable
+        );
         assert_eq!(SessionOutcome::Shutdown, SessionOutcome::Shutdown);
         assert_eq!(SessionOutcome::Fatal, SessionOutcome::Fatal);
 
@@ -1817,7 +1816,11 @@ mod tests {
 
         let event = rx.try_recv().unwrap();
         match event {
-            AgentEvent::GatewayReconnecting { platform, attempt, resumable } => {
+            AgentEvent::GatewayReconnecting {
+                platform,
+                attempt,
+                resumable,
+            } => {
                 assert_eq!(platform, "discord");
                 assert_eq!(attempt, 1);
                 assert!(resumable);
@@ -1853,7 +1856,10 @@ mod tests {
 
         let event = rx.try_recv().unwrap();
         match event {
-            AgentEvent::GatewayResumed { platform, session_id } => {
+            AgentEvent::GatewayResumed {
+                platform,
+                session_id,
+            } => {
                 assert_eq!(platform, "discord");
                 assert_eq!(session_id, "sess_xyz");
             }
@@ -1942,7 +1948,11 @@ mod tests {
 
         // 3. Disconnect (ResumableDisconnect) — state preserved
         // 4. Reconnect with RESUME (using saved session_id + seq)
-        let resume = build_resume_payload("token", state.session_id.as_ref().unwrap(), state.last_seq.unwrap());
+        let resume = build_resume_payload(
+            "token",
+            state.session_id.as_ref().unwrap(),
+            state.last_seq.unwrap(),
+        );
         assert_eq!(resume["op"], opcodes::RESUME);
         assert_eq!(resume["d"]["session_id"], "sess_initial");
         assert_eq!(resume["d"]["seq"], 3);

--- a/crates/nanobot-channels/src/platforms/telegram.rs
+++ b/crates/nanobot-channels/src/platforms/telegram.rs
@@ -13,9 +13,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::Local;
+use parking_lot::Mutex as ParkMutex;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
-use parking_lot::Mutex as ParkMutex;
 
 use nanobot_bus::events::InboundMessage;
 use nanobot_core::{MediaAttachment, MessageType, Platform, SessionSource};
@@ -428,8 +428,9 @@ pub enum CallbackResponse {
 }
 
 /// Type-erased async callback handler.
-type BoxedHandler =
-    Box<dyn Fn(CallbackContext) -> Pin<Box<dyn Future<Output = CallbackResponse> + Send>> + Send + Sync>;
+type BoxedHandler = Box<
+    dyn Fn(CallbackContext) -> Pin<Box<dyn Future<Output = CallbackResponse> + Send>> + Send + Sync,
+>;
 
 /// Router that dispatches Telegram callback queries to registered handlers
 /// based on prefix matching.
@@ -546,8 +547,7 @@ impl TelegramChannel {
         match &proxy_url {
             Some(url) => {
                 info!("Telegram HTTP client using proxy: {}", url);
-                let proxy = reqwest::Proxy::all(url)
-                    .expect("Failed to create proxy from env var");
+                let proxy = reqwest::Proxy::all(url).expect("Failed to create proxy from env var");
                 reqwest::Client::builder()
                     .proxy(proxy)
                     .build()
@@ -762,21 +762,10 @@ impl TelegramChannel {
                     if crate::commands::matches_command(text, "reset") {
                         let session_key = format!("telegram:{}", msg.chat.id);
                         let response = crate::commands::handle_reset(&session_key);
-                        Self::send_direct_reply(
-                            &client,
-                            &base_url,
-                            msg.chat.id,
-                            &response,
-                            None,
-                        )
-                        .await;
-                        Self::send_read_receipt(
-                            &client,
-                            &base_url,
-                            msg.chat.id,
-                            msg.message_id,
-                        )
-                        .await;
+                        Self::send_direct_reply(&client, &base_url, msg.chat.id, &response, None)
+                            .await;
+                        Self::send_read_receipt(&client, &base_url, msg.chat.id, msg.message_id)
+                            .await;
                     } else if let Some(response) = crate::commands::try_handle_command(text) {
                         // Built-in command matched — reply directly, skip bus.
                         Self::send_direct_reply(
@@ -787,13 +776,8 @@ impl TelegramChannel {
                             response.keyboard.as_ref(),
                         )
                         .await;
-                        Self::send_read_receipt(
-                            &client,
-                            &base_url,
-                            msg.chat.id,
-                            msg.message_id,
-                        )
-                        .await;
+                        Self::send_read_receipt(&client, &base_url, msg.chat.id, msg.message_id)
+                            .await;
                     } else {
                         match Self::dispatch_message(&handler, &msg).await {
                             Ok(true) => {
@@ -813,14 +797,9 @@ impl TelegramChannel {
                         }
                     }
                 } else if let Some(cq) = update.callback_query {
-                    if let Err(e) = Self::dispatch_callback_query(
-                        &client,
-                        &base_url,
-                        &handler,
-                        &cq,
-                        &router,
-                    )
-                    .await
+                    if let Err(e) =
+                        Self::dispatch_callback_query(&client, &base_url, &handler, &cq, &router)
+                            .await
                     {
                         error!("Failed to dispatch Telegram callback query: {e}");
                     }
@@ -993,15 +972,26 @@ impl TelegramChannel {
             if router_guard.has_handler(&ctx.action.prefix) {
                 // Show loading animation before running the handler.
                 Self::edit_message_text_static(
-                    client, base_url, &chat_id, &message_id, "⏳ Loading...", None,
+                    client,
+                    base_url,
+                    &chat_id,
+                    &message_id,
+                    "⏳ Loading...",
+                    None,
                 )
                 .await;
                 if let Some(response) = router_guard.dispatch(ctx).await {
                     drop(router_guard);
                     // Answer the callback query so the button stops loading.
                     Self::answer_callback_query_static(client, base_url, &cq.id, None, false).await;
-                    Self::execute_callback_response(client, base_url, &chat_id, &message_id, response)
-                        .await;
+                    Self::execute_callback_response(
+                        client,
+                        base_url,
+                        &chat_id,
+                        &message_id,
+                        response,
+                    )
+                    .await;
                     return Ok(());
                 }
             }
@@ -1054,10 +1044,7 @@ impl TelegramChannel {
             "tg_message_id".to_string(),
             serde_json::json!(msg.message_id),
         );
-        metadata.insert(
-            "tg_callback_query_id".to_string(),
-            serde_json::json!(cq.id),
-        );
+        metadata.insert("tg_callback_query_id".to_string(), serde_json::json!(cq.id));
         metadata.insert("tg_callback_data".to_string(), serde_json::json!(data));
 
         let inbound = InboundMessage {
@@ -1124,7 +1111,6 @@ impl TelegramChannel {
         }
     }
 
-
     /// Execute a [`CallbackResponse`] against the Telegram API.
     async fn execute_callback_response(
         client: &reqwest::Client,
@@ -1152,7 +1138,8 @@ impl TelegramChannel {
                 if let (Ok(chat_id_num), Ok(msg_id_num)) =
                     (chat_id.parse::<i64>(), message_id.parse::<i64>())
                 {
-                    let reply_markup = keyboard.map(|kb| serde_json::to_value(&kb).unwrap_or_default());
+                    let reply_markup =
+                        keyboard.map(|kb| serde_json::to_value(&kb).unwrap_or_default());
                     let body = EditMessageTextBody {
                         chat_id: chat_id_num,
                         message_id: msg_id_num,
@@ -1208,7 +1195,10 @@ impl TelegramChannel {
                 async move {
                     let (text, keyboard) = crate::commands::handle_menu_callback(&action);
                     match keyboard {
-                        Some(kb) => CallbackResponse::EditMessage { text, keyboard: Some(kb) },
+                        Some(kb) => CallbackResponse::EditMessage {
+                            text,
+                            keyboard: Some(kb),
+                        },
                         None => CallbackResponse::EditMessage {
                             text,
                             keyboard: Some(
@@ -1260,7 +1250,6 @@ impl TelegramChannel {
             });
         }
     }
-
 
     /// Get a reference-counted handle to the callback router.
     ///
@@ -1448,12 +1437,7 @@ impl BaseChannel for TelegramChannel {
         Ok(())
     }
 
-    async fn send_reaction(
-        &self,
-        chat_id: &str,
-        message_id: &str,
-        emoji: &str,
-    ) -> Result<()> {
+    async fn send_reaction(&self, chat_id: &str, message_id: &str, emoji: &str) -> Result<()> {
         debug!(
             "Sending reaction '{}' to message {} in chat {}",
             emoji, message_id, chat_id
@@ -1857,10 +1841,7 @@ impl TelegramChannel {
 #[allow(dead_code)]
 pub(crate) fn rebuild_callback_data(ctx: &CallbackContext) -> String {
     match &ctx.action.payload {
-        Some(p) => format!(
-            "{}:{}:{}",
-            ctx.action.prefix, ctx.action.action, p
-        ),
+        Some(p) => format!("{}:{}:{}", ctx.action.prefix, ctx.action.action, p),
         None => format!("{}:{}", ctx.action.prefix, ctx.action.action),
     }
 }
@@ -2628,7 +2609,10 @@ mod tests {
             .url_button("Open", "https://example.com")
             .new_row()
             .build();
-        assert_eq!(kb.inline_keyboard[0][0].url, Some("https://example.com".to_string()));
+        assert_eq!(
+            kb.inline_keyboard[0][0].url,
+            Some("https://example.com".to_string())
+        );
         assert_eq!(kb.inline_keyboard[0][0].callback_data, None);
     }
 
@@ -2804,7 +2788,9 @@ mod tests {
     async fn test_answer_callback_query_no_server() {
         let channel = TelegramChannel::new();
         // Will fail to connect but should not panic.
-        let result = channel.answer_callback_query("cb123", Some("Done!"), false).await;
+        let result = channel
+            .answer_callback_query("cb123", Some("Done!"), false)
+            .await;
         assert!(result.is_ok());
     }
 
@@ -2850,9 +2836,7 @@ mod tests {
     #[tokio::test]
     async fn test_router_no_match_returns_none() {
         let mut router = CallbackRouter::new();
-        router.register("confirm", |_ctx| async {
-            CallbackResponse::Acknowledged
-        });
+        router.register("confirm", |_ctx| async { CallbackResponse::Acknowledged });
 
         let ctx = CallbackContext {
             chat_id: "123".into(),
@@ -3014,8 +2998,14 @@ mod tests {
             CallbackResponse::Reply("hi".into()),
             CallbackResponse::Reply("hi".into())
         );
-        assert_eq!(CallbackResponse::RemoveKeyboard, CallbackResponse::RemoveKeyboard);
-        assert_eq!(CallbackResponse::Acknowledged, CallbackResponse::Acknowledged);
+        assert_eq!(
+            CallbackResponse::RemoveKeyboard,
+            CallbackResponse::RemoveKeyboard
+        );
+        assert_eq!(
+            CallbackResponse::Acknowledged,
+            CallbackResponse::Acknowledged
+        );
         assert_eq!(
             CallbackResponse::Toast("ok".into()),
             CallbackResponse::Toast("ok".into())
@@ -3086,10 +3076,8 @@ mod tests {
 
         // Router matches → handler runs, returns Acknowledged.
         // No message sent to bus.
-        let result = TelegramChannel::dispatch_callback_query(
-            &client, base_url, &tx, &cq, &router,
-        )
-        .await;
+        let result =
+            TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router).await;
         // Should succeed (HTTP calls to localhost:0 fail but are only warned).
         assert!(result.is_ok() || result.is_err());
     }
@@ -3123,10 +3111,8 @@ mod tests {
             data: Some("unknown:something".to_string()),
         };
 
-        let result = TelegramChannel::dispatch_callback_query(
-            &client, base_url, &tx, &cq, &router,
-        )
-        .await;
+        let result =
+            TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router).await;
         if result.is_ok() {
             // Falls through to bus → InboundMessage produced.
             let inbound = rx.try_recv().unwrap();

--- a/crates/nanobot-channels/src/platforms/websocket.rs
+++ b/crates/nanobot-channels/src/platforms/websocket.rs
@@ -153,11 +153,8 @@ impl WebSocketChannel {
 
         while running.load(Ordering::Relaxed) {
             // Accept with timeout so we can check the running flag.
-            let accept = tokio::time::timeout(
-                std::time::Duration::from_secs(1),
-                listener.accept(),
-            )
-            .await;
+            let accept =
+                tokio::time::timeout(std::time::Duration::from_secs(1), listener.accept()).await;
 
             let (stream, addr) = match accept {
                 Ok(Ok((s, a))) => (s, a),
@@ -817,8 +814,7 @@ mod tests {
         assert_eq!(channel.client_count(), 2);
 
         // Get both client IDs.
-        let client_ids: Vec<String> =
-            channel.clients.iter().map(|e| e.key().clone()).collect();
+        let client_ids: Vec<String> = channel.clients.iter().map(|e| e.key().clone()).collect();
         assert_eq!(client_ids.len(), 2);
 
         // Send to each client independently.

--- a/crates/nanobot-channels/tests/discord_mock.rs
+++ b/crates/nanobot-channels/tests/discord_mock.rs
@@ -201,7 +201,8 @@ async fn test_discord_edit_message_not_found() {
 
 #[tokio::test]
 async fn test_discord_edit_message_forbidden() {
-    let mock_response = r#"{"message":"Cannot edit a message authored by another user.","code":50005}"#;
+    let mock_response =
+        r#"{"message":"Cannot edit a message authored by another user.","code":50005}"#;
     let (port, _handle) = start_mock_discord_server(mock_response, 403, MockMethod::Patch).await;
 
     let channel = DiscordChannel::with_token_and_url(
@@ -243,7 +244,10 @@ async fn test_discord_delete_message_not_found() {
         format!("http://127.0.0.1:{}/", port),
     );
 
-    let result = channel.delete_message("12345", "nonexistent").await.unwrap();
+    let result = channel
+        .delete_message("12345", "nonexistent")
+        .await
+        .unwrap();
     assert!(!result.success);
     assert!(result.error.is_some());
 }

--- a/crates/nanobot-channels/tests/gateway_routing.rs
+++ b/crates/nanobot-channels/tests/gateway_routing.rs
@@ -129,7 +129,10 @@ fn build_manager_with_mock(
 
     let mut registry = ChannelRegistry::new();
     registry.register(&platform_name, move || {
-        Box::new(MockChannel::new(platform_for_closure.clone(), sent_clone.clone()))
+        Box::new(MockChannel::new(
+            platform_for_closure.clone(),
+            sent_clone.clone(),
+        ))
     });
 
     let manager = ChannelManager::new(registry, bus.clone());
@@ -147,7 +150,9 @@ async fn test_outbound_routing_single_message() {
 
     // Start the mock telegram channel
     manager.start_channel("telegram").await.unwrap();
-    assert!(manager.running_channel_names().contains(&"telegram".to_string()));
+    assert!(manager
+        .running_channel_names()
+        .contains(&"telegram".to_string()));
 
     // Spawn outbound consumer in background
     let cm = Arc::new(manager);
@@ -344,10 +349,16 @@ async fn test_stop_all_multiple_channels() {
 
     let mut registry = ChannelRegistry::new();
     registry.register("telegram", move || {
-        Box::new(MockChannel::new(Platform::Telegram, telegram_sent_clone.clone()))
+        Box::new(MockChannel::new(
+            Platform::Telegram,
+            telegram_sent_clone.clone(),
+        ))
     });
     registry.register("discord", move || {
-        Box::new(MockChannel::new(Platform::Discord, discord_sent_clone.clone()))
+        Box::new(MockChannel::new(
+            Platform::Discord,
+            discord_sent_clone.clone(),
+        ))
     });
 
     let manager = ChannelManager::new(registry, bus);
@@ -377,7 +388,10 @@ async fn test_full_roundtrip_inbound_to_outbound() {
 
     let mut registry = ChannelRegistry::new();
     registry.register("telegram", move || {
-        Box::new(MockChannel::new(Platform::Telegram, telegram_sent_clone.clone()))
+        Box::new(MockChannel::new(
+            Platform::Telegram,
+            telegram_sent_clone.clone(),
+        ))
     });
 
     let manager = ChannelManager::new(registry, bus.clone());
@@ -450,7 +464,10 @@ async fn test_full_roundtrip_inbound_to_outbound() {
 /// echo replies as outbound messages. Returns a shutdown handle.
 fn spawn_mock_agent(
     bus: MessageBus,
-) -> (tokio::task::JoinHandle<()>, tokio::sync::watch::Sender<bool>) {
+) -> (
+    tokio::task::JoinHandle<()>,
+    tokio::sync::watch::Sender<bool>,
+) {
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
     let handle = tokio::spawn(async move {
@@ -504,7 +521,10 @@ async fn test_gateway_mock_agent_single_message() {
 
     let mut registry = ChannelRegistry::new();
     registry.register("telegram", move || {
-        Box::new(MockChannel::new(Platform::Telegram, telegram_sent_clone.clone()))
+        Box::new(MockChannel::new(
+            Platform::Telegram,
+            telegram_sent_clone.clone(),
+        ))
     });
 
     let manager = ChannelManager::new(registry, bus.clone());
@@ -542,7 +562,12 @@ async fn test_gateway_mock_agent_single_message() {
 
     // Verify the reply reached the mock channel
     let recorded = telegram_sent.lock().unwrap().clone();
-    assert_eq!(recorded.len(), 1, "Expected exactly 1 message, got {:?}", recorded);
+    assert_eq!(
+        recorded.len(),
+        1,
+        "Expected exactly 1 message, got {:?}",
+        recorded
+    );
     assert_eq!(recorded[0].0, "chat_100");
     assert_eq!(recorded[0].1, "Echo: Hello gateway!");
     assert_eq!(recorded[0].2, Some("msg_in_1".to_string()));
@@ -625,13 +650,23 @@ async fn test_gateway_mock_agent_multi_platform() {
 
     // Verify Telegram received its reply
     let tg_recorded = telegram_sent.lock().unwrap().clone();
-    assert_eq!(tg_recorded.len(), 1, "Telegram should have 1 message, got {:?}", tg_recorded);
+    assert_eq!(
+        tg_recorded.len(),
+        1,
+        "Telegram should have 1 message, got {:?}",
+        tg_recorded
+    );
     assert_eq!(tg_recorded[0].0, "tg_chat_1");
     assert_eq!(tg_recorded[0].1, "Echo: From Telegram");
 
     // Verify Discord received its reply
     let dc_recorded = discord_sent.lock().unwrap().clone();
-    assert_eq!(dc_recorded.len(), 1, "Discord should have 1 message, got {:?}", dc_recorded);
+    assert_eq!(
+        dc_recorded.len(),
+        1,
+        "Discord should have 1 message, got {:?}",
+        dc_recorded
+    );
     assert_eq!(dc_recorded[0].0, "dc_channel_1");
     assert_eq!(dc_recorded[0].1, "Echo: From Discord");
 
@@ -652,7 +687,10 @@ async fn test_gateway_mock_agent_burst_messages() {
 
     let mut registry = ChannelRegistry::new();
     registry.register("telegram", move || {
-        Box::new(MockChannel::new(Platform::Telegram, telegram_sent_clone.clone()))
+        Box::new(MockChannel::new(
+            Platform::Telegram,
+            telegram_sent_clone.clone(),
+        ))
     });
 
     let manager = ChannelManager::new(registry, bus.clone());
@@ -692,13 +730,26 @@ async fn test_gateway_mock_agent_burst_messages() {
 
     // All 10 echoes should have been routed back
     let recorded = telegram_sent.lock().unwrap().clone();
-    assert_eq!(recorded.len(), 10, "Expected 10 messages, got {}", recorded.len());
+    assert_eq!(
+        recorded.len(),
+        10,
+        "Expected 10 messages, got {}",
+        recorded.len()
+    );
 
     // Verify ordering and content
     for (i, call) in recorded.iter().enumerate() {
         assert_eq!(call.0, "chat_burst", "Message {i} has wrong chat_id");
-        assert_eq!(call.1, format!("Echo: Message {i}"), "Message {i} has wrong content");
-        assert_eq!(call.2, Some(format!("msg_burst_{i}")), "Message {i} has wrong reply_to");
+        assert_eq!(
+            call.1,
+            format!("Echo: Message {i}"),
+            "Message {i} has wrong content"
+        );
+        assert_eq!(
+            call.2,
+            Some(format!("msg_burst_{i}")),
+            "Message {i} has wrong reply_to"
+        );
     }
 
     // Cleanup
@@ -767,7 +818,11 @@ async fn test_gateway_mock_agent_cross_platform_isolation() {
 
     // Discord should have zero
     let dc_recorded = discord_sent.lock().unwrap().clone();
-    assert!(dc_recorded.is_empty(), "Discord should have 0 messages, got {:?}", dc_recorded);
+    assert!(
+        dc_recorded.is_empty(),
+        "Discord should have 0 messages, got {:?}",
+        dc_recorded
+    );
 
     // Cleanup
     let _ = agent_shutdown.send(true);
@@ -786,7 +841,10 @@ async fn test_gateway_graceful_shutdown() {
 
     let mut registry = ChannelRegistry::new();
     registry.register("telegram", move || {
-        Box::new(MockChannel::new(Platform::Telegram, telegram_sent_clone.clone()))
+        Box::new(MockChannel::new(
+            Platform::Telegram,
+            telegram_sent_clone.clone(),
+        ))
     });
 
     let manager = ChannelManager::new(registry, bus.clone());

--- a/crates/nanobot-channels/tests/proxy_client.rs
+++ b/crates/nanobot-channels/tests/proxy_client.rs
@@ -1,11 +1,11 @@
 //! Integration tests for config loading with env var expansion
 //! and gateway wiring.
 
+use nanobot_bus::MessageBus;
 use nanobot_channels::base::BaseChannel;
 use nanobot_channels::platforms::telegram::TelegramChannel;
 use nanobot_channels::registry::ChannelRegistry;
 use nanobot_channels::ChannelManager;
-use nanobot_bus::MessageBus;
 use nanobot_config::loader::{expand_env_vars, load_config};
 use nanobot_core::Platform;
 

--- a/crates/nanobot-config/examples/migrate.rs
+++ b/crates/nanobot-config/examples/migrate.rs
@@ -22,7 +22,10 @@ use std::path::PathBuf;
 
 /// Migrate Python nanobot config to nanobot-rs YAML format.
 #[derive(Parser)]
-#[command(name = "migrate", about = "Migrate Python nanobot config to nanobot-rs format")]
+#[command(
+    name = "migrate",
+    about = "Migrate Python nanobot config to nanobot-rs format"
+)]
 struct Cli {
     /// Path to Python nanobot config directory (e.g. ~/.nanobot).
     #[arg(long)]
@@ -62,8 +65,8 @@ fn main() -> Result<()> {
     // Print migration report to stderr so stdout stays clean for --dry-run
     print_report(&result.report);
 
-    let yaml = serde_yaml::to_string(&result.config)
-        .context("Failed to serialize config to YAML")?;
+    let yaml =
+        serde_yaml::to_string(&result.config).context("Failed to serialize config to YAML")?;
 
     if cli.dry_run {
         println!("{}", yaml);

--- a/crates/nanobot-config/src/lib.rs
+++ b/crates/nanobot-config/src/lib.rs
@@ -12,6 +12,8 @@ pub mod schema;
 pub mod validate;
 
 pub use loader::load_config;
-pub use python_migrate::{migrate_from_python, migrate_from_str, MigrationOptions, MigrationReport, MigrationResult};
+pub use python_migrate::{
+    migrate_from_python, migrate_from_str, MigrationOptions, MigrationReport, MigrationResult,
+};
 pub use schema::Config;
 pub use validate::{fill_defaults, validate, validate_and_fill, ValidationReport};

--- a/crates/nanobot-config/src/python_migrate.rs
+++ b/crates/nanobot-config/src/python_migrate.rs
@@ -94,11 +94,11 @@ impl MigrationResult {
         let mut s = String::new();
 
         // Field mapping summary
+        s.push_str(&format!("Migration Summary\n{}\n", "-".repeat(40)));
         s.push_str(&format!(
-            "Migration Summary\n{}\n",
-            "-".repeat(40)
+            "  Mapped fields:   {}\n",
+            self.report.mapped.len()
         ));
-        s.push_str(&format!("  Mapped fields:   {}\n", self.report.mapped.len()));
         s.push_str(&format!(
             "  Unmapped fields: {}\n",
             self.report.unmapped.len()
@@ -109,10 +109,7 @@ impl MigrationResult {
         let errors = self.validation.errors().len();
         let warnings = self.validation.warnings().len();
         if errors > 0 || warnings > 0 {
-            s.push_str(&format!(
-                "\nValidation\n{}\n",
-                "-".repeat(40)
-            ));
+            s.push_str(&format!("\nValidation\n{}\n", "-".repeat(40)));
             s.push_str(&format!("  Errors:   {}\n", errors));
             s.push_str(&format!("  Warnings: {}\n", warnings));
         }
@@ -204,17 +201,8 @@ impl fmt::Display for MigrationReport {
 
 /// Known channel names for per-channel config discovery.
 const KNOWN_CHANNELS: &[&str] = &[
-    "telegram",
-    "discord",
-    "slack",
-    "matrix",
-    "whatsapp",
-    "email",
-    "dingtalk",
-    "feishu",
-    "wecom",
-    "weixin",
-    "qq",
+    "telegram", "discord", "slack", "matrix", "whatsapp", "email", "dingtalk", "feishu", "wecom",
+    "weixin", "qq",
 ];
 
 // ---------------------------------------------------------------------------
@@ -228,7 +216,10 @@ const KNOWN_CHANNELS: &[&str] = &[
 /// per-channel configs at sibling directories like `~/.nanobot-telegram/config.json`.
 ///
 /// Validates the result and optionally writes to disk (unless dry-run).
-pub fn migrate_from_python(python_home: &Path, options: &MigrationOptions) -> Result<MigrationResult> {
+pub fn migrate_from_python(
+    python_home: &Path,
+    options: &MigrationOptions,
+) -> Result<MigrationResult> {
     // 1. Read main config (JSON or YAML)
     let main_config = if let Some(ref input) = options.input_file {
         read_python_config(input)?
@@ -325,11 +316,9 @@ pub fn migrate_from_python(python_home: &Path, options: &MigrationOptions) -> Re
 /// Does not probe for per-channel configs or write to disk.
 pub fn migrate_from_str(content: &str) -> Result<MigrationResult> {
     let py: PythonConfig = if content.trim_start().starts_with('{') {
-        serde_json::from_str(content)
-            .with_context(|| "Failed to parse as JSON")?
+        serde_json::from_str(content).with_context(|| "Failed to parse as JSON")?
     } else {
-        serde_yaml::from_str(content)
-            .with_context(|| "Failed to parse as YAML")?
+        serde_yaml::from_str(content).with_context(|| "Failed to parse as YAML")?
     };
 
     let mut report = MigrationReport::default();
@@ -381,11 +370,13 @@ fn read_python_config(path: &Path) -> Result<PythonConfig> {
         _ => {
             // Auto-detect: try JSON first, then YAML
             if raw.trim_start().starts_with('{') {
-                serde_json::from_str(&raw)
-                    .with_context(|| format!("Failed to parse Python config JSON: {}", path.display()))
+                serde_json::from_str(&raw).with_context(|| {
+                    format!("Failed to parse Python config JSON: {}", path.display())
+                })
             } else {
-                serde_yaml::from_str(&raw)
-                    .with_context(|| format!("Failed to parse Python config YAML: {}", path.display()))
+                serde_yaml::from_str(&raw).with_context(|| {
+                    format!("Failed to parse Python config YAML: {}", path.display())
+                })
             }
         }
     }
@@ -481,7 +472,10 @@ fn convert_providers(py: &PythonProviders, config: &mut Config, report: &mut Mig
             });
             report.add_mapped("providers.custom → custom_providers[0] (apiBase → base_url)");
         } else {
-            report.add_note("providers.custom", "No apiBase set, skipping custom provider");
+            report.add_note(
+                "providers.custom",
+                "No apiBase set, skipping custom provider",
+            );
         }
     }
 }
@@ -498,7 +492,10 @@ fn convert_channels(
     let mut telegram_py = py.telegram.clone();
     for (name, ch_cfg) in per_channel {
         if name == "telegram" {
-            telegram_py = Some(merge_telegram(telegram_py.as_ref(), &ch_cfg.channels.telegram));
+            telegram_py = Some(merge_telegram(
+                telegram_py.as_ref(),
+                &ch_cfg.channels.telegram,
+            ));
         }
     }
     if let Some(ref tg) = telegram_py {
@@ -677,7 +674,7 @@ fn merge_discord(
 fn merge_slack(
     base: Option<&PythonSlackConfig>,
     override_cfg: &Option<PythonSlackConfig>,
-) ->PythonSlackConfig {
+) -> PythonSlackConfig {
     let base = base.cloned().unwrap_or_default();
     match override_cfg {
         Some(ov) => PythonSlackConfig {
@@ -891,7 +888,10 @@ mod tests {
     #[test]
     fn test_migration_options_with_output() {
         let opts = MigrationOptions::with_output("/tmp/test-config.yaml");
-        assert_eq!(opts.output_file.unwrap().to_str(), Some("/tmp/test-config.yaml"));
+        assert_eq!(
+            opts.output_file.unwrap().to_str(),
+            Some("/tmp/test-config.yaml")
+        );
     }
 
     // -------------------------------------------------------------------
@@ -973,7 +973,10 @@ mod tests {
         assert_eq!(dc.allowed_guilds, vec!["guild1"]);
         assert!(dc.streaming);
 
-        assert!(report.unmapped.iter().any(|u| u.contains("channels.discord.groupPolicy")));
+        assert!(report
+            .unmapped
+            .iter()
+            .any(|u| u.contains("channels.discord.groupPolicy")));
     }
 
     #[test]
@@ -987,7 +990,10 @@ mod tests {
         assert_eq!(sl.bot_token, Some("xoxb-123".to_string()));
         assert_eq!(sl.app_token, Some("xapp-456".to_string()));
 
-        assert!(report.unmapped.iter().any(|u| u.contains("channels.slack.allowFrom")));
+        assert!(report
+            .unmapped
+            .iter()
+            .any(|u| u.contains("channels.slack.allowFrom")));
     }
 
     #[test]
@@ -1054,7 +1060,10 @@ mod tests {
         assert!(!config.agent.streaming);
         assert_eq!(config.agent.tool_timeout, 60);
 
-        assert!(report.notes.iter().any(|n| n.contains("agents.defaults.provider")));
+        assert!(report
+            .notes
+            .iter()
+            .any(|n| n.contains("agents.defaults.provider")));
     }
 
     #[test]
@@ -1173,7 +1182,10 @@ mod tests {
         assert_eq!(parsed.agent.model, "anthropic/claude-opus-4-5");
         assert!(parsed.providers.openai.is_some());
         assert!(parsed.channels.telegram.is_some());
-        assert_eq!(parsed.channels.telegram.as_ref().unwrap().token, "123456:ABC-DEF");
+        assert_eq!(
+            parsed.channels.telegram.as_ref().unwrap().token,
+            "123456:ABC-DEF"
+        );
     }
 
     // -------------------------------------------------------------------
@@ -1273,7 +1285,11 @@ heartbeat:
         let result = migrate_from_str(make_full_python_json()).unwrap();
 
         // Full config should validate OK (has providers, channels, agent)
-        assert!(result.validation.is_valid(), "Validation errors: {:?}", result.validation.errors());
+        assert!(
+            result.validation.is_valid(),
+            "Validation errors: {:?}",
+            result.validation.errors()
+        );
     }
 
     #[test]
@@ -1390,7 +1406,10 @@ channels:
             Some("sk-yaml-file-test".to_string())
         );
         assert!(result.config.channels.telegram.is_some());
-        assert_eq!(result.config.channels.telegram.as_ref().unwrap().token, "111222:YAML-FILE");
+        assert_eq!(
+            result.config.channels.telegram.as_ref().unwrap().token,
+            "111222:YAML-FILE"
+        );
     }
 
     #[test]
@@ -1406,7 +1425,10 @@ channels:
 
         let result = migrate_from_python(&py_home, &opts);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No config.json or config.yaml"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No config.json or config.yaml"));
     }
 
     #[test]
@@ -1547,7 +1569,10 @@ channels:
 
         let result = migrate_from_python(&py_home, &opts).unwrap();
         assert!(result.config.channels.telegram.is_some());
-        assert_eq!(result.config.channels.telegram.as_ref().unwrap().token, "777888:PER-YAML");
+        assert_eq!(
+            result.config.channels.telegram.as_ref().unwrap().token,
+            "777888:PER-YAML"
+        );
     }
 
     // -------------------------------------------------------------------
@@ -1575,7 +1600,11 @@ channels:
     fn test_read_python_config_json_extension() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("config.json");
-        fs::write(&path, r#"{"providers": {"openai": {"apiKey": "sk-ext-test"}}}"#).unwrap();
+        fs::write(
+            &path,
+            r#"{"providers": {"openai": {"apiKey": "sk-ext-test"}}}"#,
+        )
+        .unwrap();
 
         let config = read_python_config(&path).unwrap();
         assert!(config.providers.openai.is_some());
@@ -1605,7 +1634,11 @@ channels:
     fn test_read_python_config_no_extension_auto_detect() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("config");
-        fs::write(&path, r#"{"providers": {"openai": {"apiKey": "sk-noext"}}}"#).unwrap();
+        fs::write(
+            &path,
+            r#"{"providers": {"openai": {"apiKey": "sk-noext"}}}"#,
+        )
+        .unwrap();
 
         let config = read_python_config(&path).unwrap();
         assert!(config.providers.openai.is_some());

--- a/crates/nanobot-config/src/schema.rs
+++ b/crates/nanobot-config/src/schema.rs
@@ -65,6 +65,10 @@ pub struct Config {
     /// API server configuration.
     #[serde(default)]
     pub api: ApiConfig,
+
+    /// Daemon mode configuration.
+    #[serde(default)]
+    pub daemon: DaemonConfig,
 }
 
 impl Default for Config {
@@ -84,6 +88,7 @@ impl Default for Config {
             custom_providers: Vec::new(),
             mcp_servers: HashMap::new(),
             api: ApiConfig::default(),
+            daemon: DaemonConfig::default(),
         }
     }
 }
@@ -590,6 +595,81 @@ impl Default for ApiConfig {
     }
 }
 
+/// Daemon mode configuration.
+///
+/// Controls native Unix daemon behavior: background process with PID file,
+/// signal handling, and file-based logging.
+///
+/// ```yaml
+/// daemon:
+///   enabled: false
+///   pid_file: ~/.nanobot-rs/nanobot-rs.pid
+///   log_dir: ~/.nanobot-rs/logs
+///   working_directory: /
+///   grace_period_secs: 30
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DaemonConfig {
+    /// Whether daemon mode is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Path to the PID file.
+    #[serde(default = "default_daemon_pid_file")]
+    pub pid_file: String,
+
+    /// Directory for log files.
+    #[serde(default = "default_daemon_log_dir")]
+    pub log_dir: String,
+
+    /// Working directory after daemonizing.
+    #[serde(default = "default_daemon_working_directory")]
+    pub working_directory: String,
+
+    /// Grace period in seconds for in-flight work during shutdown.
+    #[serde(default = "default_daemon_grace_period")]
+    pub grace_period_secs: u64,
+}
+
+fn default_daemon_pid_file() -> String {
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+    home.join(".nanobot-rs")
+        .join("nanobot-rs.pid")
+        .to_str()
+        .unwrap_or("/tmp/nanobot-rs.pid")
+        .to_string()
+}
+
+fn default_daemon_log_dir() -> String {
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+    home.join(".nanobot-rs")
+        .join("logs")
+        .to_str()
+        .unwrap_or("/tmp/nanobot-rs-logs")
+        .to_string()
+}
+
+fn default_daemon_working_directory() -> String {
+    "/".to_string()
+}
+
+const fn default_daemon_grace_period() -> u64 {
+    30
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            pid_file: default_daemon_pid_file(),
+            log_dir: default_daemon_log_dir(),
+            working_directory: default_daemon_working_directory(),
+            grace_period_secs: default_daemon_grace_period(),
+        }
+    }
+}
+
 /// Custom provider configuration for non-standard endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -925,5 +1005,45 @@ cron:
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.agent.model, "gpt-4o");
         assert!(config.agent.streaming);
+    }
+
+    #[test]
+    fn test_daemon_config_default() {
+        let dc = DaemonConfig::default();
+        assert!(!dc.enabled);
+        assert!(dc.pid_file.contains("nanobot-rs.pid"));
+        assert!(dc.log_dir.contains("logs"));
+        assert_eq!(dc.working_directory, "/");
+        assert_eq!(dc.grace_period_secs, 30);
+    }
+
+    #[test]
+    fn test_daemon_config_parse() {
+        let yaml = r#"
+daemon:
+  enabled: true
+  pid_file: /var/run/nanobot.pid
+  log_dir: /var/log/nanobot
+  working_directory: /opt
+  grace_period_secs: 60
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.daemon.enabled);
+        assert_eq!(config.daemon.pid_file, "/var/run/nanobot.pid");
+        assert_eq!(config.daemon.log_dir, "/var/log/nanobot");
+        assert_eq!(config.daemon.working_directory, "/opt");
+        assert_eq!(config.daemon.grace_period_secs, 60);
+    }
+
+    #[test]
+    fn test_daemon_config_yaml_roundtrip() {
+        let dc = DaemonConfig::default();
+        let yaml = serde_yaml::to_string(&dc).unwrap();
+        let parsed: DaemonConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.enabled, dc.enabled);
+        assert_eq!(parsed.pid_file, dc.pid_file);
+        assert_eq!(parsed.log_dir, dc.log_dir);
+        assert_eq!(parsed.working_directory, dc.working_directory);
+        assert_eq!(parsed.grace_period_secs, dc.grace_period_secs);
     }
 }

--- a/crates/nanobot-config/src/schema.rs
+++ b/crates/nanobot-config/src/schema.rs
@@ -598,11 +598,11 @@ impl Default for ApiConfig {
 /// Daemon mode configuration.
 ///
 /// Controls native Unix daemon behavior: background process with PID file,
-/// signal handling, and file-based logging.
+/// signal handling, and file-based logging. Activated via `nanobot-rs daemon start`
+/// on the CLI — there is no config-file toggle.
 ///
 /// ```yaml
 /// daemon:
-///   enabled: false
 ///   pid_file: ~/.nanobot-rs/nanobot-rs.pid
 ///   log_dir: ~/.nanobot-rs/logs
 ///   working_directory: /
@@ -611,10 +611,6 @@ impl Default for ApiConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct DaemonConfig {
-    /// Whether daemon mode is enabled.
-    #[serde(default)]
-    pub enabled: bool,
-
     /// Path to the PID file.
     #[serde(default = "default_daemon_pid_file")]
     pub pid_file: String,
@@ -661,7 +657,6 @@ const fn default_daemon_grace_period() -> u64 {
 impl Default for DaemonConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
             pid_file: default_daemon_pid_file(),
             log_dir: default_daemon_log_dir(),
             working_directory: default_daemon_working_directory(),
@@ -1013,7 +1008,6 @@ cron:
     #[test]
     fn test_daemon_config_default() {
         let dc = DaemonConfig::default();
-        assert!(!dc.enabled);
         assert!(dc.pid_file.contains("nanobot-rs.pid"));
         assert!(dc.log_dir.contains("logs"));
         assert_eq!(dc.working_directory, "/");
@@ -1024,14 +1018,12 @@ cron:
     fn test_daemon_config_parse() {
         let yaml = r#"
 daemon:
-  enabled: true
   pid_file: /var/run/nanobot.pid
   log_dir: /var/log/nanobot
   working_directory: /opt
   grace_period_secs: 60
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
-        assert!(config.daemon.enabled);
         assert_eq!(config.daemon.pid_file, "/var/run/nanobot.pid");
         assert_eq!(config.daemon.log_dir, "/var/log/nanobot");
         assert_eq!(config.daemon.working_directory, "/opt");
@@ -1043,7 +1035,6 @@ daemon:
         let dc = DaemonConfig::default();
         let yaml = serde_yaml::to_string(&dc).unwrap();
         let parsed: DaemonConfig = serde_yaml::from_str(&yaml).unwrap();
-        assert_eq!(parsed.enabled, dc.enabled);
         assert_eq!(parsed.pid_file, dc.pid_file);
         assert_eq!(parsed.log_dir, dc.log_dir);
         assert_eq!(parsed.working_directory, dc.working_directory);

--- a/crates/nanobot-config/src/schema.rs
+++ b/crates/nanobot-config/src/schema.rs
@@ -995,7 +995,10 @@ cron:
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert!(config.cron.enabled);
-        assert_eq!(config.cron.state_file, Some("/tmp/cron_state.json".to_string()));
+        assert_eq!(
+            config.cron.state_file,
+            Some("/tmp/cron_state.json".to_string())
+        );
         assert_eq!(config.cron.tick_secs, 30);
     }
 

--- a/crates/nanobot-config/src/validate.rs
+++ b/crates/nanobot-config/src/validate.rs
@@ -18,8 +18,8 @@
 
 use crate::schema::{
     AgentDefaults, ApiConfig, ChannelsConfig, Config, CronConfig, CustomProviderConfig,
-    DiscordConfig, DreamConfig, HeartbeatConfig, McpServerConfig, ProvidersConfig,
-    SecurityConfig, TelegramConfig,
+    DiscordConfig, DreamConfig, HeartbeatConfig, McpServerConfig, ProvidersConfig, SecurityConfig,
+    TelegramConfig,
 };
 use std::collections::HashSet;
 use std::fmt;
@@ -71,7 +71,9 @@ pub struct ValidationReport {
 
 impl ValidationReport {
     fn new() -> Self {
-        Self { findings: Vec::new() }
+        Self {
+            findings: Vec::new(),
+        }
     }
 
     fn error(&mut self, path: impl Into<String>, message: impl Into<String>) {
@@ -97,12 +99,18 @@ impl ValidationReport {
 
     /// Only error-level findings.
     pub fn errors(&self) -> Vec<&ValidationFinding> {
-        self.findings.iter().filter(|f| f.severity == Severity::Error).collect()
+        self.findings
+            .iter()
+            .filter(|f| f.severity == Severity::Error)
+            .collect()
     }
 
     /// Only warning-level findings.
     pub fn warnings(&self) -> Vec<&ValidationFinding> {
-        self.findings.iter().filter(|f| f.severity == Severity::Warning).collect()
+        self.findings
+            .iter()
+            .filter(|f| f.severity == Severity::Warning)
+            .collect()
     }
 
     /// Whether there are no errors.
@@ -297,7 +305,10 @@ fn validate_url(url: &str, path: &str, report: &mut ValidationReport) {
 fn validate_url_require_https(url: &str, path: &str, report: &mut ValidationReport) {
     validate_url(url, path, report);
     if url.starts_with("http://") {
-        report.warning(path, "URL uses HTTP instead of HTTPS — credentials may be exposed in transit");
+        report.warning(
+            path,
+            "URL uses HTTP instead of HTTPS — credentials may be exposed in transit",
+        );
     }
 }
 
@@ -342,7 +353,10 @@ fn validate_providers(
     if let Some(ref p) = providers.openrouter {
         has_provider = true;
         if p.api_key.as_deref().is_none_or(|k| k.is_empty()) {
-            report.warning("providers.openrouter.api_key", "API key is empty or missing");
+            report.warning(
+                "providers.openrouter.api_key",
+                "API key is empty or missing",
+            );
         }
     }
 
@@ -384,7 +398,10 @@ fn validate_providers(
         has_provider = true;
         if let Some(ref url) = p.base_url {
             if url.is_empty() {
-                report.warning("providers.ollama.base_url", "base_url is empty (default: http://localhost:11434)");
+                report.warning(
+                    "providers.ollama.base_url",
+                    "base_url is empty (default: http://localhost:11434)",
+                );
             }
         }
     }
@@ -393,15 +410,24 @@ fn validate_providers(
     if let Some(ref p) = providers.azure_openai {
         has_provider = true;
         if p.api_key.as_deref().is_none_or(|k| k.is_empty()) {
-            report.warning("providers.azure_openai.api_key", "API key is empty or missing");
+            report.warning(
+                "providers.azure_openai.api_key",
+                "API key is empty or missing",
+            );
         }
         if p.endpoint.as_deref().is_none_or(|e| e.is_empty()) {
-            report.error("providers.azure_openai.endpoint", "Azure endpoint is required");
+            report.error(
+                "providers.azure_openai.endpoint",
+                "Azure endpoint is required",
+            );
         } else if let Some(ref ep) = p.endpoint {
             validate_url(ep, "providers.azure_openai.endpoint", report);
         }
         if p.deployment.as_deref().is_none_or(|d| d.is_empty()) {
-            report.error("providers.azure_openai.deployment", "Deployment name is required");
+            report.error(
+                "providers.azure_openai.deployment",
+                "Deployment name is required",
+            );
         }
     }
 
@@ -428,7 +454,10 @@ fn validate_providers(
             );
         }
         if cp.base_url.is_empty() {
-            report.error(format!("{prefix}.base_url"), "Custom provider base_url is empty");
+            report.error(
+                format!("{prefix}.base_url"),
+                "Custom provider base_url is empty",
+            );
         } else {
             validate_url(&cp.base_url, &format!("{prefix}.base_url"), report);
         }
@@ -441,15 +470,26 @@ fn validate_providers(
     }
 
     if !has_provider {
-        report.error("providers", "No LLM provider configured — at least one provider is required");
+        report.error(
+            "providers",
+            "No LLM provider configured — at least one provider is required",
+        );
     }
 }
 
-fn validate_api_key_prefix(key: &str, path: &str, expected_prefix: &str, report: &mut ValidationReport) {
+fn validate_api_key_prefix(
+    key: &str,
+    path: &str,
+    expected_prefix: &str,
+    report: &mut ValidationReport,
+) {
     if !key.starts_with(expected_prefix) {
         report.warning(
             path,
-            format!("API key does not start with expected prefix '{}'", expected_prefix),
+            format!(
+                "API key does not start with expected prefix '{}'",
+                expected_prefix
+            ),
         );
     }
 }
@@ -480,7 +520,10 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if s.enabled {
             has_enabled_channel = true;
             if s.bot_token.as_deref().is_none_or(|t| t.is_empty()) {
-                report.error("channels.slack.bot_token", "Slack bot_token is required when enabled");
+                report.error(
+                    "channels.slack.bot_token",
+                    "Slack bot_token is required when enabled",
+                );
             }
         }
     }
@@ -490,13 +533,22 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if m.enabled {
             has_enabled_channel = true;
             if m.homeserver.as_deref().is_none_or(|h| h.is_empty()) {
-                report.error("channels.matrix.homeserver", "Matrix homeserver URL is required when enabled");
+                report.error(
+                    "channels.matrix.homeserver",
+                    "Matrix homeserver URL is required when enabled",
+                );
             }
             if m.user_id.as_deref().is_none_or(|u| u.is_empty()) {
-                report.error("channels.matrix.user_id", "Matrix user_id is required when enabled");
+                report.error(
+                    "channels.matrix.user_id",
+                    "Matrix user_id is required when enabled",
+                );
             }
             if m.access_token.is_none() && m.password.is_none() {
-                report.error("channels.matrix", "Either access_token or password is required for Matrix");
+                report.error(
+                    "channels.matrix",
+                    "Either access_token or password is required for Matrix",
+                );
             }
         }
     }
@@ -506,20 +558,46 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if e.enabled {
             has_enabled_channel = true;
             if e.imap_host.as_deref().is_none_or(|h| h.is_empty()) {
-                report.error("channels.email.imap_host", "IMAP host is required when email is enabled");
+                report.error(
+                    "channels.email.imap_host",
+                    "IMAP host is required when email is enabled",
+                );
             }
             if e.smtp_host.as_deref().is_none_or(|h| h.is_empty()) {
-                report.error("channels.email.smtp_host", "SMTP host is required when email is enabled");
+                report.error(
+                    "channels.email.smtp_host",
+                    "SMTP host is required when email is enabled",
+                );
             }
             if e.username.as_deref().is_none_or(|u| u.is_empty()) {
-                report.error("channels.email.username", "Username is required when email is enabled");
+                report.error(
+                    "channels.email.username",
+                    "Username is required when email is enabled",
+                );
             }
             if e.port == 0 {
-                report.warning("channels.email.port", "Email port is 0 — will use default (587 for SMTP)");
+                report.warning(
+                    "channels.email.port",
+                    "Email port is 0 — will use default (587 for SMTP)",
+                );
             } else if !(1..=65535).contains(&e.port) {
-                report.error("channels.email.port", format!("Port must be between 1 and 65535, got {}", e.port));
-            } else if e.port != 25 && e.port != 465 && e.port != 587 && e.port != 993 && e.port != 995 {
-                report.warning("channels.email.port", format!("Port {} is non-standard for email (common: 25, 465, 587, 993, 995)", e.port));
+                report.error(
+                    "channels.email.port",
+                    format!("Port must be between 1 and 65535, got {}", e.port),
+                );
+            } else if e.port != 25
+                && e.port != 465
+                && e.port != 587
+                && e.port != 993
+                && e.port != 995
+            {
+                report.warning(
+                    "channels.email.port",
+                    format!(
+                        "Port {} is non-standard for email (common: 25, 465, 587, 993, 995)",
+                        e.port
+                    ),
+                );
             }
         }
     }
@@ -529,7 +607,10 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if d.enabled {
             has_enabled_channel = true;
             if d.webhook.as_deref().is_none_or(|w| w.is_empty()) {
-                report.error("channels.dingtalk.webhook", "Webhook URL is required when DingTalk is enabled");
+                report.error(
+                    "channels.dingtalk.webhook",
+                    "Webhook URL is required when DingTalk is enabled",
+                );
             } else if let Some(ref url) = d.webhook {
                 validate_url_require_https(url, "channels.dingtalk.webhook", report);
             }
@@ -541,10 +622,16 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if f.enabled {
             has_enabled_channel = true;
             if f.app_id.as_deref().is_none_or(|a| a.is_empty()) {
-                report.error("channels.feishu.app_id", "App ID is required when Feishu is enabled");
+                report.error(
+                    "channels.feishu.app_id",
+                    "App ID is required when Feishu is enabled",
+                );
             }
             if f.app_secret.as_deref().is_none_or(|s| s.is_empty()) {
-                report.error("channels.feishu.app_secret", "App secret is required when Feishu is enabled");
+                report.error(
+                    "channels.feishu.app_secret",
+                    "App secret is required when Feishu is enabled",
+                );
             }
         }
     }
@@ -554,10 +641,16 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if w.enabled {
             has_enabled_channel = true;
             if w.corp_id.as_deref().is_none_or(|c| c.is_empty()) {
-                report.error("channels.wecom.corp_id", "Corp ID is required when WeCom is enabled");
+                report.error(
+                    "channels.wecom.corp_id",
+                    "Corp ID is required when WeCom is enabled",
+                );
             }
             if w.secret.as_deref().is_none_or(|s| s.is_empty()) {
-                report.error("channels.wecom.secret", "Secret is required when WeCom is enabled");
+                report.error(
+                    "channels.wecom.secret",
+                    "Secret is required when WeCom is enabled",
+                );
             }
         }
     }
@@ -567,7 +660,10 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if w.enabled {
             has_enabled_channel = true;
             if w.app_id.as_deref().is_none_or(|a| a.is_empty()) {
-                report.error("channels.weixin.app_id", "App ID is required when WeChat is enabled");
+                report.error(
+                    "channels.weixin.app_id",
+                    "App ID is required when WeChat is enabled",
+                );
             }
         }
     }
@@ -577,7 +673,10 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if q.enabled {
             has_enabled_channel = true;
             if q.app_id.as_deref().is_none_or(|a| a.is_empty()) {
-                report.error("channels.qq.app_id", "App ID is required when QQ is enabled");
+                report.error(
+                    "channels.qq.app_id",
+                    "App ID is required when QQ is enabled",
+                );
             }
         }
     }
@@ -587,7 +686,10 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
         if m.enabled {
             has_enabled_channel = true;
             if m.webhook_url.as_deref().is_none_or(|u| u.is_empty()) {
-                report.error("channels.mochat.webhook_url", "Webhook URL is required when Mochat is enabled");
+                report.error(
+                    "channels.mochat.webhook_url",
+                    "Webhook URL is required when Mochat is enabled",
+                );
             } else if let Some(ref url) = m.webhook_url {
                 validate_url_require_https(url, "channels.mochat.webhook_url", report);
             }
@@ -608,27 +710,45 @@ fn validate_channels(channels: &ChannelsConfig, report: &mut ValidationReport) {
     // WhatsApp
     if channels.whatsapp.as_ref().is_some_and(|w| w.enabled) {
         has_enabled_channel = true;
-        report.warning("channels.whatsapp", "WhatsApp channel is not yet implemented");
+        report.warning(
+            "channels.whatsapp",
+            "WhatsApp channel is not yet implemented",
+        );
     }
 
     if !has_enabled_channel {
-        report.warning("channels", "No channel is enabled — gateway will run in local-only mode");
+        report.warning(
+            "channels",
+            "No channel is enabled — gateway will run in local-only mode",
+        );
     }
 }
 
 fn validate_telegram(tg: &TelegramConfig, report: &mut ValidationReport) {
     if tg.token.is_empty() {
-        report.error("channels.telegram.token", "Bot token is required when Telegram is enabled");
+        report.error(
+            "channels.telegram.token",
+            "Bot token is required when Telegram is enabled",
+        );
     } else if !tg.token.contains(':') {
-        report.warning("channels.telegram.token", "Token format looks invalid — expected '123456:ABC-DEF'");
+        report.warning(
+            "channels.telegram.token",
+            "Token format looks invalid — expected '123456:ABC-DEF'",
+        );
     }
 }
 
 fn validate_discord(dc: &DiscordConfig, report: &mut ValidationReport) {
     if dc.token.is_empty() {
-        report.error("channels.discord.token", "Bot token is required when Discord is enabled");
+        report.error(
+            "channels.discord.token",
+            "Bot token is required when Discord is enabled",
+        );
     } else if dc.token.len() < 20 {
-        report.warning("channels.discord.token", "Token looks too short — expected a longer bot token");
+        report.warning(
+            "channels.discord.token",
+            "Token looks too short — expected a longer bot token",
+        );
     }
 }
 
@@ -649,14 +769,20 @@ fn validate_agent(agent: &AgentDefaults, report: &mut ValidationReport) {
     if !(0.0..=2.0).contains(&agent.temperature) {
         report.error(
             "agent.temperature",
-            format!("Temperature must be between 0.0 and 2.0, got {}", agent.temperature),
+            format!(
+                "Temperature must be between 0.0 and 2.0, got {}",
+                agent.temperature
+            ),
         );
     }
 
     if agent.max_tokens == 0 {
         report.error("agent.max_tokens", "max_tokens must be > 0");
     } else if agent.max_tokens > 128_000 {
-        report.warning("agent.max_tokens", "max_tokens > 128000 may not be supported by all models");
+        report.warning(
+            "agent.max_tokens",
+            "max_tokens > 128000 may not be supported by all models",
+        );
     }
 
     if agent.max_iterations == 0 {
@@ -669,7 +795,10 @@ fn validate_agent(agent: &AgentDefaults, report: &mut ValidationReport) {
     }
 
     if agent.tool_timeout == 0 {
-        report.warning("agent.tool_timeout", "tool_timeout of 0 means tools will timeout immediately");
+        report.warning(
+            "agent.tool_timeout",
+            "tool_timeout of 0 means tools will timeout immediately",
+        );
     }
 
     if let Some(ref workspace) = agent.workspace {
@@ -686,14 +815,23 @@ fn validate_agent(agent: &AgentDefaults, report: &mut ValidationReport) {
 fn validate_dream(dream: &DreamConfig, report: &mut ValidationReport) {
     if dream.enabled {
         if dream.interval_secs == 0 {
-            report.error("dream.interval_secs", "Dream interval must be > 0 when dream is enabled");
+            report.error(
+                "dream.interval_secs",
+                "Dream interval must be > 0 when dream is enabled",
+            );
         } else if dream.interval_secs < 60 {
-            report.warning("dream.interval_secs", "Dream interval < 60s may be too frequent and waste tokens");
+            report.warning(
+                "dream.interval_secs",
+                "Dream interval < 60s may be too frequent and waste tokens",
+            );
         }
 
         if let Some(ref model) = dream.model {
             if model.is_empty() {
-                report.warning("dream.model", "Dream model is set but empty — will fall back to agent model");
+                report.warning(
+                    "dream.model",
+                    "Dream model is set but empty — will fall back to agent model",
+                );
             }
         }
     }
@@ -706,11 +844,20 @@ fn validate_dream(dream: &DreamConfig, report: &mut ValidationReport) {
 fn validate_heartbeat(heartbeat: &HeartbeatConfig, report: &mut ValidationReport) {
     if heartbeat.enabled {
         if heartbeat.interval_secs == 0 {
-            report.error("heartbeat.interval_secs", "Heartbeat interval must be > 0 when heartbeat is enabled");
+            report.error(
+                "heartbeat.interval_secs",
+                "Heartbeat interval must be > 0 when heartbeat is enabled",
+            );
         } else if heartbeat.interval_secs < 10 {
-            report.warning("heartbeat.interval_secs", "Heartbeat interval < 10s may cause excessive load");
+            report.warning(
+                "heartbeat.interval_secs",
+                "Heartbeat interval < 10s may cause excessive load",
+            );
         } else if heartbeat.interval_secs > 86400 {
-            report.warning("heartbeat.interval_secs", "Heartbeat interval > 86400s (24h) means checks will be very infrequent");
+            report.warning(
+                "heartbeat.interval_secs",
+                "Heartbeat interval > 86400s (24h) means checks will be very infrequent",
+            );
         }
     }
 }
@@ -722,9 +869,15 @@ fn validate_heartbeat(heartbeat: &HeartbeatConfig, report: &mut ValidationReport
 fn validate_cron(cron: &CronConfig, report: &mut ValidationReport) {
     if cron.enabled {
         if cron.tick_secs == 0 {
-            report.error("cron.tick_secs", "Cron tick interval must be > 0 when cron is enabled");
+            report.error(
+                "cron.tick_secs",
+                "Cron tick interval must be > 0 when cron is enabled",
+            );
         } else if cron.tick_secs < 5 {
-            report.warning("cron.tick_secs", "Cron tick < 5s is very aggressive and may waste CPU");
+            report.warning(
+                "cron.tick_secs",
+                "Cron tick < 5s is very aggressive and may waste CPU",
+            );
         }
 
         if let Some(ref path) = cron.state_file {
@@ -742,14 +895,14 @@ fn validate_cron(cron: &CronConfig, report: &mut ValidationReport) {
 fn validate_security(security: &SecurityConfig, report: &mut ValidationReport) {
     for (i, cidr) in security.ssrf_whitelist.iter().enumerate() {
         if cidr.is_empty() {
-            report.warning(
-                format!("security.ssrf_whitelist[{i}]"),
-                "Empty CIDR entry",
-            );
+            report.warning(format!("security.ssrf_whitelist[{i}]"), "Empty CIDR entry");
         } else if cidr.parse::<ipnet::IpNet>().is_err() {
             report.warning(
                 format!("security.ssrf_whitelist[{i}]"),
-                format!("'{}' is not a valid CIDR (expected e.g. '10.0.0.0/8')", cidr),
+                format!(
+                    "'{}' is not a valid CIDR (expected e.g. '10.0.0.0/8')",
+                    cidr
+                ),
             );
         }
     }
@@ -763,7 +916,10 @@ fn validate_security(security: &SecurityConfig, report: &mut ValidationReport) {
         } else if cidr.parse::<ipnet::IpNet>().is_err() {
             report.warning(
                 format!("security.blocked_networks[{i}]"),
-                format!("'{}' is not a valid CIDR (expected e.g. '192.168.0.0/16')", cidr),
+                format!(
+                    "'{}' is not a valid CIDR (expected e.g. '192.168.0.0/16')",
+                    cidr
+                ),
             );
         }
     }
@@ -773,7 +929,10 @@ fn validate_security(security: &SecurityConfig, report: &mut ValidationReport) {
 // MCP server validation
 // ---------------------------------------------------------------------------
 
-fn validate_mcp_servers(servers: &std::collections::HashMap<String, McpServerConfig>, report: &mut ValidationReport) {
+fn validate_mcp_servers(
+    servers: &std::collections::HashMap<String, McpServerConfig>,
+    report: &mut ValidationReport,
+) {
     for (name, srv) in servers {
         let prefix = format!("mcp_servers.{name}");
 
@@ -799,7 +958,10 @@ fn validate_mcp_servers(servers: &std::collections::HashMap<String, McpServerCon
             other => {
                 report.error(
                     format!("{prefix}.transport"),
-                    format!("Unknown transport '{}'. Must be 'stdio', 'sse', or 'http'", other),
+                    format!(
+                        "Unknown transport '{}'. Must be 'stdio', 'sse', or 'http'",
+                        other
+                    ),
                 );
             }
         }
@@ -839,18 +1001,24 @@ fn validate_api(api: &ApiConfig, report: &mut ValidationReport) {
     if api.max_body_size == 0 {
         report.error("api.max_body_size", "Max body size must be > 0");
     } else if api.max_body_size < 1024 {
-        report.warning("api.max_body_size", "Max body size < 1KB may reject legitimate requests");
+        report.warning(
+            "api.max_body_size",
+            "Max body size < 1KB may reject legitimate requests",
+        );
     }
     if api.allowed_origins.is_empty() {
-        report.warning("api.allowed_origins", "No CORS origins configured — API may reject browser requests");
+        report.warning(
+            "api.allowed_origins",
+            "No CORS origins configured — API may reject browser requests",
+        );
     } else {
         for (i, origin) in api.allowed_origins.iter().enumerate() {
             if origin.is_empty() {
-                report.warning(
-                    format!("api.allowed_origins[{i}]"),
-                    "Empty origin entry",
-                );
-            } else if origin != "*" && !origin.starts_with("http://") && !origin.starts_with("https://") {
+                report.warning(format!("api.allowed_origins[{i}]"), "Empty origin entry");
+            } else if origin != "*"
+                && !origin.starts_with("http://")
+                && !origin.starts_with("https://")
+            {
                 report.warning(
                     format!("api.allowed_origins[{i}]"),
                     format!("Origin '{}' should be '*' or start with http(s)://", origin),
@@ -874,16 +1042,36 @@ fn validate_cross_field(
 
     // Build list of configured provider names
     let mut configured: Vec<&str> = Vec::new();
-    if providers.openai.is_some() { configured.push("openai"); }
-    if providers.anthropic.is_some() { configured.push("anthropic"); }
-    if providers.openrouter.is_some() { configured.push("openrouter"); }
-    if providers.ollama.is_some() { configured.push("ollama"); }
-    if providers.deepseek.is_some() { configured.push("deepseek"); }
-    if providers.gemini.is_some() { configured.push("gemini"); }
-    if providers.groq.is_some() { configured.push("groq"); }
-    if providers.moonshot.is_some() { configured.push("moonshot"); }
-    if providers.minimax.is_some() { configured.push("minimax"); }
-    if providers.azure_openai.is_some() { configured.push("azure_openai"); }
+    if providers.openai.is_some() {
+        configured.push("openai");
+    }
+    if providers.anthropic.is_some() {
+        configured.push("anthropic");
+    }
+    if providers.openrouter.is_some() {
+        configured.push("openrouter");
+    }
+    if providers.ollama.is_some() {
+        configured.push("ollama");
+    }
+    if providers.deepseek.is_some() {
+        configured.push("deepseek");
+    }
+    if providers.gemini.is_some() {
+        configured.push("gemini");
+    }
+    if providers.groq.is_some() {
+        configured.push("groq");
+    }
+    if providers.moonshot.is_some() {
+        configured.push("moonshot");
+    }
+    if providers.minimax.is_some() {
+        configured.push("minimax");
+    }
+    if providers.azure_openai.is_some() {
+        configured.push("azure_openai");
+    }
     for cp in custom {
         configured.push(&cp.name);
     }
@@ -907,7 +1095,9 @@ fn validate_cross_field(
         channels.qq.as_ref().is_some_and(|q| q.enabled),
         channels.mochat.as_ref().is_some_and(|m| m.enabled),
         channels.whatsapp.as_ref().is_some_and(|w| w.enabled),
-    ].iter().any(|&v| v);
+    ]
+    .iter()
+    .any(|&v| v);
 
     if has_enabled_channel && configured.is_empty() {
         report.warning(
@@ -929,7 +1119,11 @@ fn validate_cross_field(
     // Custom providers match by model_patterns
     if !matched {
         for cp in custom {
-            if cp.model_patterns.iter().any(|p| model_lower.contains(&p.to_lowercase())) {
+            if cp
+                .model_patterns
+                .iter()
+                .any(|p| model_lower.contains(&p.to_lowercase()))
+            {
                 matched = true;
                 break;
             }
@@ -981,7 +1175,11 @@ fn validate_cross_field(
                 }
                 if !dream_matched {
                     for cp in custom {
-                        if cp.model_patterns.iter().any(|p| dm_lower.contains(&p.to_lowercase())) {
+                        if cp
+                            .model_patterns
+                            .iter()
+                            .any(|p| dm_lower.contains(&p.to_lowercase()))
+                        {
                             dream_matched = true;
                             break;
                         }
@@ -1090,7 +1288,10 @@ mod tests {
             path: "agent.model".to_string(),
             message: "cannot be empty".to_string(),
         };
-        assert_eq!(format!("{}", finding), "[ERROR] agent.model: cannot be empty");
+        assert_eq!(
+            format!("{}", finding),
+            "[ERROR] agent.model: cannot be empty"
+        );
     }
 
     #[test]
@@ -1137,7 +1338,10 @@ mod tests {
             no_proxy: None,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "providers.openai.api_key"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "providers.openai.api_key"));
     }
 
     #[test]
@@ -1150,7 +1354,10 @@ mod tests {
             no_proxy: None,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "providers.openai.api_key" && w.message.contains("sk-")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "providers.openai.api_key" && w.message.contains("sk-")));
     }
 
     #[test]
@@ -1163,7 +1370,10 @@ mod tests {
             no_proxy: None,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "providers.anthropic.api_key" && w.message.contains("sk-ant-")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "providers.anthropic.api_key" && w.message.contains("sk-ant-")));
     }
 
     #[test]
@@ -1236,7 +1446,10 @@ mod tests {
             no_proxy: None,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "providers.ollama.base_url"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "providers.ollama.base_url"));
     }
 
     // -------------------------------------------------------------------
@@ -1263,7 +1476,10 @@ mod tests {
         });
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "channels.telegram.token"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.telegram.token"));
     }
 
     #[test]
@@ -1277,7 +1493,10 @@ mod tests {
             streaming: false,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "channels.telegram.token"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "channels.telegram.token"));
     }
 
     #[test]
@@ -1292,7 +1511,10 @@ mod tests {
         });
         let report = validate(&config);
         // Should not error on token since disabled
-        assert!(report.errors().iter().all(|e| e.path != "channels.telegram.token"));
+        assert!(report
+            .errors()
+            .iter()
+            .all(|e| e.path != "channels.telegram.token"));
     }
 
     #[test]
@@ -1306,7 +1528,10 @@ mod tests {
         });
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "channels.discord.token"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.discord.token"));
     }
 
     #[test]
@@ -1319,7 +1544,10 @@ mod tests {
             streaming: false,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "channels.discord.token"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "channels.discord.token"));
     }
 
     #[test]
@@ -1333,7 +1561,10 @@ mod tests {
         });
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "channels.slack.bot_token"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.slack.bot_token"));
     }
 
     #[test]
@@ -1391,7 +1622,10 @@ mod tests {
         config.agent.temperature = -0.5;
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "agent.temperature"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "agent.temperature"));
     }
 
     #[test]
@@ -1400,7 +1634,10 @@ mod tests {
         config.agent.temperature = 3.0;
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "agent.temperature"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "agent.temperature"));
     }
 
     #[test]
@@ -1426,7 +1663,10 @@ mod tests {
         let mut config = make_valid_config();
         config.agent.max_tokens = 200_000;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "agent.max_tokens"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "agent.max_tokens"));
     }
 
     #[test]
@@ -1435,7 +1675,10 @@ mod tests {
         config.agent.max_iterations = 0;
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "agent.max_iterations"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "agent.max_iterations"));
     }
 
     #[test]
@@ -1443,7 +1686,10 @@ mod tests {
         let mut config = make_valid_config();
         config.agent.tool_timeout = 0;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "agent.tool_timeout"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "agent.tool_timeout"));
     }
 
     #[test]
@@ -1451,7 +1697,10 @@ mod tests {
         let mut config = make_valid_config();
         config.agent.workspace = Some(String::new());
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "agent.workspace"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "agent.workspace"));
     }
 
     // -------------------------------------------------------------------
@@ -1465,7 +1714,10 @@ mod tests {
         config.dream.interval_secs = 0;
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "dream.interval_secs"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "dream.interval_secs"));
     }
 
     #[test]
@@ -1474,7 +1726,10 @@ mod tests {
         config.dream.enabled = true;
         config.dream.interval_secs = 30;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "dream.interval_secs"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "dream.interval_secs"));
     }
 
     #[test]
@@ -1483,7 +1738,10 @@ mod tests {
         config.dream.enabled = false;
         config.dream.interval_secs = 0;
         let report = validate(&config);
-        assert!(report.errors().iter().all(|e| e.path != "dream.interval_secs"));
+        assert!(report
+            .errors()
+            .iter()
+            .all(|e| e.path != "dream.interval_secs"));
     }
 
     #[test]
@@ -1506,7 +1764,10 @@ mod tests {
         config.heartbeat.interval_secs = 0;
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "heartbeat.interval_secs"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "heartbeat.interval_secs"));
     }
 
     #[test]
@@ -1515,7 +1776,10 @@ mod tests {
         config.heartbeat.enabled = true;
         config.heartbeat.interval_secs = 5;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "heartbeat.interval_secs"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "heartbeat.interval_secs"));
     }
 
     #[test]
@@ -1524,7 +1788,10 @@ mod tests {
         config.heartbeat.enabled = true;
         config.heartbeat.interval_secs = 100_000;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "heartbeat.interval_secs" && w.message.contains("24h")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "heartbeat.interval_secs" && w.message.contains("24h")));
     }
 
     #[test]
@@ -1533,7 +1800,10 @@ mod tests {
         config.heartbeat.enabled = false;
         config.heartbeat.interval_secs = 0;
         let report = validate(&config);
-        assert!(report.errors().iter().all(|e| e.path != "heartbeat.interval_secs"));
+        assert!(report
+            .errors()
+            .iter()
+            .all(|e| e.path != "heartbeat.interval_secs"));
     }
 
     // -------------------------------------------------------------------
@@ -1574,7 +1844,10 @@ mod tests {
         config.cron.enabled = true;
         config.cron.state_file = Some(String::new());
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "cron.state_file"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "cron.state_file"));
     }
 
     // -------------------------------------------------------------------
@@ -1584,10 +1857,14 @@ mod tests {
     #[test]
     fn test_security_valid_cidr() {
         let mut config = make_valid_config();
-        config.security.ssrf_whitelist = vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()];
+        config.security.ssrf_whitelist =
+            vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()];
         config.security.blocked_networks = vec!["192.168.0.0/16".to_string()];
         let report = validate(&config);
-        assert!(report.warnings().iter().all(|w| !w.path.starts_with("security.")));
+        assert!(report
+            .warnings()
+            .iter()
+            .all(|w| !w.path.starts_with("security.")));
     }
 
     #[test]
@@ -1595,7 +1872,11 @@ mod tests {
         let mut config = make_valid_config();
         config.security.ssrf_whitelist = vec!["not-a-cidr".to_string()];
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "security.ssrf_whitelist[0]" && w.message.contains("not a valid CIDR")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "security.ssrf_whitelist[0]"
+                && w.message.contains("not a valid CIDR")));
     }
 
     #[test]
@@ -1603,7 +1884,10 @@ mod tests {
         let mut config = make_valid_config();
         config.security.blocked_networks = vec![String::new()];
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "security.blocked_networks[0]"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "security.blocked_networks[0]"));
     }
 
     #[test]
@@ -1611,7 +1895,10 @@ mod tests {
         let mut config = make_valid_config();
         config.security.ssrf_whitelist = vec!["::1/128".to_string(), "fd00::/8".to_string()];
         let report = validate(&config);
-        assert!(report.warnings().iter().all(|w| !w.path.starts_with("security.")));
+        assert!(report
+            .warnings()
+            .iter()
+            .all(|w| !w.path.starts_with("security.")));
     }
 
     // -------------------------------------------------------------------
@@ -1621,13 +1908,16 @@ mod tests {
     #[test]
     fn test_mcp_stdio_valid() {
         let mut config = make_valid_config();
-        config.mcp_servers.insert("fs".to_string(), McpServerConfig {
-            transport: "stdio".to_string(),
-            command: Some("mcp-fs".to_string()),
-            args: None,
-            url: None,
-            env: HashMap::new(),
-        });
+        config.mcp_servers.insert(
+            "fs".to_string(),
+            McpServerConfig {
+                transport: "stdio".to_string(),
+                command: Some("mcp-fs".to_string()),
+                args: None,
+                url: None,
+                env: HashMap::new(),
+            },
+        );
         let report = validate(&config);
         assert!(report.is_valid(), "Unexpected errors: {}", report);
     }
@@ -1635,28 +1925,37 @@ mod tests {
     #[test]
     fn test_mcp_stdio_missing_command() {
         let mut config = make_valid_config();
-        config.mcp_servers.insert("fs".to_string(), McpServerConfig {
-            transport: "stdio".to_string(),
-            command: None,
-            args: None,
-            url: None,
-            env: HashMap::new(),
-        });
+        config.mcp_servers.insert(
+            "fs".to_string(),
+            McpServerConfig {
+                transport: "stdio".to_string(),
+                command: None,
+                args: None,
+                url: None,
+                env: HashMap::new(),
+            },
+        );
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "mcp_servers.fs.command"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "mcp_servers.fs.command"));
     }
 
     #[test]
     fn test_mcp_sse_valid() {
         let mut config = make_valid_config();
-        config.mcp_servers.insert("remote".to_string(), McpServerConfig {
-            transport: "sse".to_string(),
-            command: None,
-            args: None,
-            url: Some("https://mcp.example.com/sse".to_string()),
-            env: HashMap::new(),
-        });
+        config.mcp_servers.insert(
+            "remote".to_string(),
+            McpServerConfig {
+                transport: "sse".to_string(),
+                command: None,
+                args: None,
+                url: Some("https://mcp.example.com/sse".to_string()),
+                env: HashMap::new(),
+            },
+        );
         let report = validate(&config);
         assert!(report.is_valid(), "Unexpected errors: {}", report);
     }
@@ -1664,31 +1963,44 @@ mod tests {
     #[test]
     fn test_mcp_http_missing_url() {
         let mut config = make_valid_config();
-        config.mcp_servers.insert("remote".to_string(), McpServerConfig {
-            transport: "http".to_string(),
-            command: None,
-            args: None,
-            url: None,
-            env: HashMap::new(),
-        });
+        config.mcp_servers.insert(
+            "remote".to_string(),
+            McpServerConfig {
+                transport: "http".to_string(),
+                command: None,
+                args: None,
+                url: None,
+                env: HashMap::new(),
+            },
+        );
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "mcp_servers.remote.url"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "mcp_servers.remote.url"));
     }
 
     #[test]
     fn test_mcp_unknown_transport() {
         let mut config = make_valid_config();
-        config.mcp_servers.insert("bad".to_string(), McpServerConfig {
-            transport: "grpc".to_string(),
-            command: None,
-            args: None,
-            url: None,
-            env: HashMap::new(),
-        });
+        config.mcp_servers.insert(
+            "bad".to_string(),
+            McpServerConfig {
+                transport: "grpc".to_string(),
+                command: None,
+                args: None,
+                url: None,
+                env: HashMap::new(),
+            },
+        );
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "mcp_servers.bad.transport" && e.message.contains("Unknown transport")));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "mcp_servers.bad.transport"
+                && e.message.contains("Unknown transport")));
     }
 
     // -------------------------------------------------------------------
@@ -1713,7 +2025,10 @@ mod tests {
         });
         config.agent.model = "gpt-4o".to_string(); // gpt keywords → openai, but only anthropic configured
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "agent.model" && w.message.contains("may not match")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "agent.model" && w.message.contains("may not match")));
     }
 
     #[test]
@@ -1824,7 +2139,10 @@ mod tests {
             no_proxy: None,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "providers.openai.api_key"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "providers.openai.api_key"));
     }
 
     // -------------------------------------------------------------------
@@ -1871,7 +2189,10 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.errors().iter().any(|e| e.path == "channels.dingtalk.webhook"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.dingtalk.webhook"));
     }
 
     #[test]
@@ -1883,7 +2204,10 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.errors().iter().all(|e| e.path != "channels.dingtalk.webhook"));
+        assert!(report
+            .errors()
+            .iter()
+            .all(|e| e.path != "channels.dingtalk.webhook"));
     }
 
     // -------------------------------------------------------------------
@@ -1898,7 +2222,10 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.errors().iter().any(|e| e.path == "channels.mochat.webhook_url"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.mochat.webhook_url"));
     }
 
     // -------------------------------------------------------------------
@@ -1915,7 +2242,10 @@ mod tests {
             no_proxy: None,
         });
         let report = validate(&config);
-        assert!(report.errors().iter().any(|e| e.path == "providers.openai.base_url"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "providers.openai.base_url"));
     }
 
     #[test]
@@ -1928,7 +2258,10 @@ mod tests {
             api_version: None,
         });
         let report = validate(&config);
-        assert!(report.errors().iter().any(|e| e.path == "providers.azure_openai.endpoint"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "providers.azure_openai.endpoint"));
     }
 
     // -------------------------------------------------------------------
@@ -1954,7 +2287,10 @@ mod tests {
         });
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "custom_providers[1].name" && e.message.contains("Duplicate")));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "custom_providers[1].name" && e.message.contains("Duplicate")));
     }
 
     // -------------------------------------------------------------------
@@ -1972,7 +2308,10 @@ mod tests {
             no_proxy: None,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "custom_providers[0].model_patterns"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "custom_providers[0].model_patterns"));
     }
 
     // -------------------------------------------------------------------
@@ -1991,7 +2330,10 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "channels.email.port" && w.message.contains("0")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "channels.email.port" && w.message.contains("0")));
     }
 
     #[test]
@@ -2006,7 +2348,10 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "channels.email.port" && w.message.contains("non-standard")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "channels.email.port" && w.message.contains("non-standard")));
     }
 
     #[test]
@@ -2021,7 +2366,10 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().all(|w| w.path != "channels.email.port"));
+        assert!(report
+            .warnings()
+            .iter()
+            .all(|w| w.path != "channels.email.port"));
     }
 
     // -------------------------------------------------------------------
@@ -2037,7 +2385,11 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "channels.dingtalk.webhook" && w.message.contains("HTTP instead of HTTPS")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "channels.dingtalk.webhook"
+                && w.message.contains("HTTP instead of HTTPS")));
     }
 
     #[test]
@@ -2048,7 +2400,11 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "channels.mochat.webhook_url" && w.message.contains("HTTP instead of HTTPS")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "channels.mochat.webhook_url"
+                && w.message.contains("HTTP instead of HTTPS")));
     }
 
     #[test]
@@ -2062,7 +2418,11 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "channels.matrix.homeserver" && w.message.contains("HTTP instead of HTTPS")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "channels.matrix.homeserver"
+                && w.message.contains("HTTP instead of HTTPS")));
     }
 
     #[test]
@@ -2076,7 +2436,10 @@ mod tests {
             enabled: true,
         });
         let report = validate(&config);
-        assert!(report.warnings().iter().all(|w| w.path != "channels.matrix.homeserver"));
+        assert!(report
+            .warnings()
+            .iter()
+            .all(|w| w.path != "channels.matrix.homeserver"));
     }
 
     // -------------------------------------------------------------------
@@ -2089,7 +2452,10 @@ mod tests {
         config.agent.model = "gpt 4o".to_string();
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "agent.model" && e.message.contains("whitespace")));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "agent.model" && e.message.contains("whitespace")));
     }
 
     // -------------------------------------------------------------------
@@ -2101,7 +2467,10 @@ mod tests {
         let mut config = make_valid_config();
         config.agent.max_iterations = 1000;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "agent.max_iterations" && w.message.contains("very high")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "agent.max_iterations" && w.message.contains("very high")));
     }
 
     // -------------------------------------------------------------------
@@ -2113,7 +2482,10 @@ mod tests {
         let mut config = make_valid_config();
         config.api.allowed_origins = vec!["example.com".to_string()];
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "api.allowed_origins[0]" && w.message.contains("should be")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "api.allowed_origins[0]" && w.message.contains("should be")));
     }
 
     #[test]
@@ -2121,7 +2493,10 @@ mod tests {
         let mut config = make_valid_config();
         config.api.allowed_origins = vec!["*".to_string()];
         let report = validate(&config);
-        assert!(report.warnings().iter().all(|w| !w.path.starts_with("api.allowed_origins")));
+        assert!(report
+            .warnings()
+            .iter()
+            .all(|w| !w.path.starts_with("api.allowed_origins")));
     }
 
     #[test]
@@ -2129,7 +2504,10 @@ mod tests {
         let mut config = make_valid_config();
         config.api.allowed_origins = vec!["https://example.com".to_string()];
         let report = validate(&config);
-        assert!(report.warnings().iter().all(|w| !w.path.starts_with("api.allowed_origins")));
+        assert!(report
+            .warnings()
+            .iter()
+            .all(|w| !w.path.starts_with("api.allowed_origins")));
     }
 
     #[test]
@@ -2137,7 +2515,10 @@ mod tests {
         let mut config = make_valid_config();
         config.api.max_body_size = 512;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "api.max_body_size" && w.message.contains("1KB")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "api.max_body_size" && w.message.contains("1KB")));
     }
 
     // -------------------------------------------------------------------
@@ -2150,7 +2531,10 @@ mod tests {
         config.dream.enabled = true;
         config.dream.model = Some("claude-3".to_string()); // only openai configured
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "dream.model" && w.message.contains("may not match")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "dream.model" && w.message.contains("may not match")));
     }
 
     #[test]
@@ -2186,7 +2570,9 @@ providers:
 "#;
         let findings = validate_raw_env_vars(yaml);
         assert!(!findings.is_empty());
-        assert!(findings.iter().any(|f| f.message.contains("THIS_VAR_DOES_NOT_EXIST_XYZ")));
+        assert!(findings
+            .iter()
+            .any(|f| f.message.contains("THIS_VAR_DOES_NOT_EXIST_XYZ")));
         assert_eq!(findings[0].severity, Severity::Warning);
     }
 
@@ -2200,7 +2586,11 @@ providers:
     api_key: ${PROBABLY_MISSING_VAR_ABC:-fallback-key}
 "#;
         let findings = validate_raw_env_vars(yaml);
-        assert!(findings.is_empty(), "Expected no findings for var with default, got: {:?}", findings);
+        assert!(
+            findings.is_empty(),
+            "Expected no findings for var with default, got: {:?}",
+            findings
+        );
     }
 
     #[test]
@@ -2214,7 +2604,11 @@ providers:
 "#;
         let findings = validate_raw_env_vars(yaml);
         std::env::remove_var("NANOBOT_TEST_SET_VAR");
-        assert!(findings.is_empty(), "Expected no findings for set var, got: {:?}", findings);
+        assert!(
+            findings.is_empty(),
+            "Expected no findings for set var, got: {:?}",
+            findings
+        );
     }
 
     #[test]
@@ -2242,10 +2636,13 @@ channels:
 "#;
         let findings = validate_raw_env_vars(yaml);
         assert_eq!(findings.len(), 2);
-        let names: Vec<&str> = findings.iter().map(|f| {
-            // Extract var name from message
-            f.message.split('\'').nth(1).unwrap_or("")
-        }).collect();
+        let names: Vec<&str> = findings
+            .iter()
+            .map(|f| {
+                // Extract var name from message
+                f.message.split('\'').nth(1).unwrap_or("")
+            })
+            .collect();
         assert!(names.contains(&"MISSING_AAA"));
         assert!(names.contains(&"MISSING_BBB"));
     }
@@ -2265,7 +2662,11 @@ channels:
         std::env::remove_var("MISSING_WITH_EMPTY_DEFAULT");
         let yaml = "key: ${MISSING_WITH_EMPTY_DEFAULT:-}\n";
         let findings = validate_raw_env_vars(yaml);
-        assert!(findings.is_empty(), "Expected no warning for var with empty default, got: {:?}", findings);
+        assert!(
+            findings.is_empty(),
+            "Expected no warning for var with empty default, got: {:?}",
+            findings
+        );
     }
 
     // -------------------------------------------------------------------
@@ -2295,7 +2696,10 @@ channels:
         let config = make_valid_config(); // has openai provider + telegram enabled
         let report = validate(&config);
         assert!(report.is_valid(), "Unexpected errors: {}", report);
-        assert!(report.warnings().iter().all(|w| !w.message.contains("no LLM provider")));
+        assert!(report
+            .warnings()
+            .iter()
+            .all(|w| !w.message.contains("no LLM provider")));
     }
 
     // -------------------------------------------------------------------
@@ -2318,7 +2722,10 @@ channels:
         config.agent.max_iterations = 500;
         let report = validate(&config);
         assert!(report.is_valid());
-        assert!(report.warnings().iter().all(|w| w.path != "agent.max_iterations"));
+        assert!(report
+            .warnings()
+            .iter()
+            .all(|w| w.path != "agent.max_iterations"));
     }
 
     #[test]
@@ -2326,7 +2733,10 @@ channels:
         let mut config = make_valid_config();
         config.agent.max_iterations = 501;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "agent.max_iterations" && w.message.contains("very high")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "agent.max_iterations" && w.message.contains("very high")));
     }
 
     #[test]
@@ -2361,7 +2771,10 @@ channels:
         config.dream.enabled = true;
         config.dream.interval_secs = 59;
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "dream.interval_secs"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "dream.interval_secs"));
     }
 
     #[test]
@@ -2369,7 +2782,10 @@ channels:
         let mut config = make_valid_config();
         config.api.allowed_origins = vec![];
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "api.allowed_origins"));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "api.allowed_origins"));
     }
 
     #[test]
@@ -2378,52 +2794,73 @@ channels:
         config.api.max_body_size = 0;
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "api.max_body_size"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "api.max_body_size"));
     }
 
     #[test]
     fn test_mcp_empty_command_error() {
         let mut config = make_valid_config();
-        config.mcp_servers.insert("bad".to_string(), McpServerConfig {
-            transport: "stdio".to_string(),
-            command: Some(String::new()),
-            args: None,
-            url: None,
-            env: HashMap::new(),
-        });
+        config.mcp_servers.insert(
+            "bad".to_string(),
+            McpServerConfig {
+                transport: "stdio".to_string(),
+                command: Some(String::new()),
+                args: None,
+                url: None,
+                env: HashMap::new(),
+            },
+        );
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "mcp_servers.bad.command"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "mcp_servers.bad.command"));
     }
 
     #[test]
     fn test_mcp_sse_empty_url_error() {
         let mut config = make_valid_config();
-        config.mcp_servers.insert("bad".to_string(), McpServerConfig {
-            transport: "sse".to_string(),
-            command: None,
-            args: None,
-            url: Some(String::new()),
-            env: HashMap::new(),
-        });
+        config.mcp_servers.insert(
+            "bad".to_string(),
+            McpServerConfig {
+                transport: "sse".to_string(),
+                command: None,
+                args: None,
+                url: Some(String::new()),
+                env: HashMap::new(),
+            },
+        );
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "mcp_servers.bad.url"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "mcp_servers.bad.url"));
     }
 
     #[test]
     fn test_mcp_sse_invalid_url_error() {
         let mut config = make_valid_config();
-        config.mcp_servers.insert("bad".to_string(), McpServerConfig {
-            transport: "http".to_string(),
-            command: None,
-            args: None,
-            url: Some("not-a-url".to_string()),
-            env: HashMap::new(),
-        });
+        config.mcp_servers.insert(
+            "bad".to_string(),
+            McpServerConfig {
+                transport: "http".to_string(),
+                command: None,
+                args: None,
+                url: Some("not-a-url".to_string()),
+                env: HashMap::new(),
+            },
+        );
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "mcp_servers.bad.url"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "mcp_servers.bad.url"));
     }
 
     #[test]
@@ -2436,7 +2873,10 @@ channels:
         });
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "channels.feishu.app_id"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.feishu.app_id"));
     }
 
     #[test]
@@ -2449,7 +2889,10 @@ channels:
         });
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "channels.feishu.app_secret"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.feishu.app_secret"));
     }
 
     #[test]
@@ -2482,7 +2925,10 @@ channels:
         });
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "channels.weixin.app_id"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.weixin.app_id"));
     }
 
     #[test]
@@ -2496,7 +2942,10 @@ channels:
         });
         let report = validate(&config);
         assert!(!report.is_valid());
-        assert!(report.errors().iter().any(|e| e.path == "channels.qq.app_id"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|e| e.path == "channels.qq.app_id"));
     }
 
     #[test]
@@ -2512,7 +2961,10 @@ channels:
         });
         let report = validate(&config);
         // port=1 is in range [1, 65535] but non-standard
-        assert!(report.warnings().iter().any(|w| w.path == "channels.email.port" && w.message.contains("non-standard")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "channels.email.port" && w.message.contains("non-standard")));
     }
 
     #[test]
@@ -2520,6 +2972,10 @@ channels:
         let mut config = make_valid_config();
         config.security.blocked_networks = vec!["not-valid".to_string()];
         let report = validate(&config);
-        assert!(report.warnings().iter().any(|w| w.path == "security.blocked_networks[0]" && w.message.contains("not a valid CIDR")));
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "security.blocked_networks[0]"
+                && w.message.contains("not a valid CIDR")));
     }
 }

--- a/crates/nanobot-cron/src/service.rs
+++ b/crates/nanobot-cron/src/service.rs
@@ -146,7 +146,10 @@ impl CronService {
 
         drop(store);
         if caught_up > 0 {
-            info!("Recovered {} job(s) that were due during downtime", caught_up);
+            info!(
+                "Recovered {} job(s) that were due during downtime",
+                caught_up
+            );
             let _ = self.persist();
         }
     }
@@ -393,7 +396,9 @@ impl CronService {
 
     /// Mark a job as completed with a result.
     pub fn mark_completed(&self, job_id: &str, result: Option<String>) {
-        let is_error = result.as_ref().is_some_and(|r| r.starts_with("error:") || r.starts_with("Error"));
+        let is_error = result
+            .as_ref()
+            .is_some_and(|r| r.starts_with("error:") || r.starts_with("Error"));
         let mut store = self.store.lock();
         if let Some(job) = store.jobs.iter_mut().find(|j| j.id == job_id) {
             if let Some(last_run) = job.history.last_mut() {
@@ -431,9 +436,8 @@ impl CronService {
             CRON_TICK_INTERVAL_SECS
         );
 
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(
-            CRON_TICK_INTERVAL_SECS,
-        ));
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(CRON_TICK_INTERVAL_SECS));
 
         while *self.running.read().await {
             interval.tick().await;
@@ -493,7 +497,12 @@ impl CronService {
             next_run: job.next_run.map(|dt| dt.with_timezone(&chrono::Utc)),
             is_active: job.state == JobState::Active,
             run_count: job.history.len() as u64,
-            last_error: job.history.iter().rev().find(|r| !r.success).and_then(|r| r.result.clone()),
+            last_error: job
+                .history
+                .iter()
+                .rev()
+                .find(|r| !r.success)
+                .and_then(|r| r.result.clone()),
         }
     }
 
@@ -652,7 +661,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let svc = make_service(dir.path());
         let job = svc
-            .add_job(make_at_schedule(false), make_payload(), Some("test".to_string()))
+            .add_job(
+                make_at_schedule(false),
+                make_payload(),
+                Some("test".to_string()),
+            )
             .unwrap();
         assert_eq!(job.name.as_deref(), Some("test"));
         assert_eq!(job.state, JobState::Active);
@@ -687,12 +700,20 @@ mod tests {
     fn test_list_jobs() {
         let dir = tempfile::tempdir().unwrap();
         let svc = make_service(dir.path());
-        svc.add_job(make_at_schedule(false), make_payload(), Some("a".to_string()))
-            .unwrap();
+        svc.add_job(
+            make_at_schedule(false),
+            make_payload(),
+            Some("a".to_string()),
+        )
+        .unwrap();
         svc.add_job(make_every_schedule(), make_payload(), Some("b".to_string()))
             .unwrap();
-        svc.add_job(make_cron_schedule("0 0 * * * * *"), make_payload(), Some("c".to_string()))
-            .unwrap();
+        svc.add_job(
+            make_cron_schedule("0 0 * * * * *"),
+            make_payload(),
+            Some("c".to_string()),
+        )
+        .unwrap();
         let jobs = svc.list_jobs();
         assert_eq!(jobs.len(), 3);
     }
@@ -702,7 +723,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let svc = make_service(dir.path());
         let job = svc
-            .add_job(make_at_schedule(false), make_payload(), Some("findme".to_string()))
+            .add_job(
+                make_at_schedule(false),
+                make_payload(),
+                Some("findme".to_string()),
+            )
             .unwrap();
         let found = svc.get_job(&job.id).unwrap();
         assert_eq!(found.name.as_deref(), Some("findme"));
@@ -716,7 +741,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let svc = make_service(dir.path());
         let job = svc
-            .add_job(make_every_schedule(), make_payload(), Some("orig".to_string()))
+            .add_job(
+                make_every_schedule(),
+                make_payload(),
+                Some("orig".to_string()),
+            )
             .unwrap();
 
         let new_schedule = CronSchedule {
@@ -862,11 +891,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let svc = make_service(dir.path());
         let _job = svc
-            .add_job(
-                make_cron_schedule("0 0 * * * * *"),
-                make_payload(),
-                None,
-            )
+            .add_job(make_cron_schedule("0 0 * * * * *"), make_payload(), None)
             .unwrap();
 
         // Manually set next_run to the past
@@ -956,7 +981,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let svc = make_service(dir.path());
         let job = svc
-            .add_job(make_every_schedule(), make_payload(), Some("orig".to_string()))
+            .add_job(
+                make_every_schedule(),
+                make_payload(),
+                Some("orig".to_string()),
+            )
             .unwrap();
         svc.update_job(&job.id, None, Some(make_payload_with("new")), None, None)
             .unwrap();
@@ -1200,7 +1229,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let svc = make_service(dir.path());
         let job = svc
-            .add_job(make_every_schedule(), make_payload(), Some("stateful".to_string()))
+            .add_job(
+                make_every_schedule(),
+                make_payload(),
+                Some("stateful".to_string()),
+            )
             .unwrap();
 
         let state = svc.get_job_state(&job.id).unwrap();
@@ -1311,7 +1344,11 @@ mod tests {
         let job_id = {
             let svc = make_service(dir.path());
             let job = svc
-                .add_job(make_every_schedule(), make_payload(), Some("survive".to_string()))
+                .add_job(
+                    make_every_schedule(),
+                    make_payload(),
+                    Some("survive".to_string()),
+                )
                 .unwrap();
 
             // Simulate some runs
@@ -1339,7 +1376,11 @@ mod tests {
         let job_id = {
             let svc = make_service(dir.path());
             let job = svc
-                .add_job(make_every_schedule(), make_payload(), Some("late".to_string()))
+                .add_job(
+                    make_every_schedule(),
+                    make_payload(),
+                    Some("late".to_string()),
+                )
                 .unwrap();
 
             // Manually set next_run to the past and persist
@@ -1378,7 +1419,11 @@ mod tests {
         let svc = CronService::with_state_store(dir.path().to_path_buf(), mem_store).unwrap();
 
         let job = svc
-            .add_job(make_every_schedule(), make_payload(), Some("custom".to_string()))
+            .add_job(
+                make_every_schedule(),
+                make_payload(),
+                Some("custom".to_string()),
+            )
             .unwrap();
 
         let state = svc.get_job_state(&job.id).unwrap();
@@ -1447,8 +1492,7 @@ mod tests {
         let svc = make_service(dir.path());
 
         // Create 3 jobs due now (past "at" schedule)
-        let past_ts = (Local::now() - chrono::Duration::seconds(10))
-            .timestamp_millis();
+        let past_ts = (Local::now() - chrono::Duration::seconds(10)).timestamp_millis();
 
         let mut job_ids = Vec::new();
         for (i, pri) in [0u32, 200, 50].iter().enumerate() {

--- a/crates/nanobot-cron/src/state_store.rs
+++ b/crates/nanobot-cron/src/state_store.rs
@@ -56,7 +56,10 @@ impl FileStateStore {
             HashMap::new()
         };
 
-        Ok(Self { path, cache: parking_lot::Mutex::new(cache) })
+        Ok(Self {
+            path,
+            cache: parking_lot::Mutex::new(cache),
+        })
     }
 
     /// Flush the in-memory cache to disk.
@@ -319,7 +322,9 @@ mod tests {
 
         {
             let store = FileStateStore::new(path.clone()).unwrap();
-            store.save_state("persist", &make_state("persist", true, 99)).unwrap();
+            store
+                .save_state("persist", &make_state("persist", true, 99))
+                .unwrap();
         }
 
         // Create a new instance from the same file

--- a/crates/nanobot-daemon/Cargo.toml
+++ b/crates/nanobot-daemon/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 nanobot-config = { path = "../nanobot-config" }
 anyhow = { workspace = true }
+libc = "0.2"
 nix = { version = "0.29", features = ["process", "signal", "fs"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/nanobot-daemon/Cargo.toml
+++ b/crates/nanobot-daemon/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nanobot-daemon"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+nanobot-config = { path = "../nanobot-config" }
+anyhow = { workspace = true }
+nix = { version = "0.29", features = ["process", "signal", "fs"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-appender = "0.2"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/nanobot-daemon/Cargo.toml
+++ b/crates/nanobot-daemon/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 nanobot-config = { path = "../nanobot-config" }
 anyhow = { workspace = true }
 nix = { version = "0.29", features = ["process", "signal", "fs"] }
+tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = "0.2"

--- a/crates/nanobot-daemon/src/daemonize.rs
+++ b/crates/nanobot-daemon/src/daemonize.rs
@@ -1,0 +1,122 @@
+//! Unix daemonization via double-fork.
+//!
+//! Follows the classic daemonization pattern:
+//! 1. First fork — parent exits, child continues
+//! 2. `setsid()` — create new session
+//! 3. Second fork — ensure process is not a session leader
+//! 4. `chdir("/")` + `umask(0)` — detach from filesystem
+//! 5. Redirect stdin/stdout/stderr to `/dev/null`
+//!
+//! **Critical**: Must run BEFORE the tokio runtime starts, because `fork()`
+//! only duplicates the calling thread — all other threads (including tokio's)
+//! are lost in the child.
+
+use anyhow::{Context, Result};
+use nix::sys::stat::{umask, Mode};
+use nix::unistd::{chdir, close, dup2, fork, setsid, ForkResult};
+use std::fs::File;
+use std::os::unix::io::{AsRawFd, FromRawFd};
+
+/// Daemonize the current process using the classic double-fork technique.
+///
+/// After this function returns, the caller is running as a background daemon
+/// with no controlling terminal, `cwd` set to `working_dir`, and stdio
+/// redirected to `/dev/null`.
+///
+/// # Arguments
+///
+/// * `working_dir` - Directory to change to after daemonizing (typically `/`).
+/// * `log_file` - Optional path to redirect stderr to (for post-daemonize errors).
+///
+/// # Errors
+///
+/// Returns an error if any fork, `setsid`, or I/O operation fails.
+///
+/// # Safety
+///
+/// This function must be called BEFORE any threads are spawned (including
+/// the tokio runtime). The child process after `fork()` only has the calling
+/// thread — all other threads vanish.
+pub fn daemonize(working_dir: &str, log_file: Option<&str>) -> Result<()> {
+    // First fork
+    match unsafe { fork() }.context("first fork")? {
+        ForkResult::Parent { .. } => {
+            // Parent exits — the caller sees the process end
+            std::process::exit(0);
+        }
+        ForkResult::Child => {}
+    }
+
+    // Child: create new session
+    setsid().context("setsid")?;
+
+    // Second fork — ensures process is not session leader (can't acquire terminal)
+    match unsafe { fork() }.context("second fork")? {
+        ForkResult::Parent { .. } => {
+            std::process::exit(0);
+        }
+        ForkResult::Child => {}
+    }
+
+    // Set working directory and umask
+    chdir(working_dir).context("chdir to working_dir")?;
+    umask(Mode::from_bits(0o022).unwrap());
+
+    // Redirect stdio to /dev/null (or log file for stderr)
+    redirect_stdio(log_file)?;
+
+    tracing::info!("Daemonized successfully (pid={})", std::process::id());
+    Ok(())
+}
+
+/// Redirect stdin, stdout, and stderr to `/dev/null` or a log file.
+///
+/// Stdin and stdout go to `/dev/null`. Stderr goes to `log_file` if provided,
+/// otherwise also to `/dev/null`.
+fn redirect_stdio(log_file: Option<&str>) -> Result<()> {
+    let devnull = File::open("/dev/null").context("open /dev/null")?;
+    let devnull_fd = devnull.as_raw_fd();
+
+    // stdin → /dev/null
+    dup2(devnull_fd, 0).context("dup2 stdin")?;
+    // stdout → /dev/null
+    dup2(devnull_fd, 1).context("dup2 stdout")?;
+
+    // stderr → log file or /dev/null
+    if let Some(path) = log_file {
+        let err_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .context("open log file for stderr")?;
+        dup2(err_file.as_raw_fd(), 2).context("dup2 stderr to log file")?;
+    } else {
+        dup2(devnull_fd, 2).context("dup2 stderr")?;
+    }
+
+    // Close the original /dev/null fd (fds 0,1,2 are now the active ones)
+    close(devnull_fd).ok();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_daemonize_does_not_panic_on_struct_creation() {
+        // We cannot test actual fork in unit tests — just verify the function
+        // signature and types compile correctly.
+        // The real test is integration: `nanobot-rs daemon start`.
+        let _working_dir = "/";
+        let _log_file: Option<&str> = None;
+    }
+
+    #[test]
+    fn test_redirect_stdio_compiles() {
+        // Verify the redirect_stdio function is accessible and has the right signature.
+        // We don't call it here because it modifies global fds.
+        let _: fn(Option<&str>) -> Result<()> = redirect_stdio;
+    }
+}

--- a/crates/nanobot-daemon/src/daemonize.rs
+++ b/crates/nanobot-daemon/src/daemonize.rs
@@ -65,7 +65,9 @@ pub fn daemonize(working_dir: &str, log_file: Option<&str>) -> Result<()> {
     // Redirect stdio to /dev/null (or log file for stderr)
     redirect_stdio(log_file)?;
 
-    tracing::info!("Daemonized successfully (pid={})", std::process::id());
+    // No tracing subscriber is installed yet — stderr is redirected to the log file,
+    // so eprintln! is the correct way to emit this message.
+    eprintln!("Daemonized successfully (pid={})", std::process::id());
     Ok(())
 }
 

--- a/crates/nanobot-daemon/src/daemonize.rs
+++ b/crates/nanobot-daemon/src/daemonize.rs
@@ -15,7 +15,7 @@ use anyhow::{Context, Result};
 use nix::sys::stat::{umask, Mode};
 use nix::unistd::{chdir, close, dup2, fork, setsid, ForkResult};
 use std::fs::File;
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::AsRawFd;
 
 /// Daemonize the current process using the classic double-fork technique.
 ///

--- a/crates/nanobot-daemon/src/lib.rs
+++ b/crates/nanobot-daemon/src/lib.rs
@@ -1,0 +1,21 @@
+//! Native Unix daemon support for nanobot-rs.
+//!
+//! Provides daemonization (double-fork), PID file management with `flock`,
+//! async signal handling via `tokio::signal::unix`, and file-based logging
+//! with `tracing-appender`.
+//!
+//! Inspired by Cloudflare Pingora's `Server` architecture:
+//! - daemonize runs **before** the tokio runtime starts (fork kills threads)
+//! - PID file uses `flock(LOCK_EX|LOCK_NB)` for atomic locking
+//! - Signal handlers use async `tokio::signal::unix`, NOT `libc signal()`
+//!
+//! All public APIs are gated on `cfg(target_family = "unix")`.
+
+#[cfg(target_family = "unix")]
+pub mod daemonize;
+#[cfg(target_family = "unix")]
+pub mod logging;
+#[cfg(target_family = "unix")]
+pub mod pid_file;
+#[cfg(target_family = "unix")]
+pub mod signal;

--- a/crates/nanobot-daemon/src/logging.rs
+++ b/crates/nanobot-daemon/src/logging.rs
@@ -1,0 +1,82 @@
+//! File-based logging with `tracing-appender`.
+//!
+//! Sets up a non-blocking file writer for the `tracing` ecosystem so that
+//! daemon-mode processes can write structured logs to disk instead of
+//! (or in addition to) the terminal.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
+
+/// Guard returned by [`setup_file_logging`]. Must be kept alive for the
+/// lifetime of the application — dropping it flushes and closes the log file.
+pub type LogGuard = tracing_appender::non_blocking::WorkerGuard;
+
+/// Configure file-based logging for daemon mode.
+///
+/// Creates a non-blocking writer that appends to `{log_dir}/nanobot-rs.log`.
+/// The `tracing_subscriber` is configured with the given log level filter.
+///
+/// # Arguments
+///
+/// * `log_dir` - Directory for log files (created if it doesn't exist).
+/// * `level` - Log level filter (e.g. `"info"`, `"debug"`, `"trace"`).
+///
+/// # Returns
+///
+/// A [`LogGuard`] that must be held for the application's lifetime.
+/// Dropping the guard flushes remaining log lines and stops the writer thread.
+///
+/// # Errors
+///
+/// Returns an error if the log directory cannot be created or the subscriber
+/// cannot be installed.
+pub fn setup_file_logging(log_dir: &str, level: &str) -> Result<LogGuard> {
+    let log_path = Path::new(log_dir);
+    std::fs::create_dir_all(log_path).context("create log directory")?;
+
+    let file_appender = tracing_appender::rolling::daily(log_path, "nanobot-rs.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(level));
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_filter(filter);
+
+    let subscriber = Registry::default().with(file_layer);
+    tracing::subscriber::set_global_default(subscriber)
+        .context("set global tracing subscriber")?;
+
+    tracing::info!("File logging initialized: {}/nanobot-rs.log", log_dir);
+
+    Ok(guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_setup_file_logging_creates_directory() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path().join("logs").join("subdir");
+        let log_dir_str = log_dir.to_str().unwrap();
+
+        let _guard = setup_file_logging(log_dir_str, "info").unwrap();
+        assert!(log_dir.exists());
+
+        // Write a log line and verify it lands in a file
+        tracing::info!("test log message from unit test");
+    }
+
+    #[test]
+    fn test_setup_file_logging_rejects_bad_level() {
+        let tmp = TempDir::new().unwrap();
+        // "info" is valid, but invalid levels still work — EnvFilter falls back
+        let _guard = setup_file_logging(tmp.path().to_str().unwrap(), "info").unwrap();
+    }
+}

--- a/crates/nanobot-daemon/src/logging.rs
+++ b/crates/nanobot-daemon/src/logging.rs
@@ -38,8 +38,7 @@ pub fn setup_file_logging(log_dir: &str, level: &str) -> Result<LogGuard> {
     let file_appender = tracing_appender::rolling::daily(log_path, "nanobot-rs.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(level));
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
 
     let file_layer = tracing_subscriber::fmt::layer()
         .with_writer(non_blocking)
@@ -47,8 +46,7 @@ pub fn setup_file_logging(log_dir: &str, level: &str) -> Result<LogGuard> {
         .with_filter(filter);
 
     let subscriber = Registry::default().with(file_layer);
-    tracing::subscriber::set_global_default(subscriber)
-        .context("set global tracing subscriber")?;
+    tracing::subscriber::set_global_default(subscriber).context("set global tracing subscriber")?;
 
     tracing::info!("File logging initialized: {}/nanobot-rs.log", log_dir);
 
@@ -66,17 +64,28 @@ mod tests {
         let log_dir = tmp.path().join("logs").join("subdir");
         let log_dir_str = log_dir.to_str().unwrap();
 
-        let _guard = setup_file_logging(log_dir_str, "info").unwrap();
-        assert!(log_dir.exists());
+        // Test directory creation — ignore the global subscriber conflict
+        // (set_global_default can only be called once per process)
+        let result = setup_file_logging(log_dir_str, "info");
+        assert!(log_dir.exists(), "log directory should be created");
 
-        // Write a log line and verify it lands in a file
-        tracing::info!("test log message from unit test");
+        // The guard may fail on re-install, but directory must exist regardless
+        if let Ok(_guard) = result {
+            tracing::info!("test log message from unit test");
+        }
     }
 
     #[test]
-    fn test_setup_file_logging_rejects_bad_level() {
+    fn test_log_directory_created_even_if_subscriber_fails() {
         let tmp = TempDir::new().unwrap();
-        // "info" is valid, but invalid levels still work — EnvFilter falls back
-        let _guard = setup_file_logging(tmp.path().to_str().unwrap(), "info").unwrap();
+        let log_dir = tmp.path().join("deep").join("nested").join("logs");
+        let log_dir_str = log_dir.to_str().unwrap();
+
+        // The function creates the directory before attempting to set subscriber
+        let _ = setup_file_logging(log_dir_str, "info");
+        assert!(
+            log_dir.exists(),
+            "directory must be created even if subscriber fails"
+        );
     }
 }

--- a/crates/nanobot-daemon/src/pid_file.rs
+++ b/crates/nanobot-daemon/src/pid_file.rs
@@ -1,0 +1,212 @@
+//! PID file management with `flock`-based atomic locking.
+//!
+//! Uses `flock(LOCK_EX | LOCK_NB)` for atomic exclusive locking, which
+//! prevents race conditions compared to "check if file exists" approaches.
+//!
+//! The `PidFile` struct holds the locked file handle. When dropped, the lock
+//! is released automatically. Call `clean()` to also unlink the file.
+
+use anyhow::{bail, Context, Result};
+use nix::fcntl::{flock, FlockArg};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::Path;
+
+/// A PID file with an exclusive `flock` held for the lifetime of this struct.
+///
+/// The file is created (or opened) and locked atomically. If another process
+/// holds the lock, creation fails immediately.
+///
+/// # Drop behavior
+///
+/// When dropped, the `flock` is released. The PID file is **not** deleted
+/// automatically — call [`PidFile::clean()`] to remove it on graceful shutdown.
+pub struct PidFile {
+    /// Path to the PID file on disk.
+    path: String,
+    /// The locked file handle. Kept open to hold the flock.
+    _file: File,
+}
+
+impl PidFile {
+    /// Create and lock a PID file atomically.
+    ///
+    /// Writes the current process ID to the file and acquires an exclusive,
+    /// non-blocking `flock`. If another process already holds the lock, this
+    /// returns an error.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Filesystem path for the PID file (e.g. `/run/nanobot-rs.pid`).
+    ///
+    /// # Errors
+    ///
+    /// - If the parent directory does not exist.
+    /// - If another process holds the `flock` (double-start prevention).
+    /// - If I/O operations fail.
+    pub fn create(path: &str) -> Result<Self> {
+        // Ensure parent directory exists
+        if let Some(parent) = Path::new(path).parent() {
+            fs::create_dir_all(parent).context("create PID file parent directory")?;
+        }
+
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .read(true)
+            .open(path)
+            .context("open PID file")?;
+
+        // Acquire exclusive, non-blocking lock
+        flock(&file, FlockArg::LockExclusiveNonblock).context(
+            "failed to lock PID file — another instance may be running",
+        )?;
+
+        // Write current PID
+        let pid = std::process::id();
+        write!(&file, "{pid}").context("write PID to file")?;
+        file.sync_all().context("sync PID file")?;
+
+        tracing::info!("PID file created and locked: {path} (pid={pid})");
+
+        Ok(Self {
+            path: path.to_string(),
+            _file: file,
+        })
+    }
+
+    /// Read the PID from a file without acquiring a lock.
+    ///
+    /// Returns `Ok(None)` if the file does not exist.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Filesystem path for the PID file.
+    pub fn read_pid(path: &str) -> Result<Option<i32>> {
+        if !Path::new(path).exists() {
+            return Ok(None);
+        }
+
+        let mut file = File::open(path).context("open PID file for reading")?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .context("read PID file")?;
+
+        let pid: i32 = contents
+            .trim()
+            .parse()
+            .context("parse PID from file")?;
+
+        Ok(Some(pid))
+    }
+
+    /// Remove the PID file and release the lock.
+    ///
+    /// Consumes `self`. This is the clean-shutdown path: unlink the file
+    /// and drop the file handle (which releases the flock).
+    pub fn clean(self) -> Result<()> {
+        let path = self.path.clone();
+        drop(self); // Release the flock first
+
+        if Path::new(&path).exists() {
+            fs::remove_file(&path).context("remove PID file")?;
+            tracing::info!("PID file removed: {path}");
+        }
+
+        Ok(())
+    }
+
+    /// Returns the path to the PID file.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+/// Check whether a process with the given PID is currently running.
+///
+/// Uses `/proc/{pid}` on Linux. Returns `false` if the `/proc` entry
+/// doesn't exist.
+pub fn is_process_running(pid: i32) -> bool {
+    Path::new(&format!("/proc/{pid}")).exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_pid_file_create_and_read() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("test.pid");
+        let path_str = path.to_str().unwrap();
+
+        let pf = PidFile::create(path_str).unwrap();
+        assert_eq!(pf.path(), path_str);
+
+        // Read PID from file
+        let pid = PidFile::read_pid(path_str).unwrap();
+        assert!(pid.is_some());
+        assert_eq!(pid.unwrap() as u32, std::process::id());
+
+        pf.clean().unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_pid_file_read_nonexistent() {
+        let pid = PidFile::read_pid("/tmp/nonexistent_nanobot_test.pid").unwrap();
+        assert!(pid.is_none());
+    }
+
+    #[test]
+    fn test_pid_file_double_lock_fails() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("double.pid");
+        let path_str = path.to_str().unwrap();
+
+        let _first = PidFile::create(path_str).unwrap();
+        // Second lock attempt should fail (LOCK_NB)
+        let result = PidFile::create(path_str);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_pid_file_clean_removes_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("cleanup.pid");
+        let path_str = path.to_str().unwrap();
+
+        let pf = PidFile::create(path_str).unwrap();
+        assert!(path.exists());
+
+        pf.clean().unwrap();
+        assert!(!path.exists());
+
+        // After clean, a new lock can be acquired
+        let pf2 = PidFile::create(path_str).unwrap();
+        pf2.clean().unwrap();
+    }
+
+    #[test]
+    fn test_is_process_running() {
+        // Our own PID should be running
+        assert!(is_process_running(std::process::id() as i32));
+        // PID -1 definitely doesn't exist
+        assert!(!is_process_running(-1));
+        // Very high PID is extremely unlikely
+        assert!(!is_process_running(4_000_000));
+    }
+
+    #[test]
+    fn test_pid_file_creates_parent_directory() {
+        let tmp = TempDir::new().unwrap();
+        let nested = tmp.path().join("a").join("b").join("test.pid");
+        let path_str = nested.to_str().unwrap();
+
+        let pf = PidFile::create(path_str).unwrap();
+        assert!(nested.exists());
+        pf.clean().unwrap();
+    }
+}

--- a/crates/nanobot-daemon/src/pid_file.rs
+++ b/crates/nanobot-daemon/src/pid_file.rs
@@ -9,7 +9,7 @@
 use anyhow::Context;
 use nix::fcntl::{Flock, FlockArg};
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 use std::path::Path;
 
 /// A PID file with an exclusive `flock` held for the lifetime of this struct.
@@ -59,7 +59,7 @@ impl PidFile {
             .context("open PID file")?;
 
         // Acquire exclusive, non-blocking lock using the new Flock API
-        let lock =
+        let mut lock =
             Flock::lock(file, FlockArg::LockExclusiveNonblock).map_err(|(_file, errno)| {
                 anyhow::anyhow!(
                     "failed to lock PID file ({errno}) — another instance may be running"
@@ -70,6 +70,7 @@ impl PidFile {
         let pid = std::process::id();
         write!(&*lock, "{pid}").context("write PID to file")?;
         lock.sync_all().context("sync PID file")?;
+        lock.rewind().context("rewind PID file after write")?;
 
         tracing::info!("PID file created and locked: {path} (pid={pid})");
 

--- a/crates/nanobot-daemon/src/pid_file.rs
+++ b/crates/nanobot-daemon/src/pid_file.rs
@@ -6,8 +6,8 @@
 //! The `PidFile` struct holds the locked file handle. When dropped, the lock
 //! is released automatically. Call `clean()` to also unlink the file.
 
-use anyhow::{bail, Context, Result};
-use nix::fcntl::{flock, FlockArg};
+use anyhow::Context;
+use nix::fcntl::{Flock, FlockArg};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -25,7 +25,7 @@ pub struct PidFile {
     /// Path to the PID file on disk.
     path: String,
     /// The locked file handle. Kept open to hold the flock.
-    _file: File,
+    _lock: Flock<File>,
 }
 
 impl PidFile {
@@ -44,7 +44,7 @@ impl PidFile {
     /// - If the parent directory does not exist.
     /// - If another process holds the `flock` (double-start prevention).
     /// - If I/O operations fail.
-    pub fn create(path: &str) -> Result<Self> {
+    pub fn create(path: &str) -> anyhow::Result<Self> {
         // Ensure parent directory exists
         if let Some(parent) = Path::new(path).parent() {
             fs::create_dir_all(parent).context("create PID file parent directory")?;
@@ -58,21 +58,24 @@ impl PidFile {
             .open(path)
             .context("open PID file")?;
 
-        // Acquire exclusive, non-blocking lock
-        flock(&file, FlockArg::LockExclusiveNonblock).context(
-            "failed to lock PID file — another instance may be running",
-        )?;
+        // Acquire exclusive, non-blocking lock using the new Flock API
+        let lock =
+            Flock::lock(file, FlockArg::LockExclusiveNonblock).map_err(|(_file, errno)| {
+                anyhow::anyhow!(
+                    "failed to lock PID file ({errno}) — another instance may be running"
+                )
+            })?;
 
         // Write current PID
         let pid = std::process::id();
-        write!(&file, "{pid}").context("write PID to file")?;
-        file.sync_all().context("sync PID file")?;
+        write!(&*lock, "{pid}").context("write PID to file")?;
+        lock.sync_all().context("sync PID file")?;
 
         tracing::info!("PID file created and locked: {path} (pid={pid})");
 
         Ok(Self {
             path: path.to_string(),
-            _file: file,
+            _lock: lock,
         })
     }
 
@@ -83,7 +86,7 @@ impl PidFile {
     /// # Arguments
     ///
     /// * `path` - Filesystem path for the PID file.
-    pub fn read_pid(path: &str) -> Result<Option<i32>> {
+    pub fn read_pid(path: &str) -> anyhow::Result<Option<i32>> {
         if !Path::new(path).exists() {
             return Ok(None);
         }
@@ -93,10 +96,7 @@ impl PidFile {
         file.read_to_string(&mut contents)
             .context("read PID file")?;
 
-        let pid: i32 = contents
-            .trim()
-            .parse()
-            .context("parse PID from file")?;
+        let pid: i32 = contents.trim().parse().context("parse PID from file")?;
 
         Ok(Some(pid))
     }
@@ -105,7 +105,7 @@ impl PidFile {
     ///
     /// Consumes `self`. This is the clean-shutdown path: unlink the file
     /// and drop the file handle (which releases the flock).
-    pub fn clean(self) -> Result<()> {
+    pub fn clean(self) -> anyhow::Result<()> {
         let path = self.path.clone();
         drop(self); // Release the flock first
 

--- a/crates/nanobot-daemon/src/signal.rs
+++ b/crates/nanobot-daemon/src/signal.rs
@@ -71,9 +71,25 @@ pub fn send_sigterm(pid: i32) -> Result<()> {
         .context(format!("failed to send SIGTERM to pid {pid}"))
 }
 
+/// Install a no-op SIGHUP handler using `sigaction`.
+///
+/// This must be called **before** the tokio runtime is created to close the
+/// window where the default SIGHUP handler (terminate) is active between fork
+/// completion and `wait_for_signal()` being called.
+///
+/// When tokio's `signal(SignalKind::hangup())` is later called in
+/// `wait_for_signal()`, it overrides `SIG_IGN` with its own handler.
+pub fn install_early_sighup_handler() {
+    let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
+    sa.sa_sigaction = libc::SIG_IGN;
+    unsafe {
+        libc::sigaction(libc::SIGHUP, &sa, std::ptr::null_mut());
+    }
+}
+
 /// Send SIGTERM to a process and wait for it to exit.
 ///
-/// Polls `/proc/{pid}` every 100ms for up to `timeout_secs` seconds.
+/// Polls with `waitpid(WNOHANG)` every 100ms for up to `timeout_secs` seconds.
 /// Returns `Ok(())` if the process exited, or an error if it's still
 /// running after the timeout.
 ///
@@ -84,14 +100,21 @@ pub fn send_sigterm(pid: i32) -> Result<()> {
 pub fn send_sigterm_and_wait(pid: i32, timeout_secs: u64) -> Result<()> {
     send_sigterm(pid)?;
 
-    let check_interval = std::time::Duration::from_millis(100);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
+    // Poll with waitpid(WNOHANG) — no /proc filesystem access needed.
+    // waitpid on a non-child returns ECHILD, which we treat as "done".
+    let nix_pid = Pid::from_raw(pid);
     while std::time::Instant::now() < deadline {
-        if !crate::pid_file::is_process_running(pid) {
+        let exited = match nix::sys::wait::waitpid(nix_pid, Some(nix::sys::wait::WaitPidFlag::WNOHANG)) {
+            Ok(_) => true,
+            Err(nix::errno::Errno::ECHILD) => true,
+            Err(e) => anyhow::bail!("waitpid error: {e}"),
+        };
+        if exited {
             return Ok(());
         }
-        std::thread::sleep(check_interval);
+        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
     anyhow::bail!("process {pid} did not exit within {timeout_secs}s")

--- a/crates/nanobot-daemon/src/signal.rs
+++ b/crates/nanobot-daemon/src/signal.rs
@@ -1,0 +1,122 @@
+//! Async signal handling via `tokio::signal::unix`.
+//!
+//! Provides a unified interface for receiving SIGTERM, SIGINT, and SIGHUP
+//! asynchronously within a tokio runtime. Also provides a helper for sending
+//! SIGTERM to another process (used by `daemon stop`).
+//!
+//! **Design**: Uses `tokio::signal::unix::signal()` (async), NOT `libc signal()`
+//! (which is unsafe and not async-safe).
+
+use anyhow::{Context, Result};
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
+use tokio::signal::unix::{signal, SignalKind};
+
+/// The type of shutdown signal received.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShutdownSignal {
+    /// SIGTERM — graceful shutdown (drain connections, complete in-flight work).
+    Graceful,
+    /// SIGINT (Ctrl+C) — fast shutdown.
+    Fast,
+    /// SIGHUP — reload/log rotation (placeholder for now).
+    Reload,
+}
+
+/// Wait for the next Unix signal and return its type.
+///
+/// Listens for SIGTERM, SIGINT, and SIGHUP concurrently. This function
+/// should be used inside a `tokio::select!` block or as a top-level
+/// shutdown signal waiter.
+///
+/// # Panics
+///
+/// Panics if the signal handlers cannot be installed (should not happen
+/// on a standard Unix system).
+pub async fn wait_for_signal() -> ShutdownSignal {
+    let mut sigterm = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let mut sigint = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    let mut sighup = signal(SignalKind::hangup()).expect("install SIGHUP handler");
+
+    tokio::select! {
+        _ = sigterm.recv() => {
+            tracing::info!("Received SIGTERM");
+            ShutdownSignal::Graceful
+        }
+        _ = sigint.recv() => {
+            tracing::info!("Received SIGINT");
+            ShutdownSignal::Fast
+        }
+        _ = sighup.recv() => {
+            tracing::info!("Received SIGHUP");
+            ShutdownSignal::Reload
+        }
+    }
+}
+
+/// Send SIGTERM to a process by PID.
+///
+/// Used by `daemon stop` to signal the background daemon to shut down.
+///
+/// # Arguments
+///
+/// * `pid` - Process ID to signal.
+///
+/// # Errors
+///
+/// Returns an error if the process does not exist or the caller lacks
+/// permission to signal it.
+pub fn send_sigterm(pid: i32) -> Result<()> {
+    kill(Pid::from_raw(pid), Signal::SIGTERM)
+        .context(format!("failed to send SIGTERM to pid {pid}"))
+}
+
+/// Send SIGTERM to a process and wait for it to exit.
+///
+/// Polls `/proc/{pid}` every 100ms for up to `timeout_secs` seconds.
+/// Returns `Ok(())` if the process exited, or an error if it's still
+/// running after the timeout.
+///
+/// # Arguments
+///
+/// * `pid` - Process ID to signal.
+/// * `timeout_secs` - Maximum seconds to wait for exit.
+pub fn send_sigterm_and_wait(pid: i32, timeout_secs: u64) -> Result<()> {
+    send_sigterm(pid)?;
+
+    let check_interval = std::time::Duration::from_millis(100);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+
+    while std::time::Instant::now() < deadline {
+        if !crate::pid_file::is_process_running(pid) {
+            return Ok(());
+        }
+        std::thread::sleep(check_interval);
+    }
+
+    anyhow::bail!("process {pid} did not exit within {timeout_secs}s")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_shutdown_signal_variants() {
+        let graceful = ShutdownSignal::Graceful;
+        let fast = ShutdownSignal::Fast;
+        let reload = ShutdownSignal::Reload;
+
+        assert_eq!(graceful, ShutdownSignal::Graceful);
+        assert_eq!(fast, ShutdownSignal::Fast);
+        assert_eq!(reload, ShutdownSignal::Reload);
+        assert_ne!(graceful, fast);
+    }
+
+    #[test]
+    fn test_send_sigterm_to_nonexistent_process() {
+        // PID 4_000_000 is extremely unlikely to exist
+        let result = send_sigterm(4_000_000);
+        assert!(result.is_err());
+    }
+}

--- a/crates/nanobot-heartbeat/src/service.rs
+++ b/crates/nanobot-heartbeat/src/service.rs
@@ -44,8 +44,8 @@ impl HeartbeatService {
     /// Create a new heartbeat service with default state directory.
     pub fn new(config: nanobot_config::Config) -> Self {
         let interval_secs = config.heartbeat.interval_secs.max(DEFAULT_INTERVAL_SECS);
-        let data_dir = nanobot_config::paths::get_data_dir()
-            .unwrap_or_else(|_| std::env::temp_dir());
+        let data_dir =
+            nanobot_config::paths::get_data_dir().unwrap_or_else(|_| std::env::temp_dir());
         let state_path = data_dir.join("heartbeat_state.json");
         let state = load_state(&state_path).unwrap_or_default();
 
@@ -145,10 +145,7 @@ impl HeartbeatService {
             match self.run_checks().await {
                 Ok(snapshot) => {
                     if snapshot.healthy && !snapshot.degraded {
-                        debug!(
-                            "Heartbeat: all {} checks healthy",
-                            snapshot.checks.len()
-                        );
+                        debug!("Heartbeat: all {} checks healthy", snapshot.checks.len());
                     } else if snapshot.healthy && snapshot.degraded {
                         warn!(
                             "Heartbeat: {} degraded: {}",
@@ -210,10 +207,7 @@ impl HeartbeatService {
         // Emit state change notification if status transitioned
         if let Some(ref prev) = previous_status {
             if prev != &current_status {
-                info!(
-                    "Health status changed: {} → {}",
-                    prev, current_status
-                );
+                info!("Health status changed: {} → {}", prev, current_status);
                 if let Some(bus) = &self.bus {
                     bus.emit_event(AgentEvent::HealthStatusChanged {
                         from: prev.clone(),
@@ -322,7 +316,11 @@ impl HeartbeatService {
                                 f.last_restart_at = Some(Local::now());
                                 f.backoff_secs = (f.backoff_secs * 2).min(MAX_BACKOFF_SECS);
                                 new_restart_count += 1;
-                                restarts.push((f.component.clone(), check.message.clone(), backoff));
+                                restarts.push((
+                                    f.component.clone(),
+                                    check.message.clone(),
+                                    backoff,
+                                ));
                             }
                         } else {
                             // New component failure entry
@@ -337,11 +335,19 @@ impl HeartbeatService {
                                     INITIAL_BACKOFF_SECS
                                 },
                                 last_failure_at: Some(Local::now()),
-                                last_restart_at: if should_restart { Some(Local::now()) } else { None },
+                                last_restart_at: if should_restart {
+                                    Some(Local::now())
+                                } else {
+                                    None
+                                },
                             };
                             if should_restart {
                                 new_restart_count += 1;
-                                restarts.push((check.component.clone(), check.message.clone(), INITIAL_BACKOFF_SECS));
+                                restarts.push((
+                                    check.component.clone(),
+                                    check.message.clone(),
+                                    INITIAL_BACKOFF_SECS,
+                                ));
                             }
                             state.component_failures.push(state_entry);
                         }
@@ -764,8 +770,7 @@ mod tests {
     #[tokio::test]
     async fn test_restart_triggered_after_threshold() {
         let dir = tempfile::tempdir().unwrap();
-        let svc = make_service(dir.path())
-            .with_failures_before_restart(3);
+        let svc = make_service(dir.path()).with_failures_before_restart(3);
 
         svc.register_check(Arc::new(ToggleCheck::new("comp", false)));
 
@@ -785,8 +790,7 @@ mod tests {
     #[tokio::test]
     async fn test_restart_not_triggered_below_threshold() {
         let dir = tempfile::tempdir().unwrap();
-        let svc = make_service(dir.path())
-            .with_failures_before_restart(5);
+        let svc = make_service(dir.path()).with_failures_before_restart(5);
 
         svc.register_check(Arc::new(ToggleCheck::new("comp", false)));
 
@@ -802,8 +806,7 @@ mod tests {
     #[tokio::test]
     async fn test_exponential_backoff() {
         let dir = tempfile::tempdir().unwrap();
-        let svc = make_service(dir.path())
-            .with_failures_before_restart(2);
+        let svc = make_service(dir.path()).with_failures_before_restart(2);
 
         let check = Arc::new(ToggleCheck::new("comp", false));
         svc.register_check(check.clone());
@@ -829,8 +832,7 @@ mod tests {
     #[tokio::test]
     async fn test_no_double_restart() {
         let dir = tempfile::tempdir().unwrap();
-        let svc = make_service(dir.path())
-            .with_failures_before_restart(2);
+        let svc = make_service(dir.path()).with_failures_before_restart(2);
 
         svc.register_check(Arc::new(MockCheck {
             name: "comp".to_string(),
@@ -871,7 +873,10 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert!(matches!(event, AgentEvent::HeartbeatCheck { healthy: true, .. }));
+        assert!(matches!(
+            event,
+            AgentEvent::HeartbeatCheck { healthy: true, .. }
+        ));
     }
 
     #[tokio::test]
@@ -879,8 +884,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let bus = MessageBus::new();
         let mut events_rx = bus.subscribe_events();
-        let mut svc = make_service(dir.path())
-            .with_failures_before_restart(2);
+        let mut svc = make_service(dir.path()).with_failures_before_restart(2);
         svc.set_bus(bus);
 
         svc.register_check(Arc::new(MockCheck {
@@ -898,7 +902,8 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap();
-            if matches!(event, AgentEvent::RestartRequested { component, .. } if component == "comp") {
+            if matches!(event, AgentEvent::RestartRequested { component, .. } if component == "comp")
+            {
                 got_restart = true;
             }
         }
@@ -924,7 +929,10 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert!(matches!(event, AgentEvent::HeartbeatCheck { healthy: true, .. }));
+        assert!(matches!(
+            event,
+            AgentEvent::HeartbeatCheck { healthy: true, .. }
+        ));
         assert_eq!(svc.state().restarts_requested, 0);
     }
 
@@ -1171,7 +1179,10 @@ mod tests {
                 _ => break,
             }
         }
-        assert_eq!(change_count, 0, "Should not emit change when status unchanged");
+        assert_eq!(
+            change_count, 0,
+            "Should not emit change when status unchanged"
+        );
     }
 
     // === ComponentStatusChanged events ===
@@ -1201,14 +1212,23 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap();
-            if let AgentEvent::ComponentStatusChanged { component, from, to, .. } = &event {
+            if let AgentEvent::ComponentStatusChanged {
+                component,
+                from,
+                to,
+                ..
+            } = &event
+            {
                 if component == "comp" && from == "Healthy" && to == "Unhealthy" {
                     got_component_change = true;
                     break;
                 }
             }
         }
-        assert!(got_component_change, "Expected ComponentStatusChanged event");
+        assert!(
+            got_component_change,
+            "Expected ComponentStatusChanged event"
+        );
     }
 
     #[tokio::test]
@@ -1234,7 +1254,10 @@ mod tests {
                 _ => break,
             }
         }
-        assert_eq!(component_changes, 0, "Should not emit ComponentStatusChanged when stable");
+        assert_eq!(
+            component_changes, 0,
+            "Should not emit ComponentStatusChanged when stable"
+        );
     }
 
     #[tokio::test]
@@ -1261,14 +1284,23 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap();
-            if let AgentEvent::ComponentStatusChanged { component, from, to, .. } = &event {
+            if let AgentEvent::ComponentStatusChanged {
+                component,
+                from,
+                to,
+                ..
+            } = &event
+            {
                 if component == "comp" && from == "Unhealthy" && to == "Healthy" {
                     got_recovery = true;
                     break;
                 }
             }
         }
-        assert!(got_recovery, "Expected ComponentStatusChanged recovery event");
+        assert!(
+            got_recovery,
+            "Expected ComponentStatusChanged recovery event"
+        );
     }
 
     // === Full health report ===

--- a/crates/nanobot-heartbeat/src/types.rs
+++ b/crates/nanobot-heartbeat/src/types.rs
@@ -103,7 +103,12 @@ impl HealthSnapshot {
 
         format!(
             "{}: {} healthy, {} degraded, {} failed, {} skipped ({} total)",
-            status, healthy, degraded, failed, skipped, self.checks.len()
+            status,
+            healthy,
+            degraded,
+            failed,
+            skipped,
+            self.checks.len()
         )
     }
 }
@@ -173,9 +178,7 @@ pub struct HealthCheckRegistry {
 impl HealthCheckRegistry {
     /// Create a new empty registry.
     pub fn new() -> Self {
-        Self {
-            checks: Vec::new(),
-        }
+        Self { checks: Vec::new() }
     }
 
     /// Register a health check component.
@@ -183,10 +186,7 @@ impl HealthCheckRegistry {
         let name = check.component_name().to_string();
         // Prevent duplicates
         if let Some(_existing) = self.checks.iter().find(|c| c.component_name() == name) {
-            tracing::warn!(
-                "Health check '{}' already registered, replacing",
-                name
-            );
+            tracing::warn!("Health check '{}' already registered, replacing", name);
             self.checks.retain(|c| c.component_name() != name);
         }
         self.checks.push(check);
@@ -304,12 +304,8 @@ impl FullHealthReport {
                         CheckStatus::Skipped => "skipped".to_string(),
                     },
                     message: c.message.clone(),
-                    consecutive_failures: failure
-                        .map(|f| f.consecutive_failures)
-                        .unwrap_or(0),
-                    restart_pending: failure
-                        .map(|f| f.restart_pending)
-                        .unwrap_or(false),
+                    consecutive_failures: failure.map(|f| f.consecutive_failures).unwrap_or(0),
+                    restart_pending: failure.map(|f| f.restart_pending).unwrap_or(false),
                 }
             })
             .collect();
@@ -344,7 +340,12 @@ mod tests {
 
     #[test]
     fn test_check_status_serde() {
-        for status in &[CheckStatus::Healthy, CheckStatus::Degraded, CheckStatus::Unhealthy, CheckStatus::Skipped] {
+        for status in &[
+            CheckStatus::Healthy,
+            CheckStatus::Degraded,
+            CheckStatus::Unhealthy,
+            CheckStatus::Skipped,
+        ] {
             let json = serde_json::to_string(status).unwrap();
             let back: CheckStatus = serde_json::from_str(&json).unwrap();
             assert_eq!(*status, back);
@@ -455,28 +456,24 @@ mod tests {
 
     #[test]
     fn test_health_snapshot_summary_degraded() {
-        let checks = vec![
-            HealthCheckResult {
-                component: "a".to_string(),
-                status: CheckStatus::Degraded,
-                message: "partial".to_string(),
-                timestamp: Local::now(),
-            },
-        ];
+        let checks = vec![HealthCheckResult {
+            component: "a".to_string(),
+            status: CheckStatus::Degraded,
+            message: "partial".to_string(),
+            timestamp: Local::now(),
+        }];
         let snap = HealthSnapshot::from_checks(checks);
         assert!(snap.summary().starts_with("degraded:"));
     }
 
     #[test]
     fn test_health_snapshot_summary_unhealthy() {
-        let checks = vec![
-            HealthCheckResult {
-                component: "a".to_string(),
-                status: CheckStatus::Unhealthy,
-                message: "down".to_string(),
-                timestamp: Local::now(),
-            },
-        ];
+        let checks = vec![HealthCheckResult {
+            component: "a".to_string(),
+            status: CheckStatus::Unhealthy,
+            message: "down".to_string(),
+            timestamp: Local::now(),
+        }];
         let snap = HealthSnapshot::from_checks(checks);
         assert!(snap.summary().starts_with("unhealthy:"));
     }

--- a/crates/nanobot-providers/src/anthropic.rs
+++ b/crates/nanobot-providers/src/anthropic.rs
@@ -394,23 +394,24 @@ impl LlmProvider for AnthropicProvider {
                     .context("Failed to parse Anthropic response")?;
 
                 // Extract text content
-                let content = api_resp
-                    .get("content")
-                    .and_then(|c| c.as_array())
-                    .and_then(|blocks| {
-                        blocks
-                            .iter()
-                            .filter_map(|b| {
-                                if b.get("type")?.as_str()? == "text" {
-                                    b.get("text")?.as_str().map(String::from)
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                            .next()
-                    });
+                let content =
+                    api_resp
+                        .get("content")
+                        .and_then(|c| c.as_array())
+                        .and_then(|blocks| {
+                            blocks
+                                .iter()
+                                .filter_map(|b| {
+                                    if b.get("type")?.as_str()? == "text" {
+                                        b.get("text")?.as_str().map(String::from)
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .into_iter()
+                                .next()
+                        });
 
                 // Extract tool calls
                 let tool_calls = api_resp

--- a/crates/nanobot-providers/src/middleware.rs
+++ b/crates/nanobot-providers/src/middleware.rs
@@ -99,10 +99,7 @@ impl MiddlewareConfig {
     }
 
     /// Create with custom retry and rate-limit bucket.
-    pub fn with_retry_and_rate_limit(
-        retry: RetryConfig,
-        requests_per_minute: u64,
-    ) -> Self {
+    pub fn with_retry_and_rate_limit(retry: RetryConfig, requests_per_minute: u64) -> Self {
         use crate::rate_limit::TokenBucket;
         use std::time::Duration;
         Self {
@@ -196,7 +193,10 @@ impl LlmProvider for ProviderMiddleware {
 
         // 2. Rate limit: acquire a token (may block)
         self.config.rate_limiter.acquire().await;
-        debug!(provider = self.inner.name(), "Rate limit token acquired for complete()");
+        debug!(
+            provider = self.inner.name(),
+            "Rate limit token acquired for complete()"
+        );
 
         // 3. Retry with exponential backoff + circuit breaker recording
         let inner = self.inner.clone();
@@ -234,7 +234,10 @@ impl LlmProvider for ProviderMiddleware {
 
         // 2. Rate limit: acquire a token (may block)
         self.config.rate_limiter.acquire().await;
-        debug!(provider = self.inner.name(), "Rate limit token acquired for complete_stream()");
+        debug!(
+            provider = self.inner.name(),
+            "Rate limit token acquired for complete_stream()"
+        );
 
         // 3. Retry with exponential backoff + circuit breaker recording
         // Note: we only retry the initial HTTP connection/stream-open.
@@ -302,7 +305,9 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LlmProvider for MockProvider {
-        fn name(&self) -> &str { "mock_middleware" }
+        fn name(&self) -> &str {
+            "mock_middleware"
+        }
 
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             let n = self.call_count.fetch_add(1, Ordering::SeqCst);
@@ -333,7 +338,9 @@ mod tests {
             Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
         }
 
-        fn supports_model(&self, _model: &str) -> bool { true }
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
     }
 
     /// Mock provider that returns 503 errors for testing 503-specific retry.
@@ -357,7 +364,9 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LlmProvider for MockProvider503 {
-        fn name(&self) -> &str { "mock_503" }
+        fn name(&self) -> &str {
+            "mock_503"
+        }
 
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             let n = self.call_count.fetch_add(1, Ordering::SeqCst);
@@ -388,7 +397,9 @@ mod tests {
             Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
         }
 
-        fn supports_model(&self, _model: &str) -> bool { true }
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
     }
 
     // -------------------------------------------------------------------
@@ -637,10 +648,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_middleware_config_with_circuit_breaker() {
-        let config = MiddlewareConfig::default_unlimited()
-            .with_circuit_breaker();
+        let config = MiddlewareConfig::default_unlimited().with_circuit_breaker();
         assert!(config.circuit_breaker.is_some());
-        assert_eq!(config.circuit_breaker.as_ref().unwrap().state_name(), "CLOSED");
+        assert_eq!(
+            config.circuit_breaker.as_ref().unwrap().state_name(),
+            "CLOSED"
+        );
     }
 
     #[tokio::test]
@@ -648,14 +661,15 @@ mod tests {
         let cb_config = CircuitBreakerConfig::default()
             .with_failure_threshold(10)
             .with_reset_timeout(Duration::from_secs(60));
-        let config = MiddlewareConfig::default_unlimited()
-            .with_circuit_breaker_config(cb_config);
+        let config = MiddlewareConfig::default_unlimited().with_circuit_breaker_config(cb_config);
         assert!(config.circuit_breaker.is_some());
     }
 
     #[tokio::test]
     async fn test_middleware_from_retry_policy() {
-        let policy = RetryPolicy::default().with_max_retries(5).with_jitter(false);
+        let policy = RetryPolicy::default()
+            .with_max_retries(5)
+            .with_jitter(false);
         let config = MiddlewareConfig::from_retry_policy(policy);
         assert_eq!(config.retry.max_retries, 5);
         assert!(config.circuit_breaker.is_some());

--- a/crates/nanobot-providers/src/rate_limit.rs
+++ b/crates/nanobot-providers/src/rate_limit.rs
@@ -129,7 +129,12 @@ impl TokenBucket {
         loop {
             let current = self.tokens.load(Ordering::Acquire);
             let new_tokens = (current + tokens_to_add).min(self.capacity);
-            match self.tokens.compare_exchange(current, new_tokens, Ordering::AcqRel, Ordering::Acquire) {
+            match self.tokens.compare_exchange(
+                current,
+                new_tokens,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
                 Ok(_) => return new_tokens,
                 Err(_) => continue, // Another thread refilled, retry
             }
@@ -143,7 +148,12 @@ impl TokenBucket {
             if current == 0 {
                 return false;
             }
-            match self.tokens.compare_exchange(current, current - 1, Ordering::AcqRel, Ordering::Acquire) {
+            match self.tokens.compare_exchange(
+                current,
+                current - 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
                 Ok(_) => return true,
                 Err(_) => continue,
             }
@@ -157,7 +167,10 @@ impl RateLimiter for TokenBucket {
         loop {
             self.refill();
             if self.consume_one() {
-                trace!(available = self.tokens.load(Ordering::Relaxed), "Rate limit token acquired");
+                trace!(
+                    available = self.tokens.load(Ordering::Relaxed),
+                    "Rate limit token acquired"
+                );
                 return;
             }
             // Wait for a fraction of the refill interval before retrying

--- a/crates/nanobot-providers/src/retry.rs
+++ b/crates/nanobot-providers/src/retry.rs
@@ -18,8 +18,8 @@
 
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::time::Duration;
-use tracing::{debug, info, warn};
 use tokio::time::sleep;
+use tracing::{debug, info, warn};
 
 /// Default maximum number of retry attempts.
 pub const DEFAULT_MAX_RETRIES: u32 = 3;
@@ -201,7 +201,10 @@ impl RetryConfig {
 
 impl From<RetryPolicy> for RetryConfig {
     fn from(policy: RetryPolicy) -> Self {
-        let retry_on_server_error = policy.retryable_status_codes.iter().any(|c| (500..600).contains(c));
+        let retry_on_server_error = policy
+            .retryable_status_codes
+            .iter()
+            .any(|c| (500..600).contains(c));
         Self {
             max_retries: policy.max_retries,
             initial_backoff: policy.base_delay,
@@ -492,10 +495,7 @@ pub fn backoff_with_jitter(base: Duration, attempt: u32, max_delay: Duration) ->
 ///
 /// Uses [`RetryConfig`] for backward compatibility. New code should use
 /// `retry_with_policy` instead.
-pub async fn retry_with_backoff<F, Fut, T>(
-    config: &RetryConfig,
-    op: F,
-) -> anyhow::Result<T>
+pub async fn retry_with_backoff<F, Fut, T>(config: &RetryConfig, op: F) -> anyhow::Result<T>
 where
     F: Fn(u32) -> Fut,
     Fut: std::future::Future<Output = anyhow::Result<T>>,
@@ -811,11 +811,26 @@ mod tests {
 
     #[test]
     fn test_extract_status_code() {
-        assert_eq!(extract_status_code("API error (429): rate limited"), Some(429));
-        assert_eq!(extract_status_code("Anthropic API error (503): unavailable"), Some(503));
-        assert_eq!(extract_status_code("API error (401): unauthorized"), Some(401));
-        assert_eq!(extract_status_code("API error (429 Too Many Requests): rate limited"), Some(429));
-        assert_eq!(extract_status_code("Anthropic API error (503 Service Unavailable): "), Some(503));
+        assert_eq!(
+            extract_status_code("API error (429): rate limited"),
+            Some(429)
+        );
+        assert_eq!(
+            extract_status_code("Anthropic API error (503): unavailable"),
+            Some(503)
+        );
+        assert_eq!(
+            extract_status_code("API error (401): unauthorized"),
+            Some(401)
+        );
+        assert_eq!(
+            extract_status_code("API error (429 Too Many Requests): rate limited"),
+            Some(429)
+        );
+        assert_eq!(
+            extract_status_code("Anthropic API error (503 Service Unavailable): "),
+            Some(503)
+        );
         assert_eq!(extract_status_code("Some other error"), None);
     }
 
@@ -855,9 +870,7 @@ mod tests {
 
     #[test]
     fn test_circuit_breaker_trips_after_threshold() {
-        let cb = CircuitBreaker::new(
-            CircuitBreakerConfig::default().with_failure_threshold(3),
-        );
+        let cb = CircuitBreaker::new(CircuitBreakerConfig::default().with_failure_threshold(3));
         assert_eq!(cb.state_name(), "CLOSED");
 
         cb.record_failure();
@@ -872,9 +885,7 @@ mod tests {
 
     #[test]
     fn test_circuit_breaker_success_resets_failures() {
-        let cb = CircuitBreaker::new(
-            CircuitBreakerConfig::default().with_failure_threshold(3),
-        );
+        let cb = CircuitBreaker::new(CircuitBreakerConfig::default().with_failure_threshold(3));
         cb.record_failure();
         cb.record_failure();
         assert_eq!(cb.failure_count(), 2);
@@ -935,9 +946,7 @@ mod tests {
 
     #[test]
     fn test_circuit_breaker_reset() {
-        let cb = CircuitBreaker::new(
-            CircuitBreakerConfig::default().with_failure_threshold(1),
-        );
+        let cb = CircuitBreaker::new(CircuitBreakerConfig::default().with_failure_threshold(1));
         cb.record_failure();
         assert_eq!(cb.state_name(), "OPEN");
 
@@ -961,11 +970,9 @@ mod tests {
     #[tokio::test]
     async fn test_retry_succeeds_on_first_try() {
         let config = RetryConfig::default();
-        let result = retry_with_backoff(&config, |_attempt| async {
-            Ok::<_, anyhow::Error>(42)
-        })
-        .await
-        .unwrap();
+        let result = retry_with_backoff(&config, |_attempt| async { Ok::<_, anyhow::Error>(42) })
+            .await
+            .unwrap();
         assert_eq!(result, 42);
     }
 
@@ -1042,7 +1049,9 @@ mod tests {
     async fn test_retry_policy_retries_on_429() {
         use std::sync::atomic::{AtomicU32, Ordering};
         let calls = Arc::new(AtomicU32::new(0));
-        let policy = RetryPolicy::default().with_max_retries(3).with_jitter(false);
+        let policy = RetryPolicy::default()
+            .with_max_retries(3)
+            .with_jitter(false);
 
         let calls_clone = calls.clone();
         let result = retry_with_policy(&policy, None, move |_attempt| {
@@ -1066,7 +1075,9 @@ mod tests {
     async fn test_retry_policy_retries_on_503() {
         use std::sync::atomic::{AtomicU32, Ordering};
         let calls = Arc::new(AtomicU32::new(0));
-        let policy = RetryPolicy::default().with_max_retries(2).with_jitter(false);
+        let policy = RetryPolicy::default()
+            .with_max_retries(2)
+            .with_jitter(false);
 
         let calls_clone = calls.clone();
         let result = retry_with_policy(&policy, None, move |_attempt| {
@@ -1128,7 +1139,9 @@ mod tests {
     async fn test_retry_policy_retries_on_connection_error() {
         use std::sync::atomic::{AtomicU32, Ordering};
         let calls = Arc::new(AtomicU32::new(0));
-        let policy = RetryPolicy::default().with_max_retries(2).with_jitter(false);
+        let policy = RetryPolicy::default()
+            .with_max_retries(2)
+            .with_jitter(false);
 
         let calls_clone = calls.clone();
         let result = retry_with_policy(&policy, None, move |_attempt| {
@@ -1150,7 +1163,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_policy_exhausted() {
-        let policy = RetryPolicy::default().with_max_retries(1).with_jitter(false);
+        let policy = RetryPolicy::default()
+            .with_max_retries(1)
+            .with_jitter(false);
         let result = retry_with_policy(&policy, None, |_attempt| async {
             Err::<(), _>(anyhow::anyhow!("API error (500): internal error"))
         })
@@ -1167,7 +1182,9 @@ mod tests {
                 .with_failure_threshold(3)
                 .with_success_threshold(1),
         );
-        let policy = RetryPolicy::default().with_max_retries(0).with_jitter(false);
+        let policy = RetryPolicy::default()
+            .with_max_retries(0)
+            .with_jitter(false);
 
         let calls_clone = calls.clone();
         // Fail 3 times to trip the breaker (no retries so each call = 1 attempt).
@@ -1201,10 +1218,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_policy_success_records_to_circuit_breaker() {
-        let cb = CircuitBreaker::new(
-            CircuitBreakerConfig::default().with_failure_threshold(1),
-        );
-        let policy = RetryPolicy::default().with_max_retries(0).with_jitter(false);
+        let cb = CircuitBreaker::new(CircuitBreakerConfig::default().with_failure_threshold(1));
+        let policy = RetryPolicy::default()
+            .with_max_retries(0)
+            .with_jitter(false);
 
         // Succeed.
         let result = retry_with_policy(&policy, Some(&cb), |_attempt| async {
@@ -1374,7 +1391,9 @@ mod tests {
                 .with_failure_threshold(3)
                 .with_success_threshold(1),
         );
-        let policy = RetryPolicy::default().with_max_retries(0).with_jitter(false);
+        let policy = RetryPolicy::default()
+            .with_max_retries(0)
+            .with_jitter(false);
 
         let calls_clone = calls.clone();
 

--- a/crates/nanobot-providers/tests/anthropic_sse.rs
+++ b/crates/nanobot-providers/tests/anthropic_sse.rs
@@ -162,7 +162,10 @@ async fn test_anthropic_non_streaming_tool_calls() {
     let provider = make_provider(port);
 
     let response = provider.complete(make_request(false)).await.unwrap();
-    assert_eq!(response.content.as_deref(), Some("Let me check the weather."));
+    assert_eq!(
+        response.content.as_deref(),
+        Some("Let me check the weather.")
+    );
     let tool_calls = response.tool_calls.unwrap();
     assert_eq!(tool_calls.len(), 1);
     assert_eq!(tool_calls[0].id, "toolu_abc");

--- a/crates/nanobot-session/src/manager.rs
+++ b/crates/nanobot-session/src/manager.rs
@@ -112,7 +112,9 @@ impl SessionManager {
         self.store.lock().save(&session)?;
 
         // Also persist notes to dedicated note store
-        self.note_store.lock().save_notes(&session.key, &session.notes)?;
+        self.note_store
+            .lock()
+            .save_notes(&session.key, &session.notes)?;
 
         // Update cache
         self.sessions.insert(session.key.clone(), session);
@@ -198,11 +200,8 @@ impl SessionManager {
 
         // Also check persisted sessions not currently in memory
         if let Ok(disk_results) = self.note_store.lock().search_notes(query) {
-            let in_memory_keys: std::collections::HashSet<String> = self
-                .sessions
-                .iter()
-                .map(|e| e.key().clone())
-                .collect();
+            let in_memory_keys: std::collections::HashSet<String> =
+                self.sessions.iter().map(|e| e.key().clone()).collect();
 
             for (key, note) in disk_results {
                 if !in_memory_keys.contains(&key) {
@@ -225,11 +224,8 @@ impl SessionManager {
         }
 
         if let Ok(disk_results) = self.note_store.lock().search_notes_by_tag(tag) {
-            let in_memory_keys: std::collections::HashSet<String> = self
-                .sessions
-                .iter()
-                .map(|e| e.key().clone())
-                .collect();
+            let in_memory_keys: std::collections::HashSet<String> =
+                self.sessions.iter().map(|e| e.key().clone()).collect();
 
             for (key, note) in disk_results {
                 if !in_memory_keys.contains(&key) {

--- a/crates/nanobot-session/src/note_store.rs
+++ b/crates/nanobot-session/src/note_store.rs
@@ -32,7 +32,8 @@ impl NoteStore {
 
     /// Get the file path for a session's notes.
     fn notes_path(&self, session_key: &str) -> PathBuf {
-        self.dir.join(format!("{}.notes.json", Self::safe_key(session_key)))
+        self.dir
+            .join(format!("{}.notes.json", Self::safe_key(session_key)))
     }
 
     /// Load all notes for a session.
@@ -61,16 +62,17 @@ impl NoteStore {
         if notes.is_empty() {
             // Remove the file if there are no notes
             if path.exists() {
-                std::fs::remove_file(&path)
-                    .with_context(|| format!("Failed to remove empty notes file: {}", path.display()))?;
+                std::fs::remove_file(&path).with_context(|| {
+                    format!("Failed to remove empty notes file: {}", path.display())
+                })?;
             }
             return Ok(());
         }
 
         debug!("Saving {} notes for session '{}'", notes.len(), session_key);
 
-        let json = serde_json::to_string_pretty(notes)
-            .with_context(|| "Failed to serialize notes")?;
+        let json =
+            serde_json::to_string_pretty(notes).with_context(|| "Failed to serialize notes")?;
 
         // Atomic write: write to temp file then rename
         let tmp_path = path.with_extension("notes.tmp");
@@ -152,9 +154,7 @@ impl NoteStore {
                     let name = filename.to_string_lossy();
                     if name.ends_with(".notes.json") {
                         // Strip ".notes.json" suffix and convert back from safe key
-                        let key = name
-                            .trim_end_matches(".notes.json")
-                            .to_string();
+                        let key = name.trim_end_matches(".notes.json").to_string();
                         keys.push(key);
                     }
                 }
@@ -307,7 +307,11 @@ mod tests {
             .save_notes(
                 "session:a",
                 &vec![
-                    Note::new("n1".to_string(), "a".to_string(), vec!["decision".to_string()]),
+                    Note::new(
+                        "n1".to_string(),
+                        "a".to_string(),
+                        vec!["decision".to_string()],
+                    ),
                     Note::new("n2".to_string(), "b".to_string(), vec!["todo".to_string()]),
                 ],
             )
@@ -338,7 +342,11 @@ mod tests {
         store
             .save_notes(
                 "session:x",
-                &vec![Note::new("n1".to_string(), "a".to_string(), vec!["Backend".to_string()])],
+                &vec![Note::new(
+                    "n1".to_string(),
+                    "a".to_string(),
+                    vec!["Backend".to_string()],
+                )],
             )
             .unwrap();
 
@@ -364,7 +372,10 @@ mod tests {
 
     #[test]
     fn test_safe_key_sanitization() {
-        assert_eq!(NoteStore::safe_key("telegram:chat/123"), "telegram_chat_123");
+        assert_eq!(
+            NoteStore::safe_key("telegram:chat/123"),
+            "telegram_chat_123"
+        );
         assert_eq!(NoteStore::safe_key("discord:guild\\x"), "discord_guild_x");
     }
 

--- a/crates/nanobot-session/src/types.rs
+++ b/crates/nanobot-session/src/types.rs
@@ -663,11 +663,7 @@ mod tests {
     #[test]
     fn test_search_notes_by_title() {
         let mut session = Session::new("test:notes".to_string());
-        session.save_note(
-            "api design".to_string(),
-            "Use REST".to_string(),
-            vec![],
-        );
+        session.save_note("api design".to_string(), "Use REST".to_string(), vec![]);
         session.save_note("database".to_string(), "Use SQLite".to_string(), vec![]);
 
         let results = session.search_notes("api");
@@ -678,7 +674,11 @@ mod tests {
     #[test]
     fn test_search_notes_by_content() {
         let mut session = Session::new("test:notes".to_string());
-        session.save_note("n1".to_string(), "Use PostgreSQL for production".to_string(), vec![]);
+        session.save_note(
+            "n1".to_string(),
+            "Use PostgreSQL for production".to_string(),
+            vec![],
+        );
 
         let results = session.search_notes("postgresql");
         assert_eq!(results.len(), 1);

--- a/crates/nanobot-tools/src/builtins/spawn.rs
+++ b/crates/nanobot-tools/src/builtins/spawn.rs
@@ -74,7 +74,10 @@ impl Tool for SpawnTool {
                 Err(e) => Err(ToolError::Execution(format!("Failed to spawn task: {}", e))),
             }
         } else {
-            Ok(format!("Spawned background task '{}' (no spawner wired): {}", name, task))
+            Ok(format!(
+                "Spawned background task '{}' (no spawner wired): {}",
+                name, task
+            ))
         }
     }
 }
@@ -215,9 +218,7 @@ mod tests {
         }
 
         let tool = SpawnTool::new().with_spawner(Arc::new(FailingSpawner));
-        let result = tool
-            .execute(serde_json::json!({ "task": "fail me" }))
-            .await;
+        let result = tool.execute(serde_json::json!({ "task": "fail me" })).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("no capacity"));
     }

--- a/crates/nanobot-tools/src/skill_loader.rs
+++ b/crates/nanobot-tools/src/skill_loader.rs
@@ -140,7 +140,8 @@ impl SkillWatcher {
     pub fn new(root: PathBuf) -> Result<Self> {
         let (tx, rx) = std::sync::mpsc::channel();
 
-        let mut watcher = notify::recommended_watcher(tx).context("Failed to create file watcher")?;
+        let mut watcher =
+            notify::recommended_watcher(tx).context("Failed to create file watcher")?;
 
         watcher
             .watch(&root, notify::RecursiveMode::Recursive)
@@ -159,10 +160,7 @@ impl SkillWatcher {
         while let Ok(result) = self.rx.try_recv() {
             if let Ok(event) = result {
                 for path in &event.paths {
-                    if path
-                        .extension()
-                        .is_some_and(|ext| ext == "md")
-                    {
+                    if path.extension().is_some_and(|ext| ext == "md") {
                         paths.insert(path.clone());
                     }
                 }
@@ -229,8 +227,10 @@ impl SkillLoader {
         let files = collect_md_files(&self.root)?;
 
         // Prune cache entries for files that no longer exist.
-        let file_set: Vec<PathBuf> =
-            files.iter().map(|p| p.canonicalize().unwrap_or_else(|_| p.clone())).collect();
+        let file_set: Vec<PathBuf> = files
+            .iter()
+            .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
+            .collect();
         self.cache.retain(|k, _| file_set.contains(k));
 
         let mut skills = Vec::new();
@@ -255,9 +255,7 @@ impl SkillLoader {
             if let Some(entry) = self.cache.get(&canonical) {
                 if entry.content_hash == hash {
                     debug!("Cache hit for {}", path.display());
-                    if let Some(prev) =
-                        seen_names.insert(entry.skill.name.clone(), path.clone())
-                    {
+                    if let Some(prev) = seen_names.insert(entry.skill.name.clone(), path.clone()) {
                         warn!(
                             "Duplicate skill name '{}' — file {} shadows {}",
                             entry.skill.name,
@@ -272,10 +270,7 @@ impl SkillLoader {
             }
 
             // Cache miss or content changed — parse the file.
-            let relative = path
-                .strip_prefix(&self.root)
-                .unwrap_or(path)
-                .to_path_buf();
+            let relative = path.strip_prefix(&self.root).unwrap_or(path).to_path_buf();
             match Self::parse_skill(&content, path, &relative) {
                 Ok(skill) => {
                     debug!(
@@ -284,9 +279,7 @@ impl SkillLoader {
                         skill.category,
                         relative.display()
                     );
-                    if let Some(prev) =
-                        seen_names.insert(skill.name.clone(), path.clone())
-                    {
+                    if let Some(prev) = seen_names.insert(skill.name.clone(), path.clone()) {
                         warn!(
                             "Duplicate skill name '{}' — file {} shadows {}",
                             skill.name,
@@ -410,10 +403,7 @@ impl SkillLoader {
                     adj.entry(dep.as_str()).or_default().push(name);
                     *in_degree.entry(name).or_insert(0) += 1;
                 } else {
-                    warn!(
-                        "Skill '{}' depends on '{}' which is not loaded",
-                        name, dep
-                    );
+                    warn!("Skill '{}' depends on '{}' which is not loaded", name, dep);
                 }
             }
         }
@@ -456,10 +446,7 @@ impl SkillLoader {
                 .filter(|n| !result.contains(&n.to_string()))
                 .map(|n| n.to_string())
                 .collect();
-            warn!(
-                "Circular dependency detected among skills: {:?}",
-                remaining
-            );
+            warn!("Circular dependency detected among skills: {:?}", remaining);
             result.extend(remaining);
         }
 
@@ -524,10 +511,7 @@ impl SkillLoader {
                     if dep_skill.version.is_none() {
                         warnings.push(VersionWarning {
                             skill_name: skill.name.clone(),
-                            message: format!(
-                                "Dependency '{}' has no version declared",
-                                dep
-                            ),
+                            message: format!("Dependency '{}' has no version declared", dep),
                         });
                     }
                 }
@@ -581,7 +565,10 @@ impl SkillLoader {
     pub fn invalidate_by_name(&mut self, name: &str) {
         if let Some(skill) = self.by_name.remove(name) {
             // Find and remove from path cache.
-            let canonical = skill.source_path.canonicalize().unwrap_or(skill.source_path.clone());
+            let canonical = skill
+                .source_path
+                .canonicalize()
+                .unwrap_or(skill.source_path.clone());
             self.cache.remove(&canonical);
             self.rebuild_dependents();
         }
@@ -642,11 +629,7 @@ impl SkillLoader {
         names
     }
 
-    fn collect_dependents_recursive(
-        &self,
-        name: &str,
-        result: &mut HashSet<String>,
-    ) {
+    fn collect_dependents_recursive(&self, name: &str, result: &mut HashSet<String>) {
         if result.contains(name) {
             return;
         }
@@ -685,7 +668,10 @@ impl SkillLoader {
         }
         let watcher = SkillWatcher::new(self.root.clone())?;
         self.watcher = Some(watcher);
-        info!("Started watching {} for skill file changes", self.root.display());
+        info!(
+            "Started watching {} for skill file changes",
+            self.root.display()
+        );
         Ok(())
     }
 
@@ -720,8 +706,7 @@ impl SkillLoader {
                         .values()
                         .find(|s| {
                             s.source_path == *p
-                                || s.source_path.canonicalize().ok()
-                                    == p.canonicalize().ok()
+                                || s.source_path.canonicalize().ok() == p.canonicalize().ok()
                         })
                         .map(|s| s.name.clone())
                 })
@@ -748,10 +733,9 @@ impl SkillLoader {
             .cache
             .values()
             .filter_map(|entry| {
-                let current_mtime =
-                    std::fs::metadata(&entry.skill.source_path)
-                        .ok()
-                        .and_then(|m| m.modified().ok());
+                let current_mtime = std::fs::metadata(&entry.skill.source_path)
+                    .ok()
+                    .and_then(|m| m.modified().ok());
                 if current_mtime != entry.skill.modified_at {
                     Some(entry.skill.source_path.clone())
                 } else {
@@ -767,16 +751,11 @@ impl SkillLoader {
         // Check for new files.
         if self.root.exists() {
             let files = collect_md_files(&self.root)?;
-            let cached_paths: HashSet<PathBuf> = self
-                .cache
-                .keys()
-                .cloned()
-                .collect();
+            let cached_paths: HashSet<PathBuf> = self.cache.keys().cloned().collect();
 
             let mut new_paths = Vec::new();
             for file in &files {
-                let canonical =
-                    file.canonicalize().unwrap_or_else(|_| file.clone());
+                let canonical = file.canonicalize().unwrap_or_else(|_| file.clone());
                 if !cached_paths.contains(&canonical) {
                     new_paths.push(canonical);
                 }
@@ -790,27 +769,19 @@ impl SkillLoader {
         }
 
         if !changed_paths.is_empty() {
-            let names_before: HashSet<String> =
-                self.by_name.keys().cloned().collect();
+            let names_before: HashSet<String> = self.by_name.keys().cloned().collect();
             self.load_all()?;
-            let names_after: HashSet<String> =
-                self.by_name.keys().cloned().collect();
+            let names_after: HashSet<String> = self.by_name.keys().cloned().collect();
 
             // Names that are new or were reloaded.
-            reloaded = names_after
-                .difference(&names_before)
-                .cloned()
-                .collect();
+            reloaded = names_after.difference(&names_before).cloned().collect();
 
             // Also include names whose cache was invalidated (changed content).
             for path in &changed_paths {
                 if let Some(name) = self
                     .by_name
                     .values()
-                    .find(|s| {
-                        s.source_path.canonicalize().ok()
-                            == path.canonicalize().ok()
-                    })
+                    .find(|s| s.source_path.canonicalize().ok() == path.canonicalize().ok())
                     .map(|s| s.name.clone())
                 {
                     if !reloaded.contains(&name) {
@@ -824,11 +795,7 @@ impl SkillLoader {
             self.load_all()?;
             let count_after = self.by_name.len();
             if count_after > count_before {
-                reloaded = self
-                    .by_name
-                    .keys()
-                    .cloned()
-                    .collect();
+                reloaded = self.by_name.keys().cloned().collect();
             }
         }
 
@@ -872,9 +839,7 @@ impl SkillLoader {
             });
 
         if name.is_empty() {
-            anyhow::bail!(
-                "Skill name is empty (no frontmatter 'name' and file stem is empty)"
-            );
+            anyhow::bail!("Skill name is empty (no frontmatter 'name' and file stem is empty)");
         }
 
         if name.contains(|c: char| !c.is_alphanumeric() && c != '_' && c != '-') {
@@ -920,8 +885,7 @@ impl SkillLoader {
             .and_then(|v| v.as_str())
             .map(String::from);
         let dependencies = yaml_string_array(&frontmatter, "dependencies");
-        let modified_at =
-            std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
+        let modified_at = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
 
         Ok(Skill {
             name,
@@ -952,8 +916,8 @@ fn collect_md_files(dir: &Path) -> Result<Vec<PathBuf>> {
 }
 
 fn walk_dir(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    let entries = std::fs::read_dir(dir)
-        .with_context(|| format!("Failed to read dir: {}", dir.display()))?;
+    let entries =
+        std::fs::read_dir(dir).with_context(|| format!("Failed to read dir: {}", dir.display()))?;
 
     for entry in entries {
         let entry = entry.context("Failed to read dir entry")?;
@@ -991,9 +955,7 @@ fn parse_frontmatter(content: &str) -> Result<(serde_yaml::Value, String)> {
     }
 
     let after_first = &trimmed[3..];
-    let end = after_first
-        .find("---")
-        .context("Unclosed frontmatter")?;
+    let end = after_first.find("---").context("Unclosed frontmatter")?;
 
     let frontmatter_str = &after_first[..end];
     let body = after_first[end + 3..].to_string();
@@ -1008,10 +970,7 @@ fn parse_frontmatter(content: &str) -> Result<(serde_yaml::Value, String)> {
 ///
 /// Skips parameters with empty names (logs a warning).
 fn parse_parameters(frontmatter: &serde_yaml::Value) -> Vec<SkillParameter> {
-    let params = match frontmatter
-        .get("parameters")
-        .and_then(|v| v.as_sequence())
-    {
+    let params = match frontmatter.get("parameters").and_then(|v| v.as_sequence()) {
         Some(seq) => seq,
         None => return Vec::new(),
     };
@@ -1033,10 +992,7 @@ fn parse_parameters(frontmatter: &serde_yaml::Value) -> Vec<SkillParameter> {
                     .and_then(|d| d.as_str())
                     .unwrap_or("")
                     .to_string();
-                let required = v
-                    .get("required")
-                    .and_then(|r| r.as_bool())
-                    .unwrap_or(false);
+                let required = v.get("required").and_then(|r| r.as_bool()).unwrap_or(false);
                 Some(SkillParameter {
                     name,
                     description,
@@ -1148,12 +1104,23 @@ mod tests {
     #[test]
     fn test_version_parse_trimmed() {
         let v = Version::parse("  1.0.0  ").unwrap();
-        assert_eq!(v, Version { major: 1, minor: 0, patch: 0 });
+        assert_eq!(
+            v,
+            Version {
+                major: 1,
+                minor: 0,
+                patch: 0
+            }
+        );
     }
 
     #[test]
     fn test_version_display() {
-        let v = Version { major: 1, minor: 2, patch: 3 };
+        let v = Version {
+            major: 1,
+            minor: 2,
+            patch: 3,
+        };
         assert_eq!(format!("{}", v), "1.2.3");
     }
 
@@ -1242,8 +1209,7 @@ mod tests {
 
     #[test]
     fn test_parse_parameters_string_shorthand() {
-        let yaml =
-            serde_yaml::from_str("parameters:\n  - query\n  - limit\n").unwrap();
+        let yaml = serde_yaml::from_str("parameters:\n  - query\n  - limit\n").unwrap();
         let params = parse_parameters(&yaml);
         assert_eq!(params.len(), 2);
         assert!(!params[0].required);
@@ -1279,8 +1245,7 @@ mod tests {
 
     #[test]
     fn test_yaml_string_array_present() {
-        let yaml: serde_yaml::Value =
-            serde_yaml::from_str("tags:\n  - a\n  - b\n").unwrap();
+        let yaml: serde_yaml::Value = serde_yaml::from_str("tags:\n  - a\n  - b\n").unwrap();
         assert_eq!(yaml_string_array(&yaml, "tags"), vec!["a", "b"]);
     }
 
@@ -1328,8 +1293,7 @@ mod tests {
 
     #[test]
     fn test_load_all_nonexistent_dir() {
-        let mut loader =
-            SkillLoader::new(PathBuf::from("/tmp/no_such_skills_dir_xyz"));
+        let mut loader = SkillLoader::new(PathBuf::from("/tmp/no_such_skills_dir_xyz"));
         let skills = loader.load_all().unwrap();
         assert!(skills.is_empty());
     }
@@ -1429,10 +1393,7 @@ mod tests {
         let mut loader = SkillLoader::new(tmp.path().to_path_buf());
         loader.load_all().unwrap();
 
-        assert_eq!(
-            loader.get("c").unwrap().dependencies,
-            vec!["a", "b"]
-        );
+        assert_eq!(loader.get("c").unwrap().dependencies, vec!["a", "b"]);
     }
 
     #[test]
@@ -1698,10 +1659,11 @@ mod tests {
         let warnings = loader.check_versions();
         // base has no version (1 warning) + top depends on base which has no version (1 warning)
         assert_eq!(warnings.len(), 2);
-        let messages: Vec<&str> =
-            warnings.iter().map(|w| w.message.as_str()).collect();
+        let messages: Vec<&str> = warnings.iter().map(|w| w.message.as_str()).collect();
         assert!(messages.iter().any(|m| m.contains("No version declared")));
-        assert!(messages.iter().any(|m| m.contains("Dependency 'base' has no version")));
+        assert!(messages
+            .iter()
+            .any(|m| m.contains("Dependency 'base' has no version")));
     }
 
     #[test]
@@ -1803,16 +1765,8 @@ mod tests {
     #[test]
     fn test_invalidate_pattern() {
         let tmp = tempfile::tempdir().unwrap();
-        write_skill(
-            tmp.path(),
-            "devops/a.md",
-            "---\nname: a\n---\nA.",
-        );
-        write_skill(
-            tmp.path(),
-            "monitor/b.md",
-            "---\nname: b\n---\nB.",
-        );
+        write_skill(tmp.path(), "devops/a.md", "---\nname: a\n---\nA.");
+        write_skill(tmp.path(), "monitor/b.md", "---\nname: b\n---\nB.");
 
         let mut loader = SkillLoader::new(tmp.path().to_path_buf());
         loader.load_all().unwrap();
@@ -2092,10 +2046,7 @@ mod tests {
         let mut loader = SkillLoader::new(tmp.path().to_path_buf());
         loader.load_all().unwrap();
 
-        assert_eq!(
-            loader.get("deploy").unwrap().tags,
-            vec!["deploy", "cicd"]
-        );
+        assert_eq!(loader.get("deploy").unwrap().tags, vec!["deploy", "cicd"]);
     }
 
     #[test]
@@ -2195,11 +2146,7 @@ mod tests {
     #[test]
     fn test_invalidate_all_forces_full_reload() {
         let tmp = tempfile::tempdir().unwrap();
-        write_skill(
-            tmp.path(),
-            "a.md",
-            "---\nname: a\n---\nAlpha.",
-        );
+        write_skill(tmp.path(), "a.md", "---\nname: a\n---\nAlpha.");
 
         let mut loader = SkillLoader::new(tmp.path().to_path_buf());
         loader.load_all().unwrap();
@@ -2261,11 +2208,7 @@ mod tests {
         loader.load_all().unwrap();
         assert_eq!(loader.len(), 1);
 
-        write_skill(
-            tmp.path(),
-            "second.md",
-            "---\nname: second\n---\nSecond.",
-        );
+        write_skill(tmp.path(), "second.md", "---\nname: second\n---\nSecond.");
 
         loader.load_all().unwrap();
         assert_eq!(loader.len(), 2);
@@ -2320,16 +2263,8 @@ mod tests {
     #[test]
     fn test_duplicate_name_last_wins() {
         let tmp = tempfile::tempdir().unwrap();
-        write_skill(
-            tmp.path(),
-            "a.md",
-            "---\nname: dup\n---\nFirst.",
-        );
-        write_skill(
-            tmp.path(),
-            "b.md",
-            "---\nname: dup\n---\nSecond.",
-        );
+        write_skill(tmp.path(), "a.md", "---\nname: dup\n---\nFirst.");
+        write_skill(tmp.path(), "b.md", "---\nname: dup\n---\nSecond.");
 
         let mut loader = SkillLoader::new(tmp.path().to_path_buf());
         let skills = loader.load_all().unwrap();
@@ -2426,7 +2361,11 @@ mod tests {
     #[test]
     fn test_watcher_detects_new_file() {
         let tmp = tempfile::tempdir().unwrap();
-        write_skill(tmp.path(), "existing.md", "---\nname: existing\n---\nExisting.");
+        write_skill(
+            tmp.path(),
+            "existing.md",
+            "---\nname: existing\n---\nExisting.",
+        );
 
         let mut loader = SkillLoader::new(tmp.path().to_path_buf());
         loader.load_all().unwrap();
@@ -2436,7 +2375,11 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(200));
 
         // Add a new file.
-        write_skill(tmp.path(), "new_skill.md", "---\nname: new_skill\n---\nNew.");
+        write_skill(
+            tmp.path(),
+            "new_skill.md",
+            "---\nname: new_skill\n---\nNew.",
+        );
 
         std::thread::sleep(std::time::Duration::from_millis(500));
 
@@ -2463,26 +2406,14 @@ mod tests {
         assert!(!loader.is_watching());
 
         // Modify file mtime to trigger reload.
-        let new_time =
-            std::time::SystemTime::now() + std::time::Duration::from_secs(10);
-        filetime::set_file_mtime(
-            &path,
-            filetime::FileTime::from_system_time(new_time),
-        )
-        .unwrap();
+        let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(10);
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(new_time)).unwrap();
         fs::write(&path, "---\nname: fallback\n---\nUpdated.").unwrap();
-        filetime::set_file_mtime(
-            &path,
-            filetime::FileTime::from_system_time(new_time),
-        )
-        .unwrap();
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(new_time)).unwrap();
 
         let reloaded = loader.reload_changed().unwrap();
         assert!(reloaded.contains(&"fallback".to_string()));
-        assert_eq!(
-            loader.get("fallback").unwrap().instructions,
-            "Updated."
-        );
+        assert_eq!(loader.get("fallback").unwrap().instructions, "Updated.");
     }
 
     #[test]

--- a/crates/nanobot-tools/src/skills.rs
+++ b/crates/nanobot-tools/src/skills.rs
@@ -162,7 +162,11 @@ impl SkillStore {
             }
         }
 
-        info!("Loaded {} skill(s) from {}", loaded.len(), self.root.display());
+        info!(
+            "Loaded {} skill(s) from {}",
+            loaded.len(),
+            self.root.display()
+        );
         Ok(loaded)
     }
 
@@ -201,14 +205,10 @@ impl SkillStore {
         if self.root.exists() {
             let files = collect_md_files(&self.root)?;
             for path in files {
-                let already_known = self
-                    .by_name
-                    .values()
-                    .any(|s| s.source_path == path);
+                let already_known = self.by_name.values().any(|s| s.source_path == path);
 
                 if !already_known {
-                    let relative =
-                        path.strip_prefix(&self.root).unwrap_or(&path).to_path_buf();
+                    let relative = path.strip_prefix(&self.root).unwrap_or(&path).to_path_buf();
                     if let Ok(skill) = Self::parse_skill_file(&path, &relative) {
                         info!(
                             "Discovered new skill '{}' at {}",
@@ -346,8 +346,8 @@ fn collect_md_files(dir: &Path) -> Result<Vec<PathBuf>> {
 }
 
 fn walk_dir(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    let entries = std::fs::read_dir(dir)
-        .with_context(|| format!("Failed to read dir: {}", dir.display()))?;
+    let entries =
+        std::fs::read_dir(dir).with_context(|| format!("Failed to read dir: {}", dir.display()))?;
 
     for entry in entries {
         let entry = entry.context("Failed to read dir entry")?;
@@ -418,10 +418,7 @@ fn parse_parameters(frontmatter: &serde_yaml::Value) -> Vec<SkillParameter> {
                     .and_then(|d| d.as_str())
                     .unwrap_or("")
                     .to_string();
-                let required = v
-                    .get("required")
-                    .and_then(|r| r.as_bool())
-                    .unwrap_or(false);
+                let required = v.get("required").and_then(|r| r.as_bool()).unwrap_or(false);
                 Some(SkillParameter {
                     name,
                     description,
@@ -872,17 +869,9 @@ mod tests {
 
         // Bump mtime and overwrite.
         let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(10);
-        filetime::set_file_mtime(
-            &path,
-            filetime::FileTime::from_system_time(new_time),
-        )
-        .unwrap();
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(new_time)).unwrap();
         fs::write(&path, "---\nname: test\n---\nUpdated.").unwrap();
-        filetime::set_file_mtime(
-            &path,
-            filetime::FileTime::from_system_time(new_time),
-        )
-        .unwrap();
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(new_time)).unwrap();
 
         let reloaded = store.reload_changed().unwrap();
         assert_eq!(reloaded, vec!["test"]);
@@ -921,8 +910,7 @@ mod tests {
 
     #[test]
     fn test_yaml_string_array_present() {
-        let yaml: serde_yaml::Value =
-            serde_yaml::from_str("tags:\n  - a\n  - b\n").unwrap();
+        let yaml: serde_yaml::Value = serde_yaml::from_str("tags:\n  - a\n  - b\n").unwrap();
         assert_eq!(yaml_string_array(&yaml, "tags"), vec!["a", "b"]);
     }
 

--- a/crates/nanobot-tools/src/trait_def.rs
+++ b/crates/nanobot-tools/src/trait_def.rs
@@ -194,9 +194,15 @@ mod tests {
             ) -> anyhow::Result<String> {
                 Ok(format!("{}:{}", name, prompt))
             }
-            async fn status(&self, _task_id: &str) -> Option<SpawnStatus> { None }
-            async fn cancel(&self, _task_id: &str) -> bool { false }
-            async fn list(&self) -> Vec<(String, String, SpawnStatus)> { vec![] }
+            async fn status(&self, _task_id: &str) -> Option<SpawnStatus> {
+                None
+            }
+            async fn cancel(&self, _task_id: &str) -> bool {
+                false
+            }
+            async fn list(&self) -> Vec<(String, String, SpawnStatus)> {
+                vec![]
+            }
         }
 
         let spawner = StubSpawner;

--- a/docs/plan-daemon.md
+++ b/docs/plan-daemon.md
@@ -1,0 +1,81 @@
+# Daemon Mode Implementation Plan
+
+## Module Structure: `crates/nanobot-daemon/`
+
+```
+crates/nanobot-daemon/
+├── Cargo.toml
+└── src/
+    ├── lib.rs         — pub mod daemonize, pid_file, signal, logging
+    ├── daemonize.rs   — Daemonizer struct: double-fork via nix crate
+    ├── pid_file.rs    — PidFile: flock-based atomic PID file lock
+    ├── signal.rs      — SignalHandler: tokio::signal::unix for SIGTERM/SIGINT/SIGHUP
+    └── logging.rs     — setup_file_logging: tracing-appender non-blocking writer
+```
+
+## API Surface
+
+### daemonize.rs
+- `pub struct Daemonizer { working_dir, pid_file, log_file }`
+- `pub fn daemonize(config: &DaemonConfig) -> Result<()>` — double-fork, setsid, chdir, umask, redirect stdio
+
+### pid_file.rs
+- `pub struct PidFile { path, file }` — holds locked file handle
+- `pub fn create(path: &str) -> Result<PidFile>` — create + flock(LOCK_EX|LOCK_NB) + write PID
+- `pub fn read_pid(path: &str) -> Result<Option<i32>>` — read PID from file (no lock)
+- `pub fn clean(self) -> Result<()>` — drop lock + unlink file (consume on exit)
+
+### signal.rs
+- `pub enum ShutdownSignal { Graceful, Fast, Reload }`
+- `pub async fn wait_for_signal() -> ShutdownSignal` — tokio::signal::unix for SIGTERM/SIGINT/SIGHUP
+- `pub fn send_sigterm(pid: i32) -> Result<()>` — for `daemon stop`
+
+### logging.rs
+- `pub fn setup_file_logging(log_dir: &str, level: &str) -> Result<WorkerGuard>` — tracing-appender non-blocking
+
+## Integration Points
+
+### main.rs
+- Add `Daemon` subcommand with `DaemonAction` enum (Start, Stop, Restart, Status)
+- `daemon start`: call `nanobot_daemon::daemonize::daemonize()` BEFORE `#[tokio::main]` enters
+- `daemon stop`: read PID, send SIGTERM, wait
+- `daemon restart`: stop + start
+- `daemon status`: read PID, check `/proc/{pid}` exists
+
+### gateway.rs
+- Replace `tokio::signal::ctrl_c()` with `nanobot_daemon::signal::wait_for_signal()`
+- Handle `Graceful` (SIGTERM) and `Fast` (SIGINT) shutdown signals
+- Log `Reload` (SIGHUP) as placeholder
+- Create PidFile on start, clean on exit
+
+### serve.rs
+- Same signal/PID treatment as gateway.rs
+
+## Config Schema Changes
+
+```rust
+// In crates/nanobot-config/src/schema.rs:
+pub struct DaemonConfig {
+    pub enabled: bool,              // default false
+    pub pid_file: String,           // default ~/.nanobot-rs/nanobot-rs.pid
+    pub log_dir: String,            // default ~/.nanobot-rs/logs
+    pub working_directory: String,  // default "/"
+    pub grace_period_secs: u64,     // default 30
+}
+```
+
+Add `daemon: DaemonConfig` field to `Config` struct.
+
+## Dependencies
+
+- `nix` (for fork, setsid, flock, kill — manual double-fork, no daemonize crate)
+- `tracing-appender` (for non-blocking file writer)
+- `tokio` with `signal` feature (already in workspace)
+
+## Test Plan
+
+- `pid_file.rs`: test create/read/clean with tempdir, test double-lock fails
+- `daemonize.rs`: test Daemonizer::new builds correct struct (can't test actual fork in unit tests)
+- `signal.rs`: test ShutdownSignal enum construction
+- `logging.rs`: test setup creates log directory and returns guard
+- `schema.rs`: test DaemonConfig defaults, test YAML parse with daemon section

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -40,10 +40,7 @@ pub fn validate(config: &Config) -> Result<()> {
         std::process::exit(1);
     }
 
-    println!(
-        "\nConfiguration is valid with {} warning(s).",
-        num_warnings
-    );
+    println!("\nConfiguration is valid with {} warning(s).", num_warnings);
     Ok(())
 }
 

--- a/src/commands/cron.rs
+++ b/src/commands/cron.rs
@@ -22,7 +22,10 @@ pub fn list(_config: &Config) -> Result<()> {
     }
 
     println!("Cron Jobs ({}):\n", states.len());
-    println!("{:<38} {:<20} {:<10} {:<8} {:<20}", "ID", "Name", "State", "Runs", "Next Run");
+    println!(
+        "{:<38} {:<20} {:<10} {:<8} {:<20}",
+        "ID", "Name", "State", "Runs", "Next Run"
+    );
     println!("{}", "-".repeat(100));
 
     for (job, state) in &states {
@@ -65,9 +68,7 @@ pub fn status(_config: &Config, name: &str) -> Result<()> {
 
     // Find by name or ID prefix
     let found = states.iter().find(|(job, _)| {
-        job.name.as_deref() == Some(name)
-            || job.id == name
-            || job.id.starts_with(name)
+        job.name.as_deref() == Some(name) || job.id == name || job.id.starts_with(name)
     });
 
     match found {
@@ -89,7 +90,9 @@ pub fn status(_config: &Config, name: &str) -> Result<()> {
             println!("Schedule:");
             match job.schedule.kind {
                 nanobot_cron::ScheduleKind::At => {
-                    let ts = job.schedule.at_ms
+                    let ts = job
+                        .schedule
+                        .at_ms
                         .and_then(chrono::DateTime::from_timestamp_millis)
                         .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
                         .unwrap_or_else(|| "invalid".to_string());
@@ -113,13 +116,15 @@ pub fn status(_config: &Config, name: &str) -> Result<()> {
             println!("  Run count:  {}", state.run_count);
             println!(
                 "  Last run:   {}",
-                state.last_run
+                state
+                    .last_run
                     .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
                     .unwrap_or_else(|| "never".to_string())
             );
             println!(
                 "  Next run:   {}",
-                state.next_run
+                state
+                    .next_run
                     .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
                     .unwrap_or_else(|| "n/a".to_string())
             );
@@ -150,7 +155,10 @@ pub fn status(_config: &Config, name: &str) -> Result<()> {
             if let Some(cid) = &job.payload.chat_id {
                 println!("  Chat ID: {}", cid);
             }
-            println!("  Deliver: {}", if job.payload.deliver { "yes" } else { "no" });
+            println!(
+                "  Deliver: {}",
+                if job.payload.deliver { "yes" } else { "no" }
+            );
         }
         None => {
             println!("Cron job '{}' not found.", name);

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -1,0 +1,147 @@
+//! Daemon subcommand — manage the nanobot-rs background daemon.
+//!
+//! Provides `start`, `stop`, `restart`, and `status` actions for controlling
+//! the daemonized nanobot-rs process.
+
+use anyhow::{bail, Result};
+use nanobot_config::Config;
+
+/// Actions for the `daemon` subcommand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DaemonAction {
+    /// Daemonize the process and run the gateway.
+    Start,
+    /// Send SIGTERM to the running daemon and wait for exit.
+    Stop,
+    /// Stop then start the daemon.
+    Restart,
+    /// Check if the daemon is running.
+    Status,
+}
+
+/// Execute a daemon management action.
+///
+/// **Note**: `Start` performs daemonization and must run BEFORE the tokio
+/// runtime is initialized (fork kills threads). The caller is responsible
+/// for calling this before `#[tokio::main]` sets up the runtime.
+///
+/// The `Start` action does NOT actually launch the gateway — it only
+/// daemonizes. The caller should proceed to start the gateway after
+/// `run(DaemonAction::Start)` returns `Ok(())`.
+///
+/// # Arguments
+///
+/// * `action` - Which daemon action to perform.
+/// * `config` - The loaded configuration (for PID file paths, etc.).
+pub fn run(action: &DaemonAction, config: &Config) -> Result<()> {
+    match action {
+        DaemonAction::Start => do_start(config),
+        DaemonAction::Stop => do_stop(config),
+        DaemonAction::Restart => do_restart(config),
+        DaemonAction::Status => do_status(config),
+    }
+}
+
+/// Perform daemonization: double-fork, PID file, redirect stdio.
+///
+/// This must be called before the tokio runtime starts.
+fn do_start(config: &Config) -> Result<()> {
+    let pid_file_path = &config.daemon.pid_file;
+    let log_dir = &config.daemon.log_dir;
+    let working_dir = &config.daemon.working_directory;
+
+    // Ensure log directory exists before daemonize (stderr redirect needs it)
+    std::fs::create_dir_all(log_dir)?;
+
+    // Create PID file with flock — prevents double-start
+    let log_file_path = std::path::Path::new(log_dir).join("nanobot-rs.err");
+    let log_file_str = log_file_path.to_str().unwrap_or("/dev/null");
+
+    // PID file is created and locked here. We leak it intentionally —
+    // the lock should persist for the daemon's lifetime, and the file
+    // will be cleaned up on process exit via tempfile or explicit stop.
+    nanobot_daemon::pid_file::PidFile::create(pid_file_path)?;
+
+    // Daemonize: double-fork, setsid, chdir, redirect stdio
+    nanobot_daemon::daemonize::daemonize(working_dir, Some(log_file_str))?;
+
+    // Setup file logging in the daemon process
+    let _guard = nanobot_daemon::logging::setup_file_logging(log_dir, "info");
+    tracing::info!("Daemon started (pid={})", std::process::id());
+
+    // NOTE: The caller should now start the gateway/serve.
+    // The logging guard is intentionally leaked to keep file logging alive.
+    std::mem::forget(_guard);
+
+    Ok(())
+}
+
+/// Stop the running daemon by sending SIGTERM.
+fn do_stop(config: &Config) -> Result<()> {
+    let pid = match nanobot_daemon::pid_file::PidFile::read_pid(&config.daemon.pid_file)? {
+        Some(pid) => pid,
+        None => bail!("No PID file found at {} — is the daemon running?", config.daemon.pid_file),
+    };
+
+    if !nanobot_daemon::pid_file::is_process_running(pid) {
+        // Stale PID file — clean it up
+        let _ = std::fs::remove_file(&config.daemon.pid_file);
+        bail!("Process {pid} is not running. Removed stale PID file.");
+    }
+
+    println!("Stopping daemon (pid={pid})...");
+    let timeout = config.daemon.grace_period_secs;
+    nanobot_daemon::signal::send_sigterm_and_wait(pid, timeout)?;
+    println!("Daemon stopped.");
+
+    // Clean up PID file
+    let _ = std::fs::remove_file(&config.daemon.pid_file);
+    Ok(())
+}
+
+/// Restart: stop the existing daemon, then start a new one.
+fn do_restart(config: &Config) -> Result<()> {
+    // Try to stop — ignore errors if not running
+    if nanobot_daemon::pid_file::PidFile::read_pid(&config.daemon.pid_file)?.is_some() {
+        let _ = do_stop(config);
+    }
+    do_start(config)
+}
+
+/// Check the daemon's status.
+fn do_status(config: &Config) -> Result<()> {
+    match nanobot_daemon::pid_file::PidFile::read_pid(&config.daemon.pid_file)? {
+        Some(pid) => {
+            if nanobot_daemon::pid_file::is_process_running(pid) {
+                println!("Daemon is running (pid={pid})");
+            } else {
+                println!("Daemon is NOT running (stale PID file: pid={pid})");
+            }
+        }
+        None => {
+            println!("Daemon is NOT running (no PID file)");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_daemon_action_equality() {
+        assert_eq!(DaemonAction::Start, DaemonAction::Start);
+        assert_eq!(DaemonAction::Stop, DaemonAction::Stop);
+        assert_ne!(DaemonAction::Start, DaemonAction::Stop);
+    }
+
+    #[test]
+    fn test_status_no_pid_file() {
+        let config = Config::default();
+        // Default PID file shouldn't exist — status should succeed but report not running
+        let result = do_status(&config);
+        // This succeeds (prints "not running"), doesn't error
+        assert!(result.is_ok());
+    }
+}

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -74,7 +74,7 @@ fn do_start(config: &Config) -> Result<nanobot_daemon::pid_file::PidFile> {
     let pid_file = nanobot_daemon::pid_file::PidFile::create(pid_file_path)?;
 
     // Setup file logging in the daemon process
-    let _guard = nanobot_daemon::logging::setup_file_logging(log_dir, "info");
+    let _guard = nanobot_daemon::logging::setup_file_logging(log_dir, "info")?;
     tracing::info!("Daemon started (pid={})", std::process::id());
 
     // Store the logging guard in a global so it lives for the process lifetime.
@@ -112,18 +112,41 @@ fn do_stop(config: &Config) -> Result<()> {
     Ok(())
 }
 
-/// Restart: stop the existing daemon, then start a new one.
+/// Restart: stop the existing daemon, then re-exec `daemon start`.
+///
+/// Cannot call `do_start` directly because the gateway launch logic lives
+/// in `main.rs`. Instead, we re-exec ourselves with the `daemon start`
+/// subcommand so the new process follows the full startup path.
 fn do_restart(config: &Config) -> Result<()> {
     // Try to stop — ignore errors if not running
     if nanobot_daemon::pid_file::PidFile::read_pid(&config.daemon.pid_file)?.is_some() {
         let _ = do_stop(config);
     }
-    let _pid_file = do_start(config)?;
-    // NOTE: restart calls do_start which daemonizes. After daemonize,
-    // the grandchild returns here but the process will exit when this
-    // function returns because there's no gateway to run.
-    // A full restart should be done via: `daemon stop && daemon start`
-    // (where start is wired to gateway::run in main.rs)
+
+    // Re-exec ourselves: `nanobot-rs -c <config> daemon start`
+    let exe = std::env::current_exe()?;
+    // Look for -c argument in our own args
+    let args: Vec<String> = std::env::args().collect();
+    let mut cmd = std::process::Command::new(&exe);
+    let mut found_config = false;
+    for i in 1..args.len() {
+        if args[i] == "-c" || args[i] == "--config" {
+            if i + 1 < args.len() {
+                cmd.arg("-c").arg(&args[i + 1]);
+                found_config = true;
+            }
+        } else if args[i - 1] != "-c" && args[i - 1] != "--config" {
+            // Skip the old subcommand args
+        }
+    }
+    if !found_config {
+        // Try default config path
+        cmd.arg("-c").arg("/root/.nanobot-rs/config.yaml");
+    }
+    cmd.arg("daemon").arg("start");
+
+    let child = cmd.spawn()?;
+    println!("Restarted daemon (new process pid={})", child.id());
     Ok(())
 }
 

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -28,19 +28,33 @@ pub enum DaemonAction {
 ///
 /// * `action` - Which daemon action to perform.
 /// * `config` - The loaded configuration (for PID file paths, etc.).
-pub fn handle_daemon_command(action: DaemonAction, config: Config) -> Result<()> {
+///
+/// # Returns
+///
+/// For `DaemonAction::Start`, returns `Ok(Some(PidFile))` so the caller
+/// can pass it to the gateway runner for cleanup on shutdown.
+/// For other actions, returns `Ok(None)`.
+pub fn handle_daemon_command(
+    action: DaemonAction,
+    config: Config,
+) -> Result<Option<nanobot_daemon::pid_file::PidFile>> {
     match action {
-        DaemonAction::Start => do_start(&config),
-        DaemonAction::Stop => do_stop(&config),
-        DaemonAction::Restart => do_restart(&config),
-        DaemonAction::Status => do_status(&config),
+        DaemonAction::Start => do_start(&config).map(Some),
+        DaemonAction::Stop => do_stop(&config).map(|()| None),
+        DaemonAction::Restart => do_restart(&config).map(|()| None),
+        DaemonAction::Status => do_status(&config).map(|()| None),
     }
 }
 
 /// Perform daemonization: double-fork, PID file, redirect stdio.
 ///
-/// This must be called before the tokio runtime starts.
-fn do_start(config: &Config) -> Result<()> {
+/// This must be called before the tokio runtime starts. After daemonize
+/// returns, the caller is the grandchild process (the actual daemon).
+/// The PID file is created AFTER daemonize to ensure it contains the
+/// correct (grandchild) PID.
+///
+/// Returns a `PidFile` whose lock persists for the daemon's lifetime.
+fn do_start(config: &Config) -> Result<nanobot_daemon::pid_file::PidFile> {
     let pid_file_path = &config.daemon.pid_file;
     let log_dir = &config.daemon.log_dir;
     let working_dir = &config.daemon.working_directory;
@@ -48,27 +62,26 @@ fn do_start(config: &Config) -> Result<()> {
     // Ensure log directory exists before daemonize (stderr redirect needs it)
     std::fs::create_dir_all(log_dir)?;
 
-    // Create PID file with flock — prevents double-start
     let log_file_path = std::path::Path::new(log_dir).join("nanobot-rs.err");
     let log_file_str = log_file_path.to_str().unwrap_or("/dev/null");
 
-    // PID file is created and locked here. We leak it intentionally —
-    // the lock should persist for the daemon's lifetime, and the file
-    // will be cleaned up on process exit via tempfile or explicit stop.
-    nanobot_daemon::pid_file::PidFile::create(pid_file_path)?;
-
-    // Daemonize: double-fork, setsid, chdir, redirect stdio
+    // Daemonize FIRST: double-fork, setsid, chdir, redirect stdio.
+    // After this returns, we are the grandchild (the actual daemon) with a NEW PID.
     nanobot_daemon::daemonize::daemonize(working_dir, Some(log_file_str))?;
+
+    // NOW create PID file — after daemonize, so the PID is the grandchild's.
+    // flock prevents double-start: if another instance holds the lock, we fail.
+    let pid_file = nanobot_daemon::pid_file::PidFile::create(pid_file_path)?;
 
     // Setup file logging in the daemon process
     let _guard = nanobot_daemon::logging::setup_file_logging(log_dir, "info");
     tracing::info!("Daemon started (pid={})", std::process::id());
 
-    // NOTE: The caller should now start the gateway/serve.
-    // The logging guard is intentionally leaked to keep file logging alive.
-    std::mem::forget(_guard);
+    // Store the logging guard in a global so it lives for the process lifetime.
+    // Box::leak is intentional — the guard must outlive all log calls.
+    Box::leak(Box::new(_guard));
 
-    Ok(())
+    Ok(pid_file)
 }
 
 /// Stop the running daemon by sending SIGTERM.
@@ -105,7 +118,13 @@ fn do_restart(config: &Config) -> Result<()> {
     if nanobot_daemon::pid_file::PidFile::read_pid(&config.daemon.pid_file)?.is_some() {
         let _ = do_stop(config);
     }
-    do_start(config)
+    let _pid_file = do_start(config)?;
+    // NOTE: restart calls do_start which daemonizes. After daemonize,
+    // the grandchild returns here but the process will exit when this
+    // function returns because there's no gateway to run.
+    // A full restart should be done via: `daemon stop && daemon start`
+    // (where start is wired to gateway::run in main.rs)
+    Ok(())
 }
 
 /// Check the daemon's status.

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -6,6 +6,17 @@
 use anyhow::{bail, Result};
 use nanobot_config::Config;
 
+/// Handles returned by [`do_start`] that must live for the daemon's lifetime.
+///
+/// Dropping `DaemonHandles` flushes remaining log lines (via `log_guard`)
+/// then releases the PID file lock.
+pub struct DaemonHandles {
+    /// PID file holding the flock — released on drop.
+    pub pid_file: nanobot_daemon::pid_file::PidFile,
+    /// Non-blocking log writer guard — flushes remaining logs on drop.
+    pub log_guard: nanobot_daemon::logging::LogGuard,
+}
+
 /// Actions for the `daemon` subcommand.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DaemonAction {
@@ -31,13 +42,13 @@ pub enum DaemonAction {
 ///
 /// # Returns
 ///
-/// For `DaemonAction::Start`, returns `Ok(Some(PidFile))` so the caller
-/// can pass it to the gateway runner for cleanup on shutdown.
+/// For `DaemonAction::Start`, returns `Ok(Some(DaemonHandles))` so the caller
+/// can hold them for the process lifetime and drop on shutdown (flushing logs).
 /// For other actions, returns `Ok(None)`.
 pub fn handle_daemon_command(
     action: DaemonAction,
     config: Config,
-) -> Result<Option<nanobot_daemon::pid_file::PidFile>> {
+) -> Result<Option<DaemonHandles>> {
     match action {
         DaemonAction::Start => do_start(&config).map(Some),
         DaemonAction::Stop => do_stop(&config).map(|()| None),
@@ -46,15 +57,16 @@ pub fn handle_daemon_command(
     }
 }
 
-/// Perform daemonization: double-fork, PID file, redirect stdio.
+/// Perform daemonization: double-fork, PID file, redirect stdio, file logging.
 ///
 /// This must be called before the tokio runtime starts. After daemonize
 /// returns, the caller is the grandchild process (the actual daemon).
 /// The PID file is created AFTER daemonize to ensure it contains the
 /// correct (grandchild) PID.
 ///
-/// Returns a `PidFile` whose lock persists for the daemon's lifetime.
-fn do_start(config: &Config) -> Result<nanobot_daemon::pid_file::PidFile> {
+/// Returns [`DaemonHandles`] whose `log_guard` and `pid_file` must be held
+/// for the daemon's lifetime and dropped on shutdown.
+fn do_start(config: &Config) -> Result<DaemonHandles> {
     let pid_file_path = &config.daemon.pid_file;
     let log_dir = &config.daemon.log_dir;
     let working_dir = &config.daemon.working_directory;
@@ -71,17 +83,24 @@ fn do_start(config: &Config) -> Result<nanobot_daemon::pid_file::PidFile> {
 
     // NOW create PID file — after daemonize, so the PID is the grandchild's.
     // flock prevents double-start: if another instance holds the lock, we fail.
+    // But first, clean up stale PID file from a previous crashed instance.
+    if let Ok(Some(old_pid)) = nanobot_daemon::pid_file::PidFile::read_pid(pid_file_path) {
+        if !nanobot_daemon::pid_file::is_process_running(old_pid) {
+            let _ = std::fs::remove_file(pid_file_path);
+            // No tracing subscriber yet — stderr is redirected to log file
+            eprintln!("Cleaned stale PID file from crashed instance (pid={old_pid})");
+        }
+    }
     let pid_file = nanobot_daemon::pid_file::PidFile::create(pid_file_path)?;
 
     // Setup file logging in the daemon process
-    let _guard = nanobot_daemon::logging::setup_file_logging(log_dir, "info")?;
+    let log_guard = nanobot_daemon::logging::setup_file_logging(log_dir, "info")?;
     tracing::info!("Daemon started (pid={})", std::process::id());
 
-    // Store the logging guard in a global so it lives for the process lifetime.
-    // Box::leak is intentional — the guard must outlive all log calls.
-    Box::leak(Box::new(_guard));
-
-    Ok(pid_file)
+    Ok(DaemonHandles {
+        pid_file,
+        log_guard,
+    })
 }
 
 /// Stop the running daemon by sending SIGTERM.
@@ -123,29 +142,20 @@ fn do_restart(config: &Config) -> Result<()> {
         let _ = do_stop(config);
     }
 
-    // Re-exec ourselves: `nanobot-rs -c <config> daemon start`
+    // Re-exec: rebuild args replacing "restart" with "start"
     let exe = std::env::current_exe()?;
-    // Look for -c argument in our own args
-    let args: Vec<String> = std::env::args().collect();
-    let mut cmd = std::process::Command::new(&exe);
-    let mut found_config = false;
-    for i in 1..args.len() {
-        if args[i] == "-c" || args[i] == "--config" {
-            if i + 1 < args.len() {
-                cmd.arg("-c").arg(&args[i + 1]);
-                found_config = true;
+    let args: Vec<String> = std::env::args()
+        .skip(1) // skip program name
+        .map(|a| {
+            if a == "restart" {
+                "start".to_string()
+            } else {
+                a
             }
-        } else if args[i - 1] != "-c" && args[i - 1] != "--config" {
-            // Skip the old subcommand args
-        }
-    }
-    if !found_config {
-        // Try default config path
-        cmd.arg("-c").arg("/root/.nanobot-rs/config.yaml");
-    }
-    cmd.arg("daemon").arg("start");
+        })
+        .collect();
 
-    let child = cmd.spawn()?;
+    let child = std::process::Command::new(&exe).args(&args).spawn()?;
     println!("Restarted daemon (new process pid={})", child.id());
     Ok(())
 }
@@ -157,7 +167,9 @@ fn do_status(config: &Config) -> Result<()> {
             if nanobot_daemon::pid_file::is_process_running(pid) {
                 println!("Daemon is running (pid={pid})");
             } else {
-                println!("Daemon is NOT running (stale PID file: pid={pid})");
+                // Auto-clean stale PID file
+                let _ = std::fs::remove_file(&config.daemon.pid_file);
+                println!("Daemon is NOT running (cleaned stale PID file: pid={pid})");
             }
         }
         None => {

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -19,26 +19,21 @@ pub enum DaemonAction {
     Status,
 }
 
-/// Execute a daemon management action.
+/// Handle a daemon CLI subcommand.
 ///
-/// **Note**: `Start` performs daemonization and must run BEFORE the tokio
-/// runtime is initialized (fork kills threads). The caller is responsible
-/// for calling this before `#[tokio::main]` sets up the runtime.
-///
-/// The `Start` action does NOT actually launch the gateway — it only
-/// daemonizes. The caller should proceed to start the gateway after
-/// `run(DaemonAction::Start)` returns `Ok(())`.
+/// Maps from the string-based subcommand name to the typed [`DaemonAction`]
+/// and dispatches accordingly.
 ///
 /// # Arguments
 ///
 /// * `action` - Which daemon action to perform.
 /// * `config` - The loaded configuration (for PID file paths, etc.).
-pub fn run(action: &DaemonAction, config: &Config) -> Result<()> {
+pub fn handle_daemon_command(action: DaemonAction, config: Config) -> Result<()> {
     match action {
-        DaemonAction::Start => do_start(config),
-        DaemonAction::Stop => do_stop(config),
-        DaemonAction::Restart => do_restart(config),
-        DaemonAction::Status => do_status(config),
+        DaemonAction::Start => do_start(&config),
+        DaemonAction::Stop => do_stop(&config),
+        DaemonAction::Restart => do_restart(&config),
+        DaemonAction::Status => do_status(&config),
     }
 }
 
@@ -80,7 +75,12 @@ fn do_start(config: &Config) -> Result<()> {
 fn do_stop(config: &Config) -> Result<()> {
     let pid = match nanobot_daemon::pid_file::PidFile::read_pid(&config.daemon.pid_file)? {
         Some(pid) => pid,
-        None => bail!("No PID file found at {} — is the daemon running?", config.daemon.pid_file),
+        None => {
+            bail!(
+                "No PID file found at {} — is the daemon running?",
+                config.daemon.pid_file
+            )
+        }
     };
 
     if !nanobot_daemon::pid_file::is_process_running(pid) {

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -172,7 +172,6 @@ pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
     // ── Wait for shutdown signal ──────────────────────────────
     #[cfg(target_family = "unix")]
     {
-        let grace_period = config.daemon.grace_period_secs;
         loop {
             let sig = nanobot_daemon::signal::wait_for_signal().await;
             match sig {
@@ -191,7 +190,6 @@ pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
                 }
             }
         }
-        let _ = grace_period; // Used by daemon stop's send_sigterm_and_wait
     }
 
     #[cfg(not(target_family = "unix"))]

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -3,8 +3,7 @@
 //! Wires together: bus, channels, agent loop, session manager,
 //! provider registry, tool registry, heartbeat, and API server.
 //!
-//! Supports both foreground and daemon modes. When `config.daemon.enabled`
-//! is true, the process daemonizes before starting components.
+//! Supports daemon mode when launched via `nanobot-rs daemon start`.
 
 use std::sync::Arc;
 
@@ -23,20 +22,8 @@ use tracing::info;
 
 /// Run the gateway — starts all components and connects them via the bus.
 ///
-/// When `config.daemon.enabled` is true, the process will daemonize (double-fork)
-/// before starting. In daemon mode, signal handling uses SIGTERM/SIGINT/SIGHUP
-/// instead of just Ctrl+C.
+/// PID file management is handled by the `daemon start` command, not here.
 pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
-    // Daemonize if configured (PID file is created in the daemon command handler
-    // for explicit `daemon start`, or here for config-driven daemon mode)
-    #[cfg(target_family = "unix")]
-    let _pid_guard = if config.daemon.enabled {
-        let pid = nanobot_daemon::pid_file::PidFile::create(&config.daemon.pid_file)?;
-        Some(pid)
-    } else {
-        None
-    };
-
     info!("Starting nanobot gateway...");
 
     // ── Shared bus ────────────────────────────────────────────
@@ -234,14 +221,6 @@ pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
     // ── Graceful shutdown ─────────────────────────────────────
     info!("Stopping all channels...");
     channel_manager.stop_all().await;
-
-    // Clean up PID file on exit
-    #[cfg(target_family = "unix")]
-    if let Some(guard) = _pid_guard {
-        if let Err(e) = guard.clean() {
-            tracing::warn!("Failed to clean PID file: {}", e);
-        }
-    }
 
     info!("Gateway shutting down");
     Ok(())

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -2,6 +2,9 @@
 //!
 //! Wires together: bus, channels, agent loop, session manager,
 //! provider registry, tool registry, heartbeat, and API server.
+//!
+//! Supports both foreground and daemon modes. When `config.daemon.enabled`
+//! is true, the process daemonizes before starting components.
 
 use std::sync::Arc;
 
@@ -19,7 +22,21 @@ use nanobot_tools::builtins;
 use tracing::info;
 
 /// Run the gateway — starts all components and connects them via the bus.
+///
+/// When `config.daemon.enabled` is true, the process will daemonize (double-fork)
+/// before starting. In daemon mode, signal handling uses SIGTERM/SIGINT/SIGHUP
+/// instead of just Ctrl+C.
 pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
+    // Daemonize if configured (PID file is created in the daemon command handler
+    // for explicit `daemon start`, or here for config-driven daemon mode)
+    #[cfg(target_family = "unix")]
+    let _pid_guard = if config.daemon.enabled {
+        let pid = nanobot_daemon::pid_file::PidFile::create(&config.daemon.pid_file)?;
+        Some(pid)
+    } else {
+        None
+    };
+
     info!("Starting nanobot gateway...");
 
     // ── Shared bus ────────────────────────────────────────────
@@ -111,21 +128,21 @@ pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
     );
 
     // ── Spawn background tasks ────────────────────────────────
-    let agent_handle = tokio::spawn(async move {
+    let _agent_handle = tokio::spawn(async move {
         if let Err(e) = agent_loop.run().await {
             tracing::error!("Agent loop error: {}", e);
         }
     });
 
     let outbound_cm = channel_manager.clone();
-    let outbound_handle = tokio::spawn(async move {
+    let _outbound_handle = tokio::spawn(async move {
         outbound_cm.run_outbound_consumer().await;
     });
 
     // ── Typing indicator lifecycle ──────────────────────────────
     let typing_cm = channel_manager.clone();
     let mut typing_event_rx = bus.subscribe_events();
-    let typing_handle = tokio::spawn(async move {
+    let _typing_handle = tokio::spawn(async move {
         loop {
             match typing_event_rx.recv().await {
                 Ok(AgentEvent::Started { session_key }) => {
@@ -145,7 +162,7 @@ pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
     });
 
     let heartbeat_enabled = config.heartbeat.enabled;
-    let heartbeat_handle = tokio::spawn(async move {
+    let _heartbeat_handle = tokio::spawn(async move {
         if heartbeat_enabled {
             if let Err(e) = heartbeat.run().await {
                 tracing::error!("Heartbeat error: {}", e);
@@ -156,7 +173,7 @@ pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
         }
     });
 
-    let api_handle = tokio::spawn(async move {
+    let _api_handle = tokio::spawn(async move {
         if let Err(e) = api_server.run().await {
             tracing::error!("API server error: {}", e);
         }
@@ -166,30 +183,65 @@ pub async fn run(config: Config, channels: Vec<String>) -> Result<()> {
     info!("Press Ctrl+C to stop");
 
     // ── Wait for shutdown signal ──────────────────────────────
-    tokio::select! {
-        _ = tokio::signal::ctrl_c() => {
-            info!("Received shutdown signal");
+    #[cfg(target_family = "unix")]
+    {
+        let grace_period = config.daemon.grace_period_secs;
+        loop {
+            let sig = nanobot_daemon::signal::wait_for_signal().await;
+            match sig {
+                nanobot_daemon::signal::ShutdownSignal::Graceful => {
+                    info!("Received graceful shutdown signal (SIGTERM)");
+                    break;
+                }
+                nanobot_daemon::signal::ShutdownSignal::Fast => {
+                    info!("Received fast shutdown signal (SIGINT)");
+                    break;
+                }
+                nanobot_daemon::signal::ShutdownSignal::Reload => {
+                    info!("Received SIGHUP (log rotation placeholder — not yet implemented)");
+                    // Keep running; future sprint will add config reload
+                    continue;
+                }
+            }
         }
-        _ = agent_handle => {
-            info!("Agent loop exited");
-        }
-        _ = outbound_handle => {
-            info!("Outbound consumer exited");
-        }
-        _ = heartbeat_handle => {
-            info!("Heartbeat exited");
-        }
-        _ = api_handle => {
-            info!("API server exited");
-        }
-        _ = typing_handle => {
-            info!("Typing handler exited");
+        let _ = grace_period; // Used by daemon stop's send_sigterm_and_wait
+    }
+
+    #[cfg(not(target_family = "unix"))]
+    {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                info!("Received shutdown signal");
+            }
+            _ = _agent_handle => {
+                info!("Agent loop exited");
+            }
+            _ = _outbound_handle => {
+                info!("Outbound consumer exited");
+            }
+            _ = _heartbeat_handle => {
+                info!("Heartbeat exited");
+            }
+            _ = _api_handle => {
+                info!("API server exited");
+            }
+            _ = _typing_handle => {
+                info!("Typing handler exited");
+            }
         }
     }
 
     // ── Graceful shutdown ─────────────────────────────────────
     info!("Stopping all channels...");
     channel_manager.stop_all().await;
+
+    // Clean up PID file on exit
+    #[cfg(target_family = "unix")]
+    if let Some(guard) = _pid_guard {
+        if let Err(e) = guard.clean() {
+            tracing::warn!("Failed to clean PID file: {}", e);
+        }
+    }
 
     info!("Gateway shutting down");
     Ok(())

--- a/src/commands/health.rs
+++ b/src/commands/health.rs
@@ -33,7 +33,11 @@ pub fn check(_config: &Config) -> Result<()> {
         println!(
             "Last snapshot ({}): {}",
             snapshot.timestamp.format("%Y-%m-%d %H:%M:%S"),
-            if snapshot.healthy { "HEALTHY" } else { "UNHEALTHY" }
+            if snapshot.healthy {
+                "HEALTHY"
+            } else {
+                "UNHEALTHY"
+            }
         );
 
         if !snapshot.checks.is_empty() {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@
 pub mod agent;
 pub mod config;
 pub mod cron;
+pub mod daemon;
 pub mod gateway;
 pub mod health;
 pub mod heartbeat;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -42,7 +42,7 @@ pub async fn run(config: Config, port_override: Option<u16>) -> Result<()> {
         tool_registry.clone(),
     );
 
-    let agent_handle = tokio::spawn(async move {
+    let _agent_handle = tokio::spawn(async move {
         if let Err(e) = agent_loop.run().await {
             tracing::error!("Agent loop error: {}", e);
         }
@@ -57,7 +57,7 @@ pub async fn run(config: Config, port_override: Option<u16>) -> Result<()> {
         tool_registry,
         port_override,
     );
-    let api_handle = tokio::spawn(async move {
+    let _api_handle = tokio::spawn(async move {
         if let Err(e) = server.run().await {
             tracing::error!("API server error: {}", e);
         }
@@ -65,15 +65,40 @@ pub async fn run(config: Config, port_override: Option<u16>) -> Result<()> {
 
     info!("API server running on port {}", effective_port);
 
-    tokio::select! {
-        _ = tokio::signal::ctrl_c() => {
-            info!("Received shutdown signal");
+    // ── Wait for shutdown signal ──────────────────────────────
+    #[cfg(target_family = "unix")]
+    {
+        loop {
+            let sig = nanobot_daemon::signal::wait_for_signal().await;
+            match sig {
+                nanobot_daemon::signal::ShutdownSignal::Graceful => {
+                    info!("Received graceful shutdown signal (SIGTERM)");
+                    break;
+                }
+                nanobot_daemon::signal::ShutdownSignal::Fast => {
+                    info!("Received fast shutdown signal (SIGINT)");
+                    break;
+                }
+                nanobot_daemon::signal::ShutdownSignal::Reload => {
+                    info!("Received SIGHUP (log rotation placeholder)");
+                    continue;
+                }
+            }
         }
-        _ = agent_handle => {
-            info!("Agent loop exited");
-        }
-        _ = api_handle => {
-            info!("API server exited");
+    }
+
+    #[cfg(not(target_family = "unix"))]
+    {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                info!("Received shutdown signal");
+            }
+            _ = _agent_handle => {
+                info!("Agent loop exited");
+            }
+            _ = _api_handle => {
+                info!("API server exited");
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,18 @@ async fn main() -> Result<()> {
                 DaemonSubcommand::Restart => commands::daemon::DaemonAction::Restart,
                 DaemonSubcommand::Status => commands::daemon::DaemonAction::Status,
             };
-            commands::daemon::handle_daemon_command(action, config)?;
+            match action {
+                commands::daemon::DaemonAction::Start => {
+                    // daemonize, create PID file, then start gateway
+                    let _pid_file = commands::daemon::handle_daemon_command(action, config.clone())?
+                        .expect("Start always returns Some(PidFile)");
+                    // After daemonize, start the gateway in the daemon process
+                    commands::gateway::run(config, vec![]).await?;
+                }
+                _ => {
+                    commands::daemon::handle_daemon_command(action, config)?;
+                }
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,12 @@ enum Commands {
 
     /// Show current configuration and status.
     Status,
+
+    /// Daemon management commands (Unix only).
+    Daemon {
+        #[command(subcommand)]
+        subcommand: DaemonSubcommand,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,12 +130,24 @@ enum DaemonSubcommand {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Initialize tracing
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&cli.log_level)),
-        )
-        .init();
+    // For daemon start, skip terminal tracing init — the daemon module
+    // will set up file-based logging after daemonize. For all other
+    // commands (including daemon stop/status), use terminal tracing.
+    let is_daemon_start = matches!(
+        &cli.command,
+        Commands::Daemon {
+            subcommand: DaemonSubcommand::Start
+        }
+    );
+
+    if !is_daemon_start {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| EnvFilter::new(&cli.log_level)),
+            )
+            .init();
+    }
 
     // Load configuration
     let config = nanobot_config::load_config(cli.config.as_deref())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,13 +126,12 @@ enum DaemonSubcommand {
     Status,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // For daemon start, skip terminal tracing init — the daemon module
-    // will set up file-based logging after daemonize. For all other
-    // commands (including daemon stop/status), use terminal tracing.
+    // For daemon start, we must fork BEFORE starting the tokio runtime.
+    // fork() only copies the calling thread — tokio worker threads are lost.
+    // All other commands need the runtime, so we defer its creation.
     let is_daemon_start = matches!(
         &cli.command,
         Commands::Daemon {
@@ -154,16 +153,20 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Agent { message } => {
-            commands::agent::run(config, message).await?;
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(commands::agent::run(config, message))?;
         }
         Commands::Gateway { channels } => {
-            commands::gateway::run(config, channels).await?;
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(commands::gateway::run(config, channels))?;
         }
         Commands::Serve { port } => {
-            commands::serve::run(config, port).await?;
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(commands::serve::run(config, port))?;
         }
         Commands::Heartbeat => {
-            commands::heartbeat::run(config).await?;
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(commands::heartbeat::run(config))?;
         }
         Commands::Health => {
             commands::health::check(&config)?;
@@ -199,11 +202,12 @@ async fn main() -> Result<()> {
             };
             match action {
                 commands::daemon::DaemonAction::Start => {
-                    // daemonize, create PID file, then start gateway
+                    // Fork happens HERE — before any tokio runtime exists.
                     let _pid_file = commands::daemon::handle_daemon_command(action, config.clone())?
                         .expect("Start always returns Some(PidFile)");
-                    // After daemonize, start the gateway in the daemon process
-                    commands::gateway::run(config, vec![]).await?;
+                    // Now start tokio runtime in the daemon process
+                    let rt = tokio::runtime::Runtime::new()?;
+                    rt.block_on(commands::gateway::run(config, vec![]))?;
                 }
                 _ => {
                     commands::daemon::handle_daemon_command(action, config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,11 @@ fn main() -> Result<()> {
                     // Fork happens HERE — before any tokio runtime exists.
                     let handles = commands::daemon::handle_daemon_command(action, config.clone())?
                         .expect("Start always returns Some(DaemonHandles)");
+
+                    // Install SIGHUP ignore handler before tokio runtime — closes the
+                    // window where default SIGHUP would kill the daemon during startup
+                    nanobot_daemon::signal::install_early_sighup_handler();
+
                     // Now start tokio runtime in the daemon process
                     let rt = tokio::runtime::Runtime::new()?;
                     let result = rt.block_on(commands::gateway::run(config, vec![]));

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,11 +203,20 @@ fn main() -> Result<()> {
             match action {
                 commands::daemon::DaemonAction::Start => {
                     // Fork happens HERE — before any tokio runtime exists.
-                    let _pid_file = commands::daemon::handle_daemon_command(action, config.clone())?
-                        .expect("Start always returns Some(PidFile)");
+                    let handles = commands::daemon::handle_daemon_command(action, config.clone())?
+                        .expect("Start always returns Some(DaemonHandles)");
                     // Now start tokio runtime in the daemon process
                     let rt = tokio::runtime::Runtime::new()?;
-                    rt.block_on(commands::gateway::run(config, vec![]))?;
+                    let result = rt.block_on(commands::gateway::run(config, vec![]));
+
+                    // Drop log_guard first to flush remaining log lines,
+                    // then pid_file releases the flock and cleans up.
+                    drop(handles.log_guard);
+                    if let Err(e) = handles.pid_file.clean() {
+                        eprintln!("Failed to clean PID file: {e}");
+                    }
+
+                    result?;
                 }
                 _ => {
                     commands::daemon::handle_daemon_command(action, config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,21 @@ enum ConfigSubcommand {
     },
 }
 
+#[derive(Subcommand)]
+enum DaemonSubcommand {
+    /// Start the daemon (daemonize then run gateway).
+    Start,
+
+    /// Stop the running daemon.
+    Stop,
+
+    /// Restart the daemon (stop + start).
+    Restart,
+
+    /// Check daemon status.
+    Status,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -162,6 +177,15 @@ async fn main() -> Result<()> {
         }
         Commands::Status => {
             commands::status::run(&config)?;
+        }
+        Commands::Daemon { subcommand } => {
+            let action = match subcommand {
+                DaemonSubcommand::Start => commands::daemon::DaemonAction::Start,
+                DaemonSubcommand::Stop => commands::daemon::DaemonAction::Stop,
+                DaemonSubcommand::Restart => commands::daemon::DaemonAction::Restart,
+                DaemonSubcommand::Status => commands::daemon::DaemonAction::Status,
+            };
+            commands::daemon::handle_daemon_command(action, config)?;
         }
     }
 

--- a/tests/e2e_integration_test.rs
+++ b/tests/e2e_integration_test.rs
@@ -13,9 +13,7 @@ use nanobot_bus::MessageBus;
 use nanobot_config::Config;
 use nanobot_core::{FunctionCall, MessageType, Platform, ToolCall, Usage};
 use nanobot_providers::base::{BoxStream, CompletionChunk};
-use nanobot_providers::{
-    CompletionRequest, CompletionResponse, LlmProvider, ProviderRegistry,
-};
+use nanobot_providers::{CompletionRequest, CompletionResponse, LlmProvider, ProviderRegistry};
 use nanobot_session::SessionManager;
 use nanobot_tools::{Tool, ToolError, ToolRegistry};
 use serde_json::Value;
@@ -67,17 +65,13 @@ impl LlmProvider for MockProvider {
 
     async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         let idx = self.call_count.fetch_add(1, Ordering::SeqCst) as usize;
-        let resp = self
-            .responses
-            .get(idx)
-            .cloned()
-            .unwrap_or_else(|| {
-                panic!(
-                    "MockProvider called {} times but only has {} responses",
-                    idx + 1,
-                    self.responses.len()
-                )
-            });
+        let resp = self.responses.get(idx).cloned().unwrap_or_else(|| {
+            panic!(
+                "MockProvider called {} times but only has {} responses",
+                idx + 1,
+                self.responses.len()
+            )
+        });
         Ok(resp)
     }
 
@@ -157,7 +151,10 @@ impl Tool for WeatherTool {
         })
     }
     async fn execute(&self, args: Value) -> Result<String, ToolError> {
-        let city = args.get("city").and_then(|v| v.as_str()).unwrap_or("Unknown");
+        let city = args
+            .get("city")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown");
         Ok(format!("Weather in {}: Sunny, 22C", city))
     }
 }
@@ -208,7 +205,8 @@ async fn test_e2e_simple_message_flow() {
 
     let tmp = tempfile::tempdir().unwrap();
     let session_mgr = SessionManager::new(tmp.path().to_path_buf()).unwrap();
-    let provider_reg = make_provider_registry(MockProvider::simple("Hello! I am a deterministic mock."));
+    let provider_reg =
+        make_provider_registry(MockProvider::simple("Hello! I am a deterministic mock."));
     let tool_reg = ToolRegistry::new();
 
     let agent_loop = AgentLoop::new(config, bus.clone(), session_mgr, provider_reg, tool_reg);
@@ -218,7 +216,9 @@ async fn test_e2e_simple_message_flow() {
     let agent_handle = tokio::spawn(async move { agent_loop.run().await.unwrap() });
 
     // Send inbound message
-    bus.publish_inbound(make_inbound("Hi there!")).await.unwrap();
+    bus.publish_inbound(make_inbound("Hi there!"))
+        .await
+        .unwrap();
 
     // Receive outbound
     let outbound = timeout(TEST_TIMEOUT, outbound_rx.recv())
@@ -317,7 +317,11 @@ async fn test_e2e_tool_call_flow() {
                 assert_eq!(tool_name, "weather");
                 saw_tool_call = true;
             }
-            Ok(Ok(AgentEvent::Completed { tool_calls, iterations, .. })) => {
+            Ok(Ok(AgentEvent::Completed {
+                tool_calls,
+                iterations,
+                ..
+            })) => {
                 assert_eq!(tool_calls, 1);
                 assert_eq!(iterations, 2);
                 saw_completed = true;

--- a/tests/full_integration_test.rs
+++ b/tests/full_integration_test.rs
@@ -71,7 +71,9 @@ impl LlmProvider for MockProvider {
     }
 
     async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
-        let count = self.call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let count = self
+            .call_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         // First call: tool call (if configured)
         if count == 0 {
@@ -296,8 +298,7 @@ async fn test_full_message_pipeline() {
     let bus = MessageBus::new();
 
     // Session manager
-    let session_manager =
-        SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
+    let session_manager = SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
 
     // Provider registry with mock
     let mut provider_registry = nanobot_providers::ProviderRegistry::new();
@@ -351,24 +352,34 @@ async fn test_full_message_pipeline() {
     bus.publish_inbound(inbound).await.unwrap();
 
     // Collect events until Completed
-    let all_events = collect_events_until(&mut event_rx, |e| {
-        matches!(e, AgentEvent::Completed { .. })
-    }, 3000).await;
+    let all_events = collect_events_until(
+        &mut event_rx,
+        |e| matches!(e, AgentEvent::Completed { .. }),
+        3000,
+    )
+    .await;
 
-    let has_completed = all_events.iter().any(|e| matches!(e, AgentEvent::Completed { .. }));
+    let has_completed = all_events
+        .iter()
+        .any(|e| matches!(e, AgentEvent::Completed { .. }));
     assert!(has_completed, "Expected a Completed event");
 
     // Verify the outbound message reached the mock channel
     let recorded = sent.lock().unwrap().clone();
-    assert_eq!(recorded.len(), 1, "Expected 1 outbound message, got {:?}", recorded);
+    assert_eq!(
+        recorded.len(),
+        1,
+        "Expected 1 outbound message, got {:?}",
+        recorded
+    );
     assert_eq!(recorded[0].0, "chat_42");
     assert_eq!(recorded[0].1, "The answer is 42.");
     assert_eq!(recorded[0].2, Some("msg_1".to_string())); // reply_to
 
     // Verify events: Started → Completed
-    let has_started = all_events.iter().any(|e| {
-        matches!(e, AgentEvent::Started { session_key } if session_key.contains("chat_42"))
-    });
+    let has_started = all_events.iter().any(
+        |e| matches!(e, AgentEvent::Started { session_key } if session_key.contains("chat_42")),
+    );
     assert!(has_started, "Expected a Started event for chat_42");
 
     // Cleanup
@@ -388,8 +399,7 @@ async fn test_multi_turn_conversation() {
     let config = make_test_config();
     let bus = MessageBus::new();
 
-    let session_manager =
-        SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
+    let session_manager = SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
 
     let mut provider_registry = nanobot_providers::ProviderRegistry::new();
     provider_registry.register("mock", MockProvider::new("Response."));
@@ -434,18 +444,34 @@ async fn test_multi_turn_conversation() {
     // Turn 1
     let msg1 = make_inbound("Hello", "chat_multi");
     bus.publish_inbound(msg1).await.unwrap();
-    let events1 = collect_events_until(&mut event_rx, |e| {
-        matches!(e, AgentEvent::Completed { .. })
-    }, 3000).await;
-    assert!(events1.iter().any(|e| matches!(e, AgentEvent::Completed { .. })), "Turn 1 should complete");
+    let events1 = collect_events_until(
+        &mut event_rx,
+        |e| matches!(e, AgentEvent::Completed { .. }),
+        3000,
+    )
+    .await;
+    assert!(
+        events1
+            .iter()
+            .any(|e| matches!(e, AgentEvent::Completed { .. })),
+        "Turn 1 should complete"
+    );
 
     // Turn 2
     let msg2 = make_inbound("Follow up", "chat_multi");
     bus.publish_inbound(msg2).await.unwrap();
-    let events2 = collect_events_until(&mut event_rx, |e| {
-        matches!(e, AgentEvent::Completed { .. })
-    }, 3000).await;
-    assert!(events2.iter().any(|e| matches!(e, AgentEvent::Completed { .. })), "Turn 2 should complete");
+    let events2 = collect_events_until(
+        &mut event_rx,
+        |e| matches!(e, AgentEvent::Completed { .. }),
+        3000,
+    )
+    .await;
+    assert!(
+        events2
+            .iter()
+            .any(|e| matches!(e, AgentEvent::Completed { .. })),
+        "Turn 2 should complete"
+    );
 
     // Both replies should be recorded
     let recorded = sent.lock().unwrap().clone();
@@ -456,7 +482,10 @@ async fn test_multi_turn_conversation() {
     // Session should exist and have entries
     let keys = session_manager.active_session_keys();
     assert_eq!(keys.len(), 1, "Should have exactly 1 session");
-    assert!(keys[0].contains("chat_multi"), "Session key should contain chat_multi");
+    assert!(
+        keys[0].contains("chat_multi"),
+        "Session key should contain chat_multi"
+    );
 
     outbound_handle.abort();
     agent_handle.abort();
@@ -476,8 +505,7 @@ async fn test_tool_call_flow() {
     let config = make_test_config();
     let bus = MessageBus::new();
 
-    let session_manager =
-        SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
+    let session_manager = SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
 
     // Mock provider: first call returns tool_call, second returns text
     let mut provider_registry = nanobot_providers::ProviderRegistry::new();
@@ -533,23 +561,35 @@ async fn test_tool_call_flow() {
     bus.publish_inbound(msg).await.unwrap();
 
     // Wait for completion, collecting all events
-    let all_events = collect_events_until(&mut event_rx, |e| {
-        matches!(e, AgentEvent::Completed { .. })
-    }, 5000).await;
-    assert!(all_events.iter().any(|e| matches!(e, AgentEvent::Completed { .. })),
-        "Expected completion after tool call flow");
+    let all_events = collect_events_until(
+        &mut event_rx,
+        |e| matches!(e, AgentEvent::Completed { .. }),
+        5000,
+    )
+    .await;
+    assert!(
+        all_events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::Completed { .. })),
+        "Expected completion after tool call flow"
+    );
 
     // Verify final outbound message
     let recorded = sent.lock().unwrap().clone();
-    assert_eq!(recorded.len(), 1, "Expected 1 final outbound, got {:?}", recorded);
+    assert_eq!(
+        recorded.len(),
+        1,
+        "Expected 1 final outbound, got {:?}",
+        recorded
+    );
     assert_eq!(recorded[0].0, "chat_tool");
     // The mock provider returns "Tool executed successfully." on the 2nd call
     assert_eq!(recorded[0].1, "Tool executed successfully.");
 
     // Verify we got a ToolCall event
-    let has_tool_call = all_events.iter().any(|e| {
-        matches!(e, AgentEvent::ToolCall { tool_name, .. } if tool_name == "shell")
-    });
+    let has_tool_call = all_events
+        .iter()
+        .any(|e| matches!(e, AgentEvent::ToolCall { tool_name, .. } if tool_name == "shell"));
     assert!(has_tool_call, "Expected a ToolCall event for 'shell'");
 
     outbound_handle.abort();
@@ -567,11 +607,8 @@ async fn test_cron_fires_event() {
     let bus = MessageBus::new();
     let mut event_rx = bus.subscribe_events();
 
-    let cron_service = nanobot_cron::CronService::with_bus(
-        tmp_dir.path().to_path_buf(),
-        bus,
-    )
-    .unwrap();
+    let cron_service =
+        nanobot_cron::CronService::with_bus(tmp_dir.path().to_path_buf(), bus).unwrap();
 
     // Add a one-shot "at" job that fires immediately (past timestamp)
     let schedule = nanobot_cron::CronSchedule {
@@ -587,7 +624,9 @@ async fn test_cron_fires_event() {
         chat_id: None,
         deliver: false,
     };
-    let job = cron_service.add_job(schedule, payload, Some("backup_job".to_string())).unwrap();
+    let job = cron_service
+        .add_job(schedule, payload, Some("backup_job".to_string()))
+        .unwrap();
 
     // Tick to fire the job
     let fired = cron_service.tick();
@@ -595,14 +634,23 @@ async fn test_cron_fires_event() {
     assert_eq!(fired[0].id, job.id);
 
     // Verify event on bus
-    let events = collect_events_until(&mut event_rx, |e| {
-        matches!(e, AgentEvent::CronFired { .. })
-    }, 1000).await;
+    let events = collect_events_until(
+        &mut event_rx,
+        |e| matches!(e, AgentEvent::CronFired { .. }),
+        1000,
+    )
+    .await;
 
-    let cron_event = events.iter().find(|e| matches!(e, AgentEvent::CronFired { .. }));
+    let cron_event = events
+        .iter()
+        .find(|e| matches!(e, AgentEvent::CronFired { .. }));
     assert!(cron_event.is_some(), "Expected CronFired event on bus");
     match cron_event.unwrap() {
-        AgentEvent::CronFired { job_id, job_name, message } => {
+        AgentEvent::CronFired {
+            job_id,
+            job_name,
+            message,
+        } => {
             assert_eq!(*job_id, job.id);
             assert_eq!(job_name.as_deref(), Some("backup_job"));
             assert_eq!(message, "Run daily backup");
@@ -650,14 +698,23 @@ async fn test_heartbeat_health_check() {
     assert!(matches!(snapshot.checks[0].status, CheckStatus::Unhealthy));
 
     // Verify event emitted
-    let events = collect_events_until(&mut event_rx, |e| {
-        matches!(e, AgentEvent::HeartbeatCheck { .. })
-    }, 1000).await;
+    let events = collect_events_until(
+        &mut event_rx,
+        |e| matches!(e, AgentEvent::HeartbeatCheck { .. }),
+        1000,
+    )
+    .await;
 
-    let hb_event = events.iter().find(|e| matches!(e, AgentEvent::HeartbeatCheck { .. }));
+    let hb_event = events
+        .iter()
+        .find(|e| matches!(e, AgentEvent::HeartbeatCheck { .. }));
     assert!(hb_event.is_some(), "Expected HeartbeatCheck event");
     match hb_event.unwrap() {
-        AgentEvent::HeartbeatCheck { healthy, checks_total, checks_failed } => {
+        AgentEvent::HeartbeatCheck {
+            healthy,
+            checks_total,
+            checks_failed,
+        } => {
             assert!(!healthy);
             assert_eq!(*checks_total, 1);
             assert_eq!(*checks_failed, 1);
@@ -679,7 +736,9 @@ async fn test_heartbeat_mixed_checks() {
     struct HealthyCheck;
     #[async_trait]
     impl HealthCheck for HealthyCheck {
-        fn component_name(&self) -> &str { "healthy_svc" }
+        fn component_name(&self) -> &str {
+            "healthy_svc"
+        }
         async fn report_health(&self) -> HealthCheckResult {
             HealthCheckResult {
                 component: "healthy_svc".to_string(),
@@ -693,7 +752,9 @@ async fn test_heartbeat_mixed_checks() {
     struct UnhealthyCheck;
     #[async_trait]
     impl HealthCheck for UnhealthyCheck {
-        fn component_name(&self) -> &str { "broken_svc" }
+        fn component_name(&self) -> &str {
+            "broken_svc"
+        }
         async fn report_health(&self) -> HealthCheckResult {
             HealthCheckResult {
                 component: "broken_svc".to_string(),
@@ -712,13 +773,23 @@ async fn test_heartbeat_mixed_checks() {
     assert!(!snapshot.healthy, "One unhealthy → overall unhealthy");
     assert_eq!(snapshot.checks.len(), 2);
 
-    let events = collect_events_until(&mut event_rx, |e| {
-        matches!(e, AgentEvent::HeartbeatCheck { .. })
-    }, 1000).await;
+    let events = collect_events_until(
+        &mut event_rx,
+        |e| matches!(e, AgentEvent::HeartbeatCheck { .. }),
+        1000,
+    )
+    .await;
 
-    let hb_event = events.iter().find(|e| matches!(e, AgentEvent::HeartbeatCheck { .. }));
+    let hb_event = events
+        .iter()
+        .find(|e| matches!(e, AgentEvent::HeartbeatCheck { .. }));
     assert!(hb_event.is_some());
-    if let AgentEvent::HeartbeatCheck { checks_total, checks_failed, .. } = hb_event.unwrap() {
+    if let AgentEvent::HeartbeatCheck {
+        checks_total,
+        checks_failed,
+        ..
+    } = hb_event.unwrap()
+    {
         assert_eq!(*checks_total, 2);
         assert_eq!(*checks_failed, 1);
     }
@@ -731,8 +802,7 @@ async fn test_event_ordering_started_before_completed() {
     let config = make_test_config();
     let bus = MessageBus::new();
 
-    let session_manager =
-        SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
+    let session_manager = SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
 
     let mut provider_registry = nanobot_providers::ProviderRegistry::new();
     provider_registry.register("mock", MockProvider::new("Hi."));
@@ -778,13 +848,20 @@ async fn test_event_ordering_started_before_completed() {
     bus.publish_inbound(msg).await.unwrap();
 
     // Collect events until Completed
-    let events = collect_events_until(&mut event_rx, |e| {
-        matches!(e, AgentEvent::Completed { .. })
-    }, 3000).await;
+    let events = collect_events_until(
+        &mut event_rx,
+        |e| matches!(e, AgentEvent::Completed { .. }),
+        3000,
+    )
+    .await;
 
     // Find positions
-    let started_pos = events.iter().position(|e| matches!(e, AgentEvent::Started { .. }));
-    let completed_pos = events.iter().position(|e| matches!(e, AgentEvent::Completed { .. }));
+    let started_pos = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::Started { .. }));
+    let completed_pos = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::Completed { .. }));
 
     assert!(started_pos.is_some(), "Should have a Started event");
     assert!(completed_pos.is_some(), "Should have a Completed event");
@@ -805,8 +882,7 @@ async fn test_multi_platform_routing() {
     let config = make_test_config();
     let bus = MessageBus::new();
 
-    let session_manager =
-        SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
+    let session_manager = SessionManager::new(tmp_dir.path().to_path_buf()).unwrap();
 
     let mut provider_registry = nanobot_providers::ProviderRegistry::new();
     provider_registry.register("mock", MockProvider::new("Multi-platform reply."));
@@ -879,25 +955,35 @@ async fn test_multi_platform_routing() {
     bus.publish_inbound(dc_msg).await.unwrap();
 
     // Wait for both completions — collect until we see 2 Completed events
-    let all_events = collect_events_until(&mut event_rx, |e| {
-        // Stop after seeing the second Completed event — use a counter workaround
-        matches!(e, AgentEvent::Completed { .. })
-    }, 5000).await;
-    let completed: Vec<_> = all_events.iter()
+    let all_events = collect_events_until(
+        &mut event_rx,
+        |e| {
+            // Stop after seeing the second Completed event — use a counter workaround
+            matches!(e, AgentEvent::Completed { .. })
+        },
+        5000,
+    )
+    .await;
+    let completed: Vec<_> = all_events
+        .iter()
         .filter(|e| matches!(e, AgentEvent::Completed { .. }))
         .collect();
     // If we only got one, wait for the second
     let final_events = if completed.len() < 2 {
-        let more = collect_events_until(&mut event_rx, |e| {
-            matches!(e, AgentEvent::Completed { .. })
-        }, 5000).await;
+        let more = collect_events_until(
+            &mut event_rx,
+            |e| matches!(e, AgentEvent::Completed { .. }),
+            5000,
+        )
+        .await;
         let mut combined = all_events;
         combined.extend(more);
         combined
     } else {
         all_events
     };
-    let completed_count = final_events.iter()
+    let completed_count = final_events
+        .iter()
         .filter(|e| matches!(e, AgentEvent::Completed { .. }))
         .count();
     assert_eq!(completed_count, 2, "Expected 2 Completed events");

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -10,9 +10,7 @@ use nanobot_bus::events::AgentEvent;
 use nanobot_bus::MessageBus;
 use nanobot_config::Config;
 use nanobot_core::{FunctionCall, MessageType, Platform, ToolCall, Usage};
-use nanobot_cron::{
-    CronPayload, CronSchedule, CronService, JobState, ScheduleKind,
-};
+use nanobot_cron::{CronPayload, CronSchedule, CronService, JobState, ScheduleKind};
 use nanobot_providers::base::{BoxStream, CompletionChunk};
 use nanobot_providers::{CompletionRequest, CompletionResponse, LlmProvider, ProviderRegistry};
 use nanobot_session::SessionManager;
@@ -86,10 +84,13 @@ impl LlmProvider for MockProvider {
 
     async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         let idx = self.call_count.fetch_add(1, Ordering::SeqCst) as usize;
-        self.responses
-            .get(idx)
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("MockProvider exhausted: call {} but only {} responses", idx + 1, self.responses.len()))
+        self.responses.get(idx).cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "MockProvider exhausted: call {} but only {} responses",
+                idx + 1,
+                self.responses.len()
+            )
+        })
     }
 
     async fn complete_stream(&self, request: CompletionRequest) -> anyhow::Result<BoxStream> {
@@ -283,9 +284,7 @@ async fn test_pipeline_startup_flow() {
     });
 
     // Send a message to confirm the full pipeline is live
-    bus.publish_inbound(make_inbound("ping"))
-        .await
-        .unwrap();
+    bus.publish_inbound(make_inbound("ping")).await.unwrap();
 
     let outbound = timeout(TEST_TIMEOUT, outbound_rx.recv())
         .await
@@ -387,12 +386,20 @@ async fn test_pipeline_tool_call_conversation_cycle() {
     for _ in 0..15 {
         match timeout(Duration::from_secs(2), event_rx.recv()).await {
             Ok(Ok(AgentEvent::Started { .. })) => saw_started = true,
-            Ok(Ok(AgentEvent::ToolCall { tool_name, iteration, .. })) => {
+            Ok(Ok(AgentEvent::ToolCall {
+                tool_name,
+                iteration,
+                ..
+            })) => {
                 assert_eq!(tool_name, "echo");
                 assert_eq!(iteration, 1);
                 saw_tool_call = true;
             }
-            Ok(Ok(AgentEvent::Completed { tool_calls, iterations, .. })) => {
+            Ok(Ok(AgentEvent::Completed {
+                tool_calls,
+                iterations,
+                ..
+            })) => {
                 assert_eq!(tool_calls, 1);
                 assert_eq!(iterations, 2);
                 saw_completed = true;
@@ -441,9 +448,7 @@ async fn test_pipeline_multi_turn_context_persistence() {
     });
 
     // Turn 1
-    bus.publish_inbound(make_inbound("Hi"))
-        .await
-        .unwrap();
+    bus.publish_inbound(make_inbound("Hi")).await.unwrap();
     let out1 = timeout(TEST_TIMEOUT, outbound_rx.recv())
         .await
         .expect("Timeout on turn 1")
@@ -461,9 +466,7 @@ async fn test_pipeline_multi_turn_context_persistence() {
     assert_eq!(out2.content, "Turn 2: I remember our conversation.");
 
     // Turn 3
-    bus.publish_inbound(make_inbound("Bye"))
-        .await
-        .unwrap();
+    bus.publish_inbound(make_inbound("Bye")).await.unwrap();
     let out3 = timeout(TEST_TIMEOUT, outbound_rx.recv())
         .await
         .expect("Timeout on turn 3")
@@ -482,7 +485,11 @@ async fn test_pipeline_multi_turn_context_persistence() {
     );
 
     // Verify message ordering and roles
-    let roles: Vec<String> = session.messages.iter().map(|m| format!("{:?}", m.role)).collect();
+    let roles: Vec<String> = session
+        .messages
+        .iter()
+        .map(|m| format!("{:?}", m.role))
+        .collect();
     // Pattern should alternate: User, Assistant, User, Assistant, User, Assistant
     assert!(
         roles.windows(2).all(|w| w[0] != w[1]),
@@ -551,8 +558,12 @@ async fn test_pipeline_multi_turn_with_tool_calls() {
     }
     #[async_trait]
     impl Tool for CountingTool {
-        fn name(&self) -> &str { "counter" }
-        fn description(&self) -> &str { "Count" }
+        fn name(&self) -> &str {
+            "counter"
+        }
+        fn description(&self) -> &str {
+            "Count"
+        }
         fn parameters_schema(&self) -> Value {
             serde_json::json!({"type": "object", "properties": {}})
         }
@@ -563,7 +574,9 @@ async fn test_pipeline_multi_turn_with_tool_calls() {
     }
 
     let tool_reg = ToolRegistry::new();
-    tool_reg.register(CountingTool { counter: counter_clone });
+    tool_reg.register(CountingTool {
+        counter: counter_clone,
+    });
 
     let agent_loop = AgentLoop::new(config, bus.clone(), session_mgr, provider_reg, tool_reg);
     let mut outbound_rx = bus.consume_outbound().await.unwrap();
@@ -575,19 +588,25 @@ async fn test_pipeline_multi_turn_with_tool_calls() {
     // Turn 1
     bus.publish_inbound(make_inbound("Hello")).await.unwrap();
     let out1 = timeout(TEST_TIMEOUT, outbound_rx.recv())
-        .await.expect("T1 timeout").expect("T1 closed");
+        .await
+        .expect("T1 timeout")
+        .expect("T1 closed");
     assert_eq!(out1.content, "Welcome!");
 
     // Turn 2 — triggers counter tool
     bus.publish_inbound(make_inbound("Count")).await.unwrap();
     let out2 = timeout(TEST_TIMEOUT, outbound_rx.recv())
-        .await.expect("T2 timeout").expect("T2 closed");
+        .await
+        .expect("T2 timeout")
+        .expect("T2 closed");
     assert_eq!(out2.content, "Counter is at 1.");
 
     // Turn 3
     bus.publish_inbound(make_inbound("Done")).await.unwrap();
     let out3 = timeout(TEST_TIMEOUT, outbound_rx.recv())
-        .await.expect("T3 timeout").expect("T3 closed");
+        .await
+        .expect("T3 timeout")
+        .expect("T3 closed");
     assert_eq!(out3.content, "Done!");
 
     // Verify counter was called exactly once
@@ -604,11 +623,7 @@ async fn test_pipeline_multi_turn_with_tool_calls() {
 #[tokio::test]
 async fn test_pipeline_subagent_parallel_spawn() {
     let config = Arc::new(make_config());
-    let provider = MockProvider::multi(vec![
-        "Sub-result A",
-        "Sub-result B",
-        "Sub-result C",
-    ]);
+    let provider = MockProvider::multi(vec!["Sub-result A", "Sub-result B", "Sub-result C"]);
     let provider_reg = Arc::new(make_provider_registry(provider));
     let tool_reg = Arc::new(ToolRegistry::new());
 
@@ -705,7 +720,9 @@ async fn test_pipeline_subagent_error_isolation() {
     struct FailProvider;
     #[async_trait]
     impl LlmProvider for FailProvider {
-        fn name(&self) -> &str { "fail-mock" }
+        fn name(&self) -> &str {
+            "fail-mock"
+        }
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             Err(anyhow::anyhow!("Simulated sub-agent failure"))
         }
@@ -719,7 +736,9 @@ async fn test_pipeline_subagent_error_isolation() {
             };
             Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
         }
-        fn supports_model(&self, _model: &str) -> bool { true }
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
     }
 
     // Use a shared call counter to alternate success/failure
@@ -729,7 +748,9 @@ async fn test_pipeline_subagent_error_isolation() {
     }
     #[async_trait]
     impl LlmProvider for AlternatingProvider {
-        fn name(&self) -> &str { "alt-mock" }
+        fn name(&self) -> &str {
+            "alt-mock"
+        }
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             let n = self.call_count.fetch_add(1, Ordering::SeqCst);
             if n == 1 {
@@ -757,7 +778,9 @@ async fn test_pipeline_subagent_error_isolation() {
             };
             Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
         }
-        fn supports_model(&self, _model: &str) -> bool { true }
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
     }
 
     let config = Arc::new(make_config());
@@ -831,7 +854,9 @@ fn test_pipeline_cron_add_and_tick_immediate() {
         deliver: true,
     };
 
-    let job = service.add_job(schedule, payload, Some("immediate-job".to_string())).unwrap();
+    let job = service
+        .add_job(schedule, payload, Some("immediate-job".to_string()))
+        .unwrap();
     assert_eq!(job.state, JobState::Active);
     assert!(job.next_run.is_some());
     assert_eq!(job.name, Some("immediate-job".to_string()));
@@ -873,14 +898,20 @@ fn test_pipeline_cron_recurring_every() {
         deliver: false,
     };
 
-    let job = service.add_job(schedule, payload, Some("recurring".to_string())).unwrap();
+    let job = service
+        .add_job(schedule, payload, Some("recurring".to_string()))
+        .unwrap();
 
     // First tick — next_run is now + 1ms, might not be due yet
     // Sleep a bit to ensure it's past
     std::thread::sleep(std::time::Duration::from_millis(5));
 
     let due1 = service.tick();
-    assert_eq!(due1.len(), 1, "First tick should find the recurring job due");
+    assert_eq!(
+        due1.len(),
+        1,
+        "First tick should find the recurring job due"
+    );
     assert_eq!(due1[0].payload.message, "Recurring task");
 
     // Record completion
@@ -895,8 +926,15 @@ fn test_pipeline_cron_recurring_every() {
 
     // Verify execution history
     let updated = service.get_job(&job.id).unwrap();
-    assert!(updated.history.len() >= 2, "Should have at least 2 history entries");
-    assert_eq!(updated.state, JobState::Active, "Recurring job stays active");
+    assert!(
+        updated.history.len() >= 2,
+        "Should have at least 2 history entries"
+    );
+    assert_eq!(
+        updated.state,
+        JobState::Active,
+        "Recurring job stays active"
+    );
 }
 
 #[tokio::test]
@@ -923,7 +961,9 @@ async fn test_pipeline_cron_with_bus_events() {
         deliver: true,
     };
 
-    service.add_job(schedule, payload, Some("bus-event-job".to_string())).unwrap();
+    service
+        .add_job(schedule, payload, Some("bus-event-job".to_string()))
+        .unwrap();
 
     // Tick fires the job and emits CronFired event
     let due = service.tick();
@@ -936,7 +976,11 @@ async fn test_pipeline_cron_with_bus_events() {
         .expect("Event channel closed");
 
     match event {
-        AgentEvent::CronFired { job_id, job_name, message } => {
+        AgentEvent::CronFired {
+            job_id,
+            job_name,
+            message,
+        } => {
             assert!(!job_id.is_empty());
             assert_eq!(job_name, Some("bus-event-job".to_string()));
             assert_eq!(message, "Scheduled greeting");
@@ -966,14 +1010,19 @@ fn test_pipeline_cron_mark_completed_with_result() {
         deliver: false,
     };
 
-    let job = service.add_job(schedule, payload, Some("result-recorder".to_string())).unwrap();
+    let job = service
+        .add_job(schedule, payload, Some("result-recorder".to_string()))
+        .unwrap();
 
     // Tick to fire
     let due = service.tick();
     assert_eq!(due.len(), 1);
 
     // Record a successful result
-    service.mark_completed(&job.id, Some("Execution result: 42 items processed".to_string()));
+    service.mark_completed(
+        &job.id,
+        Some("Execution result: 42 items processed".to_string()),
+    );
 
     // Verify history
     let updated = service.get_job(&job.id).unwrap();
@@ -1008,7 +1057,9 @@ fn test_pipeline_cron_list_and_state() {
             chat_id: None,
             deliver: false,
         };
-        service.add_job(schedule, payload, Some(format!("job-{}", i))).unwrap();
+        service
+            .add_job(schedule, payload, Some(format!("job-{}", i)))
+            .unwrap();
     }
 
     // List all jobs
@@ -1050,7 +1101,8 @@ async fn test_pipeline_cron_to_agent_full_flow() {
     // Set up agent stack
     let config = make_config();
     let session_mgr = SessionManager::new(tmp.path().to_path_buf()).unwrap();
-    let provider_reg = make_provider_registry(MockProvider::simple("Cron response: all systems go"));
+    let provider_reg =
+        make_provider_registry(MockProvider::simple("Cron response: all systems go"));
     let tool_reg = ToolRegistry::new();
 
     let agent_loop = AgentLoop::new(config, bus.clone(), session_mgr, provider_reg, tool_reg);
@@ -1076,7 +1128,8 @@ async fn test_pipeline_cron_to_agent_full_flow() {
         chat_id: Some("chat_cron".to_string()),
         deliver: true,
     };
-    cron.add_job(schedule, payload, Some("status-check".to_string())).unwrap();
+    cron.add_job(schedule, payload, Some("status-check".to_string()))
+        .unwrap();
 
     // Tick fires the job → emits CronFired event on bus
     let due = cron.tick();
@@ -1089,7 +1142,9 @@ async fn test_pipeline_cron_to_agent_full_flow() {
         .expect("Timeout on CronFired event")
         .expect("Event channel closed");
     match event {
-        AgentEvent::CronFired { job_name, message, .. } => {
+        AgentEvent::CronFired {
+            job_name, message, ..
+        } => {
             assert_eq!(job_name, Some("status-check".to_string()));
             assert_eq!(message, "Check system status");
         }


### PR DESCRIPTION
## Summary

Implement native Unix daemon mode for nanobot-rs, inspired by Cloudflare Pingora's Server/Service lifecycle architecture.

### New Crate: `nanobot-daemon`
- **daemonize.rs** — Double-fork via `nix` crate (setsid, chdir, umask, stdio redirect)
- **pid_file.rs** — `PidFile` with `flock(LOCK_EX|LOCK_NB)` for atomic lock
- **signal.rs** — Async signal handling via `tokio::signal::unix` (SIGTERM/SIGINT/SIGHUP)
- **logging.rs** — Non-blocking file writer via `tracing-appender`

### Config: `DaemonConfig`
```yaml
daemon:
  enabled: false
  pid_file: ~/.nanobot-rs/nanobot-rs.pid
  log_dir: ~/.nanobot-rs/logs
  working_directory: /
  grace_period_secs: 30
```

### CLI: `daemon` subcommand
- `nanobot-rs daemon start` — daemonize then run gateway
- `nanobot-rs daemon stop` — read PID, send SIGTERM
- `nanobot-rs daemon restart` — stop + start
- `nanobot-rs daemon status` — check PID file and process state

### Signal Integration
- `gateway.rs` & `serve.rs` — replaced `ctrl_c()` with unified signal handler
- SIGTERM → graceful shutdown
- SIGINT → fast shutdown
- SIGHUP → reload placeholder (logs only for now)

### Verification
- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace` — 0 warnings
- [x] `cargo fmt --all --check` — formatted

### Reference
Pingora source: `cloudflare/pingora` — `pingora-core/src/server/{mod,daemon}.rs`