### PR TITLE
fix: resolve CI failures (compile error + security audit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/nanobot-tools/src/skill_loader.rs
+++ b/crates/nanobot-tools/src/skill_loader.rs
@@ -2348,7 +2348,7 @@ mod tests {
         // Give watcher time to detect change.
         std::thread::sleep(std::time::Duration::from_millis(500));
 
-        let _reloaded = loader.reload_changed().unwrap();
+        let reloaded = loader.reload_changed().unwrap();
         assert!(
             !reloaded.is_empty() || loader.get("watched").unwrap().instructions == "Updated.",
             "Expected reload after modification"


### PR DESCRIPTION
## Changes
- Fix compile error in skill_loader.rs: \ → \ on line 2351
- Update rustls-webpki 0.103.11 → 0.103.12 (RUSTSEC-2026-0098, RUSTSEC-2026-0099)

## Verification
- \ ✅
- \ — 228 passed ✅

Closes #24