### PR TITLE
feat(evolve): Skill system with TOML manifests (Sprint 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
 dependencies = [
  "chrono",
  "once_cell",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -1411,6 +1411,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanobot-skill"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs",
+ "nanobot-core",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "nanobot-tools"
 version = "0.1.0"
 dependencies = [
@@ -1993,6 +2011,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,6 +2360,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2968,6 +3036,15 @@ name = "winnow"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/nanobot-channels",
     "crates/nanobot-api",
     "crates/nanobot-daemon",
+    "crates/nanobot-skill",
 ]
 
 [workspace.package]
@@ -33,6 +34,7 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+toml = "0.8"
 
 # Error handling
 thiserror = "2"

--- a/crates/nanobot-daemon/src/signal.rs
+++ b/crates/nanobot-daemon/src/signal.rs
@@ -106,11 +106,12 @@ pub fn send_sigterm_and_wait(pid: i32, timeout_secs: u64) -> Result<()> {
     // waitpid on a non-child returns ECHILD, which we treat as "done".
     let nix_pid = Pid::from_raw(pid);
     while std::time::Instant::now() < deadline {
-        let exited = match nix::sys::wait::waitpid(nix_pid, Some(nix::sys::wait::WaitPidFlag::WNOHANG)) {
-            Ok(_) => true,
-            Err(nix::errno::Errno::ECHILD) => true,
-            Err(e) => anyhow::bail!("waitpid error: {e}"),
-        };
+        let exited =
+            match nix::sys::wait::waitpid(nix_pid, Some(nix::sys::wait::WaitPidFlag::WNOHANG)) {
+                Ok(_) => true,
+                Err(nix::errno::Errno::ECHILD) => true,
+                Err(e) => anyhow::bail!("waitpid error: {e}"),
+            };
         if exited {
             return Ok(());
         }

--- a/crates/nanobot-skill/Cargo.toml
+++ b/crates/nanobot-skill/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nanobot-skill"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+nanobot-core = { path = "../nanobot-core" }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+toml = "0.8"
+tracing = { workspace = true }
+parking_lot = { workspace = true }
+chrono = { workspace = true }
+dirs = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/nanobot-skill/src/compiler.rs
+++ b/crates/nanobot-skill/src/compiler.rs
@@ -1,0 +1,143 @@
+//! Skill compiler — parses TOML manifests and validates required fields.
+//!
+//! This is the Phase 1 simplified compiler: parse TOML, validate, produce a [`CompiledSkill`].
+//! Future phases may add DFA/regex trigger compilation.
+
+use std::path::Path;
+
+use crate::error::{SkillError, SkillResult};
+use crate::manifest::SkillManifest;
+use crate::skill::CompiledSkill;
+
+/// Compiles raw TOML files into executable [`CompiledSkill`] instances.
+#[derive(Debug, Default)]
+pub struct SkillCompiler;
+
+impl SkillCompiler {
+    /// Create a new compiler.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Compile a TOML string into a [`CompiledSkill`].
+    ///
+    /// Parses the TOML, validates required fields, and returns a compiled skill.
+    pub fn compile_str(&self, name: &str, content: &str) -> SkillResult<CompiledSkill> {
+        let manifest: SkillManifest = toml::from_str(content).map_err(|e| SkillError::ParseFailed {
+            path: name.to_string(),
+            source: e,
+        })?;
+
+        self.validate_manifest(&manifest)?;
+        Ok(CompiledSkill::new(manifest))
+    }
+
+    /// Compile a TOML manifest file from disk.
+    pub fn compile_file(&self, path: &Path) -> SkillResult<CompiledSkill> {
+        let content = std::fs::read_to_string(path)?;
+        let name = path.display().to_string();
+        self.compile_str(&name, &content)
+    }
+
+    /// Validate a parsed manifest, returning an error on failure.
+    fn validate_manifest(&self, manifest: &SkillManifest) -> SkillResult<()> {
+        manifest
+            .validate()
+            .map_err(|errors| SkillError::ValidationFailed {
+                name: manifest.name.clone(),
+                reason: errors.join("; "),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skill::Skill;
+
+    const VALID_TOML: &str = r#"
+name = "deploy-k8s"
+version = "1.0.0"
+description = "Deploy application to Kubernetes"
+triggers = ["deploy", "k8s", "kubernetes"]
+steps = ["Check kubeconfig", "Apply manifests"]
+pitfalls = ["Do not deploy on Fridays"]
+category = "devops"
+"#;
+
+    #[test]
+    fn test_compile_valid_str() {
+        let compiler = SkillCompiler::new();
+        let skill = compiler.compile_str("test", VALID_TOML).unwrap();
+        assert_eq!(skill.name(), "deploy-k8s");
+        assert_eq!(skill.category(), "devops");
+    }
+
+    #[test]
+    fn test_compile_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("deploy.toml");
+        std::fs::write(&path, VALID_TOML).unwrap();
+
+        let compiler = SkillCompiler::new();
+        let skill = compiler.compile_file(&path).unwrap();
+        assert_eq!(skill.name(), "deploy-k8s");
+    }
+
+    #[test]
+    fn test_compile_invalid_toml() {
+        let compiler = SkillCompiler::new();
+        let result = compiler.compile_str("bad", "not valid [[[" );
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SkillError::ParseFailed { path, .. } => assert_eq!(path, "bad"),
+            other => panic!("expected ParseFailed, got {other}"),
+        }
+    }
+
+    #[test]
+    fn test_compile_missing_name() {
+        let compiler = SkillCompiler::new();
+        let toml = r#"
+version = "1.0.0"
+description = "desc"
+triggers = ["x"]
+"#;
+        let result = compiler.compile_str("test", toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compile_missing_triggers() {
+        let compiler = SkillCompiler::new();
+        let toml = r#"
+name = "x"
+version = "1.0.0"
+description = "desc"
+triggers = []
+"#;
+        let result = compiler.compile_str("test", toml);
+        assert!(matches!(result.unwrap_err(), SkillError::ValidationFailed { .. }));
+    }
+
+    #[test]
+    fn test_compile_missing_file() {
+        let compiler = SkillCompiler::new();
+        let result = compiler.compile_file(Path::new("/nonexistent/skill.toml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compile_minimal_manifest() {
+        let compiler = SkillCompiler::new();
+        let toml = r#"
+name = "minimal"
+version = "0.1.0"
+description = "Just the basics"
+triggers = ["min"]
+"#;
+        let skill = compiler.compile_str("test", toml).unwrap();
+        assert_eq!(skill.name(), "minimal");
+        assert_eq!(skill.category(), "uncategorized");
+    }
+}

--- a/crates/nanobot-skill/src/compiler.rs
+++ b/crates/nanobot-skill/src/compiler.rs
@@ -23,10 +23,11 @@ impl SkillCompiler {
     ///
     /// Parses the TOML, validates required fields, and returns a compiled skill.
     pub fn compile_str(&self, name: &str, content: &str) -> SkillResult<CompiledSkill> {
-        let manifest: SkillManifest = toml::from_str(content).map_err(|e| SkillError::ParseFailed {
-            path: name.to_string(),
-            source: e,
-        })?;
+        let manifest: SkillManifest =
+            toml::from_str(content).map_err(|e| SkillError::ParseFailed {
+                path: name.to_string(),
+                source: e,
+            })?;
 
         self.validate_manifest(&manifest)?;
         Ok(CompiledSkill::new(manifest))
@@ -87,7 +88,7 @@ category = "devops"
     #[test]
     fn test_compile_invalid_toml() {
         let compiler = SkillCompiler::new();
-        let result = compiler.compile_str("bad", "not valid [[[" );
+        let result = compiler.compile_str("bad", "not valid [[[");
         assert!(result.is_err());
         match result.unwrap_err() {
             SkillError::ParseFailed { path, .. } => assert_eq!(path, "bad"),
@@ -117,7 +118,10 @@ description = "desc"
 triggers = []
 "#;
         let result = compiler.compile_str("test", toml);
-        assert!(matches!(result.unwrap_err(), SkillError::ValidationFailed { .. }));
+        assert!(matches!(
+            result.unwrap_err(),
+            SkillError::ValidationFailed { .. }
+        ));
     }
 
     #[test]

--- a/crates/nanobot-skill/src/config.rs
+++ b/crates/nanobot-skill/src/config.rs
@@ -1,0 +1,148 @@
+//! Skill system configuration.
+//!
+//! Loaded from `~/.nanobot-rs/skills.toml` (or `NANOBOT_RS_HOME/skills.toml`).
+//! Controls skills directory, max loaded skills, and cache TTL.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Configuration for the skill subsystem.
+///
+/// Example TOML (`skills.toml`):
+/// ```toml
+/// skills_dir = "~/.nanobot-rs/skills"
+/// max_skills = 100
+/// cache_ttl_secs = 3600
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillConfig {
+    /// Directory containing skill TOML manifests.
+    ///
+    /// Defaults to `$NANOBOT_RS_HOME/skills` or `~/.nanobot-rs/skills`.
+    #[serde(default = "default_skills_dir")]
+    pub skills_dir: PathBuf,
+
+    /// Maximum number of skills to keep loaded at once.
+    #[serde(default = "default_max_skills")]
+    pub max_skills: usize,
+
+    /// Cache time-to-live in seconds for loaded manifests.
+    #[serde(default = "default_cache_ttl")]
+    pub cache_ttl_secs: u64,
+}
+
+fn default_skills_dir() -> PathBuf {
+    nanobot_home().join("skills")
+}
+
+fn nanobot_home() -> PathBuf {
+    std::env::var("NANOBOT_RS_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".nanobot-rs"))
+}
+
+fn default_max_skills() -> usize {
+    100
+}
+
+fn default_cache_ttl() -> u64 {
+    3600
+}
+
+impl Default for SkillConfig {
+    fn default() -> Self {
+        Self {
+            skills_dir: default_skills_dir(),
+            max_skills: default_max_skills(),
+            cache_ttl_secs: default_cache_ttl(),
+        }
+    }
+}
+
+impl SkillConfig {
+    /// Create config with a specific skills directory (useful for testing).
+    pub fn with_skills_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.skills_dir = dir.into();
+        self
+    }
+
+    /// Load config from a TOML file.
+    pub fn load_from_file(path: &std::path::Path) -> crate::SkillResult<Self> {
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            crate::SkillError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("Failed to read config from {}: {e}", path.display()),
+            ))
+        })?;
+        let config: Self = toml::from_str(&content).map_err(|e| crate::SkillError::ParseFailed {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = SkillConfig::default();
+        assert!(config.skills_dir.to_string_lossy().contains("skills"));
+        assert_eq!(config.max_skills, 100);
+        assert_eq!(config.cache_ttl_secs, 3600);
+    }
+
+    #[test]
+    fn test_with_skills_dir() {
+        let config = SkillConfig::default().with_skills_dir("/tmp/test-skills");
+        assert_eq!(config.skills_dir, PathBuf::from("/tmp/test-skills"));
+    }
+
+    #[test]
+    fn test_load_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skills.toml");
+        std::fs::write(
+            &path,
+            r#"
+skills_dir = "/custom/skills"
+max_skills = 50
+cache_ttl_secs = 1800
+"#,
+        )
+        .unwrap();
+        let config = SkillConfig::load_from_file(&path).unwrap();
+        assert_eq!(config.skills_dir, PathBuf::from("/custom/skills"));
+        assert_eq!(config.max_skills, 50);
+        assert_eq!(config.cache_ttl_secs, 1800);
+    }
+
+    #[test]
+    fn test_load_missing_file() {
+        let config = SkillConfig::load_from_file(std::path::Path::new("/nonexistent/skills.toml"));
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_load_invalid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skills.toml");
+        std::fs::write(&path, "not valid toml [[[[").unwrap();
+        let result = SkillConfig::load_from_file(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_toml_roundtrip() {
+        let config = SkillConfig {
+            skills_dir: PathBuf::from("/tmp/skills"),
+            max_skills: 42,
+            cache_ttl_secs: 600,
+        };
+        let toml_str = toml::to_string(&config).unwrap();
+        let parsed: SkillConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(config, parsed);
+    }
+}

--- a/crates/nanobot-skill/src/config.rs
+++ b/crates/nanobot-skill/src/config.rs
@@ -74,10 +74,11 @@ impl SkillConfig {
                 format!("Failed to read config from {}: {e}", path.display()),
             ))
         })?;
-        let config: Self = toml::from_str(&content).map_err(|e| crate::SkillError::ParseFailed {
-            path: path.display().to_string(),
-            source: e,
-        })?;
+        let config: Self =
+            toml::from_str(&content).map_err(|e| crate::SkillError::ParseFailed {
+                path: path.display().to_string(),
+                source: e,
+            })?;
         Ok(config)
     }
 }

--- a/crates/nanobot-skill/src/error.rs
+++ b/crates/nanobot-skill/src/error.rs
@@ -1,0 +1,139 @@
+//! Error types for the nanobot-skill crate.
+
+use thiserror::Error;
+
+/// Errors that can occur during skill operations.
+#[derive(Error, Debug)]
+pub enum SkillError {
+    /// A required field is missing from the TOML manifest.
+    #[error("Missing required field '{field}' in skill manifest '{name}'")]
+    MissingField {
+        /// Name of the skill manifest.
+        name: String,
+        /// Name of the missing field.
+        field: String,
+    },
+
+    /// The TOML manifest could not be parsed.
+    #[error("Failed to parse TOML manifest '{path}': {source}")]
+    ParseFailed {
+        /// Path to the manifest file.
+        path: String,
+        /// The parse error.
+        source: toml::de::Error,
+    },
+
+    /// A skill with the given name was not found.
+    #[error("Skill not found: {0}")]
+    NotFound(String),
+
+    /// A skill with the given name already exists.
+    #[error("Skill already registered: {0}")]
+    AlreadyExists(String),
+
+    /// An I/O error occurred.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The skill manifest validation failed.
+    #[error("Invalid skill manifest '{name}': {reason}")]
+    ValidationFailed {
+        /// Name of the skill manifest.
+        name: String,
+        /// Why validation failed.
+        reason: String,
+    },
+
+    /// Skill execution failed.
+    #[error("Skill execution failed for '{name}': {reason}")]
+    ExecutionFailed {
+        /// Name of the skill.
+        name: String,
+        /// Why execution failed.
+        reason: String,
+    },
+
+    /// The skill directory does not exist.
+    #[error("Skills directory not found: {0}")]
+    DirectoryNotFound(String),
+}
+
+/// Convenience alias for results using [`SkillError`].
+pub type SkillResult<T> = std::result::Result<T, SkillError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_field_display() {
+        let err = SkillError::MissingField {
+            name: "deploy".to_string(),
+            field: "version".to_string(),
+        };
+        assert!(format!("{err}").contains("version"));
+        assert!(format!("{err}").contains("deploy"));
+    }
+
+    #[test]
+    fn test_parse_failed_display() {
+        let toml_err = toml::from_str::<toml::Value>("not valid [[[").unwrap_err();
+        let err = SkillError::ParseFailed {
+            path: "skills/deploy.toml".to_string(),
+            source: toml_err,
+        };
+        assert!(format!("{err}").contains("skills/deploy.toml"));
+    }
+
+    #[test]
+    fn test_not_found_display() {
+        let err = SkillError::NotFound("my-skill".to_string());
+        assert!(format!("{err}").contains("my-skill"));
+    }
+
+    #[test]
+    fn test_already_exists_display() {
+        let err = SkillError::AlreadyExists("dup".to_string());
+        assert!(format!("{err}").contains("dup"));
+    }
+
+    #[test]
+    fn test_validation_failed_display() {
+        let err = SkillError::ValidationFailed {
+            name: "bad".to_string(),
+            reason: "name too long".to_string(),
+        };
+        assert!(format!("{err}").contains("name too long"));
+    }
+
+    #[test]
+    fn test_execution_failed_display() {
+        let err = SkillError::ExecutionFailed {
+            name: "boom".to_string(),
+            reason: "timeout".to_string(),
+        };
+        assert!(format!("{err}").contains("timeout"));
+    }
+
+    #[test]
+    fn test_directory_not_found_display() {
+        let err = SkillError::DirectoryNotFound("/tmp/nope".to_string());
+        assert!(format!("{err}").contains("/tmp/nope"));
+    }
+
+    #[test]
+    fn test_from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let err: SkillError = io_err.into();
+        assert!(matches!(err, SkillError::Io(_)));
+    }
+
+    #[test]
+    fn test_result_alias() {
+        let ok: SkillResult<i32> = Ok(42);
+        assert_eq!(ok.unwrap(), 42);
+
+        let err: SkillResult<String> = Err(SkillError::NotFound("x".to_string()));
+        assert!(err.is_err());
+    }
+}

--- a/crates/nanobot-skill/src/lib.rs
+++ b/crates/nanobot-skill/src/lib.rs
@@ -1,0 +1,22 @@
+//! # nanobot-skill
+//!
+//! Skill trait, TOML manifests, registry, compiler, and loader for the nanobot-rs framework.
+//!
+//! Skills are the primary extension mechanism. Each skill is defined by a TOML manifest
+//! and loaded from `~/.nanobot-rs/skills/` (or `NANOBOT_RS_HOME/skills/`).
+
+pub mod compiler;
+pub mod config;
+pub mod error;
+pub mod loader;
+pub mod manifest;
+pub mod registry;
+pub mod skill;
+
+pub use compiler::SkillCompiler;
+pub use config::SkillConfig;
+pub use error::{SkillError, SkillResult};
+pub use loader::SkillLoader;
+pub use manifest::SkillManifest;
+pub use registry::SkillRegistry;
+pub use skill::{CompiledSkill, ConfidenceEvent, Skill, SkillOutput};

--- a/crates/nanobot-skill/src/loader.rs
+++ b/crates/nanobot-skill/src/loader.rs
@@ -1,0 +1,283 @@
+//! Skill loader — directory scanning, lazy loading, and caching.
+//!
+//! Scans a directory for `.toml` skill manifests, compiles them on first access,
+//! and caches the results with a configurable TTL.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+
+use crate::skill::Skill;
+
+use crate::compiler::SkillCompiler;
+use crate::config::SkillConfig;
+use crate::error::{SkillError, SkillResult};
+use crate::registry::SkillRegistry;
+use crate::skill::CompiledSkill;
+
+/// Cache entry with expiration tracking.
+#[derive(Debug)]
+struct CacheEntry {
+    /// The compiled skill.
+    skill: CompiledSkill,
+    /// When the skill was loaded/last refreshed.
+    loaded_at: Instant,
+    /// Path to the source manifest.
+    #[allow(dead_code)]
+    source: PathBuf,
+}
+
+impl CacheEntry {
+    fn new(skill: CompiledSkill, source: PathBuf) -> Self {
+        Self {
+            skill,
+            loaded_at: Instant::now(),
+            source,
+        }
+    }
+
+    fn is_expired(&self, ttl: Duration) -> bool {
+        self.loaded_at.elapsed() > ttl
+    }
+}
+
+/// Loads skill manifests from a directory with lazy loading and TTL-based caching.
+#[derive(Debug)]
+pub struct SkillLoader {
+    compiler: SkillCompiler,
+    config: SkillConfig,
+    cache: Arc<RwLock<HashMap<String, CacheEntry>>>,
+}
+
+impl SkillLoader {
+    /// Create a new loader with the given config.
+    pub fn new(config: SkillConfig) -> Self {
+        Self {
+            compiler: SkillCompiler::new(),
+            config,
+            cache: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Load all `.toml` skill manifests from the configured skills directory
+    /// and register them in the given registry.
+    ///
+    /// Returns the list of skill names that were successfully loaded.
+    pub async fn load_all(&self, registry: &SkillRegistry) -> SkillResult<Vec<String>> {
+        let skills_dir = &self.config.skills_dir;
+        self.load_from_dir(skills_dir, registry).await
+    }
+
+    /// Load all `.toml` skill manifests from a specific directory.
+    pub async fn load_from_dir(
+        &self,
+        dir: &Path,
+        registry: &SkillRegistry,
+    ) -> SkillResult<Vec<String>> {
+        if !dir.exists() {
+            return Err(SkillError::DirectoryNotFound(dir.display().to_string()));
+        }
+
+        let mut loaded = Vec::new();
+        let entries = std::fs::read_dir(dir).map_err(|e| {
+            SkillError::DirectoryNotFound(format!("{}: {e}", dir.display()))
+        })?;
+
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.extension().and_then(|e| e.to_str()) == Some("toml") {
+                match self.load_skill(&path) {
+                    Ok(skill) => {
+                        let name = skill.name().to_string();
+                        if let Err(e) = registry.register(skill).await {
+                            tracing::warn!("Skipping skill from {}: {e}", path.display());
+                            // Store in cache anyway for get() access
+                            continue;
+                        }
+                        loaded.push(name);
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to load skill from {}: {e}", path.display());
+                    }
+                }
+            }
+        }
+
+        Ok(loaded)
+    }
+
+    /// Load a single skill, using the cache if fresh or recompiling if expired.
+    pub fn load_skill(&self, path: &Path) -> SkillResult<CompiledSkill> {
+        let key = path.display().to_string();
+
+        // Check cache first
+        {
+            let cache = self.cache.read();
+            if let Some(entry) = cache.get(&key) {
+                if !entry.is_expired(Duration::from_secs(self.config.cache_ttl_secs)) {
+                    return Ok(entry.skill.clone());
+                }
+            }
+        }
+
+        // Compile fresh
+        let skill = self.compiler.compile_file(path)?;
+        let entry = CacheEntry::new(skill.clone(), path.to_path_buf());
+
+        {
+            let mut cache = self.cache.write();
+            cache.insert(key, entry);
+        }
+
+        Ok(skill)
+    }
+
+    /// Force a reload, bypassing the cache.
+    pub fn reload_skill(&self, path: &Path) -> SkillResult<CompiledSkill> {
+        let skill = self.compiler.compile_file(path)?;
+        let key = path.display().to_string();
+        let entry = CacheEntry::new(skill.clone(), path.to_path_buf());
+
+        {
+            let mut cache = self.cache.write();
+            cache.insert(key, entry);
+        }
+
+        Ok(skill)
+    }
+
+    /// Clear the entire cache.
+    pub fn clear_cache(&self) {
+        self.cache.write().clear();
+    }
+
+    /// Return the number of cached entries.
+    pub fn cache_size(&self) -> usize {
+        self.cache.read().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::SkillManifestBuilder;
+
+    fn test_config(dir: &Path) -> SkillConfig {
+        SkillConfig::default().with_skills_dir(dir)
+    }
+
+    fn write_skill(dir: &Path, name: &str, triggers: &[&str]) -> PathBuf {
+        let manifest = SkillManifestBuilder::new(name, "1.0.0", format!("Skill {name}"))
+            .triggers(triggers.to_vec())
+            .build();
+        let path = dir.join(format!("{name}.toml"));
+        std::fs::write(&path, toml::to_string(&manifest).unwrap()).unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn test_load_all_from_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        write_skill(dir.path(), "deploy", &["deploy"]);
+        write_skill(dir.path(), "test", &["test"]);
+
+        let loader = SkillLoader::new(test_config(dir.path()));
+        let registry = SkillRegistry::new();
+        let loaded = loader.load_all(&registry).await.unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert!(loaded.contains(&"deploy".to_string()));
+        assert!(loaded.contains(&"test".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_load_missing_dir() {
+        let loader = SkillLoader::new(SkillConfig::default().with_skills_dir("/nonexistent"));
+        let registry = SkillRegistry::new();
+        let result = loader.load_all(&registry).await;
+        assert!(matches!(result.unwrap_err(), SkillError::DirectoryNotFound(_)));
+    }
+
+    #[test]
+    fn test_load_single_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(dir.path(), "single", &["s"]);
+
+        let loader = SkillLoader::new(test_config(dir.path()));
+        let skill = loader.load_skill(&path).unwrap();
+        assert_eq!(skill.name(), "single");
+    }
+
+    #[test]
+    fn test_load_skill_caches() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(dir.path(), "cached", &["c"]);
+
+        let loader = SkillLoader::new(test_config(dir.path()));
+        let _ = loader.load_skill(&path).unwrap();
+        assert_eq!(loader.cache_size(), 1);
+
+        // Second load hits cache
+        let skill = loader.load_skill(&path).unwrap();
+        assert_eq!(skill.name(), "cached");
+        assert_eq!(loader.cache_size(), 1);
+    }
+
+    #[test]
+    fn test_reload_skill_bypasses_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(dir.path(), "reload", &["r"]);
+
+        let loader = SkillLoader::new(test_config(dir.path()));
+        let _ = loader.load_skill(&path).unwrap();
+
+        let skill = loader.reload_skill(&path).unwrap();
+        assert_eq!(skill.name(), "reload");
+    }
+
+    #[test]
+    fn test_clear_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(dir.path(), "clear", &["x"]);
+
+        let loader = SkillLoader::new(test_config(dir.path()));
+        let _ = loader.load_skill(&path).unwrap();
+        assert_eq!(loader.cache_size(), 1);
+
+        loader.clear_cache();
+        assert_eq!(loader.cache_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_load_skips_invalid_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_skill(dir.path(), "valid", &["v"]);
+        // Write an invalid TOML file
+        std::fs::write(dir.path().join("bad.toml"), "not valid toml [[[[").unwrap();
+        // Write a non-TOML file (should be skipped)
+        std::fs::write(dir.path().join("readme.md"), "# Skills").unwrap();
+
+        let loader = SkillLoader::new(test_config(dir.path()));
+        let registry = SkillRegistry::new();
+        let loaded = loader.load_all(&registry).await.unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert!(loaded.contains(&"valid".to_string()));
+    }
+
+    #[test]
+    fn test_load_invalid_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "not valid toml [[[[ ").unwrap();
+
+        let loader = SkillLoader::new(test_config(dir.path()));
+        let result = loader.load_skill(&path);
+        assert!(result.is_err());
+    }
+}

--- a/crates/nanobot-skill/src/loader.rs
+++ b/crates/nanobot-skill/src/loader.rs
@@ -82,9 +82,8 @@ impl SkillLoader {
         }
 
         let mut loaded = Vec::new();
-        let entries = std::fs::read_dir(dir).map_err(|e| {
-            SkillError::DirectoryNotFound(format!("{}: {e}", dir.display()))
-        })?;
+        let entries = std::fs::read_dir(dir)
+            .map_err(|e| SkillError::DirectoryNotFound(format!("{}: {e}", dir.display())))?;
 
         for entry in entries {
             let entry = entry?;
@@ -200,7 +199,10 @@ mod tests {
         let loader = SkillLoader::new(SkillConfig::default().with_skills_dir("/nonexistent"));
         let registry = SkillRegistry::new();
         let result = loader.load_all(&registry).await;
-        assert!(matches!(result.unwrap_err(), SkillError::DirectoryNotFound(_)));
+        assert!(matches!(
+            result.unwrap_err(),
+            SkillError::DirectoryNotFound(_)
+        ));
     }
 
     #[test]

--- a/crates/nanobot-skill/src/manifest.rs
+++ b/crates/nanobot-skill/src/manifest.rs
@@ -1,0 +1,283 @@
+//! TOML skill manifest types.
+//!
+//! Each skill is defined by a TOML file with required fields (name, version, description,
+//! triggers) and optional fields (steps, pitfalls, category).
+
+use serde::{Deserialize, Serialize};
+
+/// Parsed TOML skill manifest.
+///
+/// Example TOML:
+/// ```toml
+/// name = "deploy-k8s"
+/// version = "1.0.0"
+/// description = "Deploy application to Kubernetes"
+/// category = "devops"
+/// triggers = ["deploy", "k8s", "kubernetes"]
+/// steps = ["Check kubeconfig", "Apply manifests", "Verify rollout"]
+/// pitfalls = ["Do not deploy to production on Fridays"]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillManifest {
+    /// Unique skill name in kebab-case (max 64 chars).
+    pub name: String,
+    /// Semantic version (e.g. "1.0.0").
+    pub version: String,
+    /// Human-readable description of what this skill does (max 1024 chars).
+    pub description: String,
+    /// Keywords that trigger this skill during matching.
+    pub triggers: Vec<String>,
+    /// Ordered list of steps to execute when the skill is activated.
+    #[serde(default)]
+    pub steps: Vec<String>,
+    /// Common pitfalls or warnings for this skill.
+    #[serde(default)]
+    pub pitfalls: Vec<String>,
+    /// Skill category for grouping (e.g. "devops", "security", "testing").
+    #[serde(default = "default_category")]
+    pub category: String,
+}
+
+fn default_category() -> String {
+    "uncategorized".to_string()
+}
+
+impl SkillManifest {
+    /// Maximum length for a skill name.
+    pub const MAX_NAME_LEN: usize = 64;
+    /// Maximum length for a description.
+    pub const MAX_DESCRIPTION_LEN: usize = 1024;
+
+    /// Validate the manifest fields.
+    ///
+    /// Ensures: non-empty name within length limit, non-empty version, non-empty description
+    /// within length limit, and at least one trigger keyword.
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+
+        if self.name.is_empty() {
+            errors.push("name must not be empty".to_string());
+        } else if self.name.len() > Self::MAX_NAME_LEN {
+            errors.push(format!(
+                "name must be at most {} characters, got {}",
+                Self::MAX_NAME_LEN,
+                self.name.len()
+            ));
+        }
+
+        if self.version.is_empty() {
+            errors.push("version must not be empty".to_string());
+        }
+
+        if self.description.is_empty() {
+            errors.push("description must not be empty".to_string());
+        } else if self.description.len() > Self::MAX_DESCRIPTION_LEN {
+            errors.push(format!(
+                "description must be at most {} characters, got {}",
+                Self::MAX_DESCRIPTION_LEN,
+                self.description.len()
+            ));
+        }
+
+        if self.triggers.is_empty() {
+            errors.push("triggers must contain at least one keyword".to_string());
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+/// Builder for constructing [`SkillManifest`] programmatically.
+#[derive(Debug, Clone)]
+pub struct SkillManifestBuilder {
+    name: String,
+    version: String,
+    description: String,
+    triggers: Vec<String>,
+    steps: Vec<String>,
+    pitfalls: Vec<String>,
+    category: String,
+}
+
+impl SkillManifestBuilder {
+    /// Create a new builder with the required fields.
+    pub fn new(
+        name: impl Into<String>,
+        version: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            description: description.into(),
+            triggers: Vec::new(),
+            steps: Vec::new(),
+            pitfalls: Vec::new(),
+            category: "uncategorized".to_string(),
+        }
+    }
+
+    /// Add trigger keywords.
+    pub fn triggers(mut self, triggers: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.triggers = triggers.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add execution steps.
+    pub fn steps(mut self, steps: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.steps = steps.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add pitfalls/warnings.
+    pub fn pitfalls(mut self, pitfalls: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.pitfalls = pitfalls.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the category.
+    pub fn category(mut self, category: impl Into<String>) -> Self {
+        self.category = category.into();
+        self
+    }
+
+    /// Build the manifest. Panics if required triggers are missing.
+    pub fn build(self) -> SkillManifest {
+        SkillManifest {
+            name: self.name,
+            version: self.version,
+            description: self.description,
+            triggers: self.triggers,
+            steps: self.steps,
+            pitfalls: self.pitfalls,
+            category: self.category,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_manifest() -> SkillManifest {
+        SkillManifestBuilder::new("deploy-k8s", "1.0.0", "Deploy to Kubernetes")
+            .triggers(["deploy", "k8s"])
+            .steps(["Apply manifests", "Verify rollout"])
+            .pitfalls(["Do not deploy on Fridays"])
+            .category("devops")
+            .build()
+    }
+
+    #[test]
+    fn test_valid_manifest() {
+        let m = valid_manifest();
+        assert_eq!(m.name, "deploy-k8s");
+        assert_eq!(m.version, "1.0.0");
+        assert_eq!(m.description, "Deploy to Kubernetes");
+        assert_eq!(m.triggers, vec!["deploy", "k8s"]);
+        assert_eq!(m.steps.len(), 2);
+        assert_eq!(m.pitfalls.len(), 1);
+        assert_eq!(m.category, "devops");
+    }
+
+    #[test]
+    fn test_validate_ok() {
+        let m = valid_manifest();
+        assert!(m.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_empty_name() {
+        let mut m = valid_manifest();
+        m.name = String::new();
+        let errors = m.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("name")));
+    }
+
+    #[test]
+    fn test_validate_name_too_long() {
+        let mut m = valid_manifest();
+        m.name = "x".repeat(100);
+        let errors = m.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("64 characters")));
+    }
+
+    #[test]
+    fn test_validate_empty_version() {
+        let mut m = valid_manifest();
+        m.version = String::new();
+        let errors = m.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("version")));
+    }
+
+    #[test]
+    fn test_validate_empty_description() {
+        let mut m = valid_manifest();
+        m.description = String::new();
+        let errors = m.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("description")));
+    }
+
+    #[test]
+    fn test_validate_description_too_long() {
+        let mut m = valid_manifest();
+        m.description = "x".repeat(2000);
+        let errors = m.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("1024 characters")));
+    }
+
+    #[test]
+    fn test_validate_empty_triggers() {
+        let mut m = valid_manifest();
+        m.triggers = Vec::new();
+        let errors = m.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("trigger")));
+    }
+
+    #[test]
+    fn test_validate_multiple_errors() {
+        let m = SkillManifest {
+            name: String::new(),
+            version: String::new(),
+            description: String::new(),
+            triggers: Vec::new(),
+            steps: Vec::new(),
+            pitfalls: Vec::new(),
+            category: "uncategorized".to_string(),
+        };
+        let errors = m.validate().unwrap_err();
+        assert!(errors.len() >= 4);
+    }
+
+    #[test]
+    fn test_toml_roundtrip() {
+        let m = valid_manifest();
+        let toml_str = toml::to_string(&m).unwrap();
+        let parsed: SkillManifest = toml::from_str(&toml_str).unwrap();
+        assert_eq!(m, parsed);
+    }
+
+    #[test]
+    fn test_toml_parse_with_defaults() {
+        let toml_str = r#"
+name = "hello"
+version = "0.1.0"
+description = "Says hello"
+triggers = ["hi", "hello"]
+"#;
+        let m: SkillManifest = toml::from_str(toml_str).unwrap();
+        assert_eq!(m.name, "hello");
+        assert!(m.steps.is_empty());
+        assert!(m.pitfalls.is_empty());
+        assert_eq!(m.category, "uncategorized");
+    }
+
+    #[test]
+    fn test_default_category() {
+        assert_eq!(default_category(), "uncategorized");
+    }
+}

--- a/crates/nanobot-skill/src/registry.rs
+++ b/crates/nanobot-skill/src/registry.rs
@@ -1,0 +1,273 @@
+//! Skill registry — register, query, and match skills by keyword.
+//!
+//! The registry holds compiled skills in an `Arc<RwLock<HashMap>>` and provides
+//! keyword-based matching against user input.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tokio::sync::RwLock as AsyncRwLock;
+
+use crate::error::{SkillError, SkillResult};
+use crate::skill::{CompiledSkill, Skill};
+
+/// A scored skill match returned by [`SkillRegistry::match_skills`].
+#[derive(Debug, Clone)]
+pub struct SkillMatch {
+    /// Name of the matched skill.
+    pub name: String,
+    /// Match score (0.0 – 1.0).
+    pub score: f64,
+}
+
+/// Central registry for loaded skills.
+///
+/// Thread-safe via `Arc<AsyncRwLock>`. Skills are stored by name and can be
+/// queried by keyword matching against trigger lists.
+#[derive(Debug, Clone)]
+pub struct SkillRegistry {
+    skills: Arc<AsyncRwLock<HashMap<String, Arc<RwLock<CompiledSkill>>>>>,
+}
+
+impl SkillRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            skills: Arc::new(AsyncRwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register a compiled skill.
+    ///
+    /// Returns an error if a skill with the same name already exists.
+    pub async fn register(&self, skill: CompiledSkill) -> SkillResult<()> {
+        let name = skill.name().to_string();
+        let mut skills = self.skills.write().await;
+        if skills.contains_key(&name) {
+            return Err(SkillError::AlreadyExists(name));
+        }
+        skills.insert(name, Arc::new(RwLock::new(skill)));
+        Ok(())
+    }
+
+    /// Get a skill by name.
+    pub async fn get(&self, name: &str) -> Option<Arc<RwLock<CompiledSkill>>> {
+        let skills = self.skills.read().await;
+        skills.get(name).cloned()
+    }
+
+    /// Remove a skill by name. Returns true if the skill was present.
+    pub async fn unregister(&self, name: &str) -> bool {
+        let mut skills = self.skills.write().await;
+        skills.remove(name).is_some()
+    }
+
+    /// Return the number of registered skills.
+    pub async fn len(&self) -> usize {
+        self.skills.read().await.len()
+    }
+
+    /// Check if the registry is empty.
+    pub async fn is_empty(&self) -> bool {
+        self.skills.read().await.is_empty()
+    }
+
+    /// List all registered skill names.
+    pub async fn skill_names(&self) -> Vec<String> {
+        self.skills.read().await.keys().cloned().collect()
+    }
+
+    /// Match skills against a query string, sorted by descending score.
+    ///
+    /// Returns skills with a score > 0.0, sorted from best to worst match.
+    pub async fn match_skills(&self, query: &str) -> Vec<SkillMatch> {
+        let skills = self.skills.read().await;
+        let mut matches: Vec<SkillMatch> = Vec::new();
+
+        for (name, skill) in skills.iter() {
+            let score = skill.read().matches(query);
+            if score > 0.0 {
+                matches.push(SkillMatch {
+                    name: name.clone(),
+                    score,
+                });
+            }
+        }
+
+        matches.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        matches
+    }
+
+    /// Update the confidence of a registered skill.
+    pub async fn update_confidence(&self, name: &str, event: crate::skill::ConfidenceEvent) -> SkillResult<()> {
+        let skills = self.skills.read().await;
+        let skill = skills
+            .get(name)
+            .ok_or_else(|| SkillError::NotFound(name.to_string()))?;
+        skill.write().update_confidence(event);
+        Ok(())
+    }
+}
+
+impl Default for SkillRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::SkillManifestBuilder;
+
+    fn make_skill(name: &str, triggers: &[&str]) -> CompiledSkill {
+        CompiledSkill::new(
+            SkillManifestBuilder::new(name, "1.0.0", format!("Skill {name}"))
+                .triggers(triggers.to_vec())
+                .build(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_register_and_get() {
+        let registry = SkillRegistry::new();
+        let skill = make_skill("deploy", &["deploy", "release"]);
+        registry.register(skill).await.unwrap();
+
+        let got = registry.get("deploy").await;
+        assert!(got.is_some());
+        assert_eq!(got.unwrap().read().name(), "deploy");
+    }
+
+    #[tokio::test]
+    async fn test_register_duplicate() {
+        let registry = SkillRegistry::new();
+        registry.register(make_skill("dup", &["x"])).await.unwrap();
+        let result = registry.register(make_skill("dup", &["x"])).await;
+        assert!(matches!(result.unwrap_err(), SkillError::AlreadyExists(_)));
+    }
+
+    #[tokio::test]
+    async fn test_get_missing() {
+        let registry = SkillRegistry::new();
+        assert!(registry.get("nope").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_unregister() {
+        let registry = SkillRegistry::new();
+        registry.register(make_skill("rm", &["x"])).await.unwrap();
+        assert!(registry.unregister("rm").await);
+        assert!(!registry.unregister("rm").await);
+        assert!(registry.get("rm").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_len_and_is_empty() {
+        let registry = SkillRegistry::new();
+        assert!(registry.is_empty().await);
+        assert_eq!(registry.len().await, 0);
+
+        registry.register(make_skill("a", &["a"])).await.unwrap();
+        assert_eq!(registry.len().await, 1);
+        assert!(!registry.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_skill_names() {
+        let registry = SkillRegistry::new();
+        registry.register(make_skill("alpha", &["a"])).await.unwrap();
+        registry.register(make_skill("beta", &["b"])).await.unwrap();
+        let mut names = registry.skill_names().await;
+        names.sort();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[tokio::test]
+    async fn test_match_skills_single_hit() {
+        let registry = SkillRegistry::new();
+        registry
+            .register(make_skill("deploy", &["deploy", "k8s"]))
+            .await
+            .unwrap();
+        registry
+            .register(make_skill("test", &["test", "unit"]))
+            .await
+            .unwrap();
+
+        let matches = registry.match_skills("please deploy").await;
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].name, "deploy");
+        assert!(matches[0].score > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_match_skills_multiple_hits() {
+        let registry = SkillRegistry::new();
+        registry
+            .register(make_skill("deploy-k8s", &["deploy", "k8s"]))
+            .await
+            .unwrap();
+        registry
+            .register(make_skill("deploy-docker", &["deploy", "docker"]))
+            .await
+            .unwrap();
+
+        let matches = registry.match_skills("deploy k8s").await;
+        // Both match on "deploy", deploy-k8s also matches on "k8s"
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].name, "deploy-k8s");
+    }
+
+    #[tokio::test]
+    async fn test_match_skills_no_hits() {
+        let registry = SkillRegistry::new();
+        registry.register(make_skill("deploy", &["deploy"])).await.unwrap();
+        let matches = registry.match_skills("run tests").await;
+        assert!(matches.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_match_skills_sorted_by_score() {
+        let registry = SkillRegistry::new();
+        // high confidence skill
+        let mut s1 = make_skill("skill-a", &["search"]);
+        s1.update_confidence(crate::skill::ConfidenceEvent::UsedSuccessfully);
+        s1.update_confidence(crate::skill::ConfidenceEvent::UsedSuccessfully);
+
+        // low confidence skill
+        let mut s2 = make_skill("skill-b", &["search"]);
+        s2.update_confidence(crate::skill::ConfidenceEvent::UsedButFailed);
+
+        registry.register(s1).await.unwrap();
+        registry.register(s2).await.unwrap();
+
+        let matches = registry.match_skills("search").await;
+        assert_eq!(matches.len(), 2);
+        assert!(matches[0].score > matches[1].score);
+        assert_eq!(matches[0].name, "skill-a");
+    }
+
+    #[tokio::test]
+    async fn test_update_confidence() {
+        let registry = SkillRegistry::new();
+        registry.register(make_skill("conf", &["x"])).await.unwrap();
+        registry
+            .update_confidence("conf", crate::skill::ConfidenceEvent::UserConfirmed)
+            .await
+            .unwrap();
+
+        let skill = registry.get("conf").await.unwrap();
+        assert!(skill.read().confidence() > 0.5);
+    }
+
+    #[tokio::test]
+    async fn test_update_confidence_missing() {
+        let registry = SkillRegistry::new();
+        let result = registry
+            .update_confidence("ghost", crate::skill::ConfidenceEvent::UsedSuccessfully)
+            .await;
+        assert!(matches!(result.unwrap_err(), SkillError::NotFound(_)));
+    }
+}

--- a/crates/nanobot-skill/src/registry.rs
+++ b/crates/nanobot-skill/src/registry.rs
@@ -95,12 +95,20 @@ impl SkillRegistry {
             }
         }
 
-        matches.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        matches.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         matches
     }
 
     /// Update the confidence of a registered skill.
-    pub async fn update_confidence(&self, name: &str, event: crate::skill::ConfidenceEvent) -> SkillResult<()> {
+    pub async fn update_confidence(
+        &self,
+        name: &str,
+        event: crate::skill::ConfidenceEvent,
+    ) -> SkillResult<()> {
         let skills = self.skills.read().await;
         let skill = skills
             .get(name)
@@ -177,7 +185,10 @@ mod tests {
     #[tokio::test]
     async fn test_skill_names() {
         let registry = SkillRegistry::new();
-        registry.register(make_skill("alpha", &["a"])).await.unwrap();
+        registry
+            .register(make_skill("alpha", &["a"]))
+            .await
+            .unwrap();
         registry.register(make_skill("beta", &["b"])).await.unwrap();
         let mut names = registry.skill_names().await;
         names.sort();
@@ -223,7 +234,10 @@ mod tests {
     #[tokio::test]
     async fn test_match_skills_no_hits() {
         let registry = SkillRegistry::new();
-        registry.register(make_skill("deploy", &["deploy"])).await.unwrap();
+        registry
+            .register(make_skill("deploy", &["deploy"]))
+            .await
+            .unwrap();
         let matches = registry.match_skills("run tests").await;
         assert!(matches.is_empty());
     }

--- a/crates/nanobot-skill/src/skill.rs
+++ b/crates/nanobot-skill/src/skill.rs
@@ -1,0 +1,332 @@
+//! Core Skill trait and related types.
+//!
+//! The [`Skill`] trait is the primary abstraction. [`CompiledSkill`] is the default
+//! implementation backed by a TOML [`SkillManifest`](crate::SkillManifest).
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::error::SkillResult;
+
+/// Output produced by skill execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum SkillOutput {
+    /// Inject a prompt segment into the agent context.
+    PromptOnly {
+        /// The prompt text to inject.
+        segment: String,
+    },
+    /// Skill executed with a concrete result.
+    Executed {
+        /// Result text.
+        result: String,
+        /// Side effects produced (e.g. "file written to /tmp/x").
+        side_effects: Vec<String>,
+    },
+}
+
+/// Events that adjust a skill's confidence score.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum ConfidenceEvent {
+    /// Skill was used and helped produce a correct result.
+    UsedSuccessfully,
+    /// Skill was invoked but the result was wrong.
+    UsedButFailed,
+    /// User explicitly confirmed the output.
+    UserConfirmed,
+    /// User corrected the output, indicating the skill was imprecise.
+    UserCorrected,
+    /// Natural confidence decay over time (hours since last use).
+    TimeDecay {
+        /// Hours elapsed since last use.
+        hours: f64,
+    },
+}
+
+/// Asynchronous trait for a nanobot skill.
+#[async_trait]
+pub trait Skill: Send + Sync + 'static {
+    /// Unique skill name (kebab-case).
+    fn name(&self) -> &str;
+
+    /// Human-readable description.
+    fn description(&self) -> &str;
+
+    /// Skill category (defaults to "uncategorized").
+    fn category(&self) -> &str {
+        "uncategorized"
+    }
+
+    /// Current confidence score (0.0 – 1.0).
+    fn confidence(&self) -> f64;
+
+    /// Return a match score (0.0 – 1.0) for the given user input.
+    ///
+    /// Phase 1: keyword-based matching. Future phases: regex + semantic.
+    fn matches(&self, query: &str) -> f64;
+
+    /// Execute the skill with optional JSON arguments.
+    async fn execute(&self, args: serde_json::Value) -> SkillResult<SkillOutput>;
+
+    /// Update confidence based on a feedback event.
+    fn update_confidence(&mut self, event: ConfidenceEvent);
+}
+
+/// A skill compiled from a TOML manifest with keyword-based matching.
+#[derive(Debug, Clone)]
+pub struct CompiledSkill {
+    manifest: crate::SkillManifest,
+    confidence: f64,
+    usage_count: u64,
+}
+
+impl CompiledSkill {
+    /// Create a new compiled skill from a validated manifest.
+    pub fn new(manifest: crate::SkillManifest) -> Self {
+        Self {
+            manifest,
+            confidence: 0.5,
+            usage_count: 0,
+        }
+    }
+
+    /// Reference to the underlying manifest.
+    pub fn manifest(&self) -> &crate::SkillManifest {
+        &self.manifest
+    }
+
+    /// How many times this skill has been used.
+    pub fn usage_count(&self) -> u64 {
+        self.usage_count
+    }
+
+    /// Build the prompt segment from manifest steps and pitfalls.
+    fn build_prompt(&self) -> String {
+        let mut parts = Vec::new();
+
+        if !self.manifest.steps.is_empty() {
+            parts.push(format!("## Steps for {}", self.manifest.name));
+            for (i, step) in self.manifest.steps.iter().enumerate() {
+                parts.push(format!("{}. {step}", i + 1));
+            }
+        }
+
+        if !self.manifest.pitfalls.is_empty() {
+            parts.push("## Pitfalls".to_string());
+            for pit in &self.manifest.pitfalls {
+                parts.push(format!("- {pit}"));
+            }
+        }
+
+        parts.join("\n")
+    }
+}
+
+#[async_trait]
+impl Skill for CompiledSkill {
+    fn name(&self) -> &str {
+        &self.manifest.name
+    }
+
+    fn description(&self) -> &str {
+        &self.manifest.description
+    }
+
+    fn category(&self) -> &str {
+        &self.manifest.category
+    }
+
+    fn confidence(&self) -> f64 {
+        self.confidence
+    }
+
+    fn matches(&self, query: &str) -> f64 {
+        let query_lower = query.to_lowercase();
+        let mut hits = 0usize;
+        let total = self.manifest.triggers.len();
+
+        for keyword in &self.manifest.triggers {
+            if query_lower.contains(&keyword.to_lowercase()) {
+                hits += 1;
+            }
+        }
+
+        if total == 0 {
+            return 0.0;
+        }
+
+        let base = hits as f64 / total as f64;
+        // Weight by confidence: high-confidence skills rank above low-confidence ones
+        base * self.confidence
+    }
+
+    async fn execute(&self, _args: serde_json::Value) -> SkillResult<SkillOutput> {
+        Ok(SkillOutput::PromptOnly {
+            segment: self.build_prompt(),
+        })
+    }
+
+    fn update_confidence(&mut self, event: ConfidenceEvent) {
+        match event {
+            ConfidenceEvent::UsedSuccessfully => {
+                self.confidence = (self.confidence + 0.1).min(1.0);
+                self.usage_count += 1;
+            }
+            ConfidenceEvent::UsedButFailed => {
+                self.confidence = (self.confidence - 0.15).max(0.0);
+                self.usage_count += 1;
+            }
+            ConfidenceEvent::UserConfirmed => {
+                self.confidence = (self.confidence + 0.2).min(1.0);
+            }
+            ConfidenceEvent::UserCorrected => {
+                self.confidence = (self.confidence - 0.1).max(0.0);
+            }
+            ConfidenceEvent::TimeDecay { hours } => {
+                // Exponential decay: lose 1% per hour
+                let decay = (-0.01 * hours).exp();
+                self.confidence *= decay;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::SkillManifestBuilder;
+
+    fn test_manifest() -> crate::SkillManifest {
+        SkillManifestBuilder::new("test-skill", "1.0.0", "A test skill")
+            .triggers(["test", "example"])
+            .steps(["Do thing A", "Do thing B"])
+            .pitfalls(["Watch out for X"])
+            .category("testing")
+            .build()
+    }
+
+    fn test_skill() -> CompiledSkill {
+        CompiledSkill::new(test_manifest())
+    }
+
+    #[test]
+    fn test_name_description_category() {
+        let skill = test_skill();
+        assert_eq!(skill.name(), "test-skill");
+        assert_eq!(skill.description(), "A test skill");
+        assert_eq!(skill.category(), "testing");
+    }
+
+    #[test]
+    fn test_matches_hit() {
+        let skill = test_skill();
+        let score = skill.matches("please test this code");
+        assert!(score > 0.0, "should match on 'test' keyword");
+    }
+
+    #[test]
+    fn test_matches_case_insensitive() {
+        let skill = test_skill();
+        let score = skill.matches("TEST THIS");
+        assert!(score > 0.0);
+    }
+
+    #[test]
+    fn test_matches_miss() {
+        let skill = test_skill();
+        let score = skill.matches("deploy to production");
+        assert_eq!(score, 0.0, "no trigger keywords present");
+    }
+
+    #[test]
+    fn test_matches_partial_hit() {
+        let skill = test_skill();
+        // Only "test" matches, not "example"
+        let score = skill.matches("test");
+        let score_both = skill.matches("test example");
+        assert!(score_both > score);
+    }
+
+    #[tokio::test]
+    async fn test_execute_returns_prompt() {
+        let skill = test_skill();
+        let output = skill.execute(serde_json::Value::Null).await.unwrap();
+        match output {
+            SkillOutput::PromptOnly { segment } => {
+                assert!(segment.contains("Steps for test-skill"));
+                assert!(segment.contains("1. Do thing A"));
+                assert!(segment.contains("Watch out for X"));
+            }
+            _ => panic!("expected PromptOnly output"),
+        }
+    }
+
+    #[test]
+    fn test_confidence_update_success() {
+        let mut skill = test_skill();
+        let initial = skill.confidence();
+        skill.update_confidence(ConfidenceEvent::UsedSuccessfully);
+        assert!(skill.confidence() > initial);
+        assert_eq!(skill.usage_count(), 1);
+    }
+
+    #[test]
+    fn test_confidence_update_failed() {
+        let mut skill = test_skill();
+        let initial = skill.confidence();
+        skill.update_confidence(ConfidenceEvent::UsedButFailed);
+        assert!(skill.confidence() < initial);
+    }
+
+    #[test]
+    fn test_confidence_update_confirmed() {
+        let mut skill = test_skill();
+        let initial = skill.confidence();
+        skill.update_confidence(ConfidenceEvent::UserConfirmed);
+        assert!(skill.confidence() > initial);
+    }
+
+    #[test]
+    fn test_confidence_update_corrected() {
+        let mut skill = test_skill();
+        let initial = skill.confidence();
+        skill.update_confidence(ConfidenceEvent::UserCorrected);
+        assert!(skill.confidence() < initial);
+    }
+
+    #[test]
+    fn test_confidence_time_decay() {
+        let mut skill = test_skill();
+        skill.confidence = 0.8;
+        skill.update_confidence(ConfidenceEvent::TimeDecay { hours: 10.0 });
+        assert!(skill.confidence() < 0.8);
+    }
+
+    #[test]
+    fn test_confidence_clamps_high() {
+        let mut skill = test_skill();
+        skill.confidence = 0.95;
+        skill.update_confidence(ConfidenceEvent::UsedSuccessfully);
+        skill.update_confidence(ConfidenceEvent::UserConfirmed);
+        assert!(skill.confidence() <= 1.0);
+    }
+
+    #[test]
+    fn test_confidence_clamps_low() {
+        let mut skill = test_skill();
+        skill.confidence = 0.05;
+        skill.update_confidence(ConfidenceEvent::UsedButFailed);
+        skill.update_confidence(ConfidenceEvent::UsedButFailed);
+        assert!(skill.confidence() >= 0.0);
+    }
+
+    #[test]
+    fn test_build_prompt_empty_manifest() {
+        let manifest = SkillManifestBuilder::new("empty", "0.1.0", "no steps")
+            .triggers(["x"])
+            .build();
+        let skill = CompiledSkill::new(manifest);
+        let prompt = skill.build_prompt();
+        assert!(prompt.is_empty());
+    }
+}


### PR DESCRIPTION
## Skill System — nanobot-skill crate

Closes #7

### Components
- **SkillManifest**: TOML manifest with name, version, triggers, steps, pitfalls
- **Skill trait**: name(), description(), category(), confidence(), matches(), execute()
- **CompiledSkill**: Default impl with keyword matching, confidence decay
- **SkillRegistry**: Arc<AsyncRwLock<HashMap>> based registry with sorted matching
- **SkillCompiler**: TOML parsing → validated CompiledSkill
- **SkillLoader**: Directory scanning with TTL cache and reload

### Verification
- 68 tests passing
- 0 clippy warnings
- cargo check clean
