### PR TITLE
feat(agent): serialize mutating tool execution for determinism

### DIFF
--- a/crates/nanobot-agent/src/runner.rs
+++ b/crates/nanobot-agent/src/runner.rs
@@ -12,7 +12,7 @@ use nanobot_providers::{CompletionRequest, ProviderRegistry};
 use nanobot_tools::ToolRegistry;
 use serde_json::Value;
 use std::sync::Arc;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Mutex};
 use tracing::{debug, info, warn};
 
 /// Callback for emitting events during agent execution.
@@ -25,6 +25,9 @@ pub struct AgentRunner {
     tools: Arc<ToolRegistry>,
     stream_tx: Option<broadcast::Sender<StreamChunk>>,
     event_callback: Option<Arc<EventCallback>>,
+    /// Guard that serializes execution of mutating tools. Read-only tools
+    /// bypass this lock and run concurrently.
+    mutating_guard: Arc<Mutex<()>>,
 }
 
 impl AgentRunner {
@@ -39,6 +42,7 @@ impl AgentRunner {
             tools,
             stream_tx: None,
             event_callback: None,
+            mutating_guard: Arc::new(Mutex::new(())),
         }
     }
 
@@ -289,7 +293,11 @@ impl AgentRunner {
         })
     }
 
-    /// Execute multiple tool calls concurrently.
+    /// Execute multiple tool calls, serializing mutating tools.
+    ///
+    /// Read-only tools run concurrently as before. Mutating tools each
+    /// acquire a shared mutex before executing, guaranteeing they run
+    /// one at a time even when the LLM issues several in a single turn.
     async fn execute_tools(&self, tool_calls: &[ToolCall]) -> Vec<String> {
         let mut handles = Vec::new();
 
@@ -297,14 +305,24 @@ impl AgentRunner {
             let tool_name = tc.function.name.clone();
             let args_str = tc.function.arguments.clone();
             let tools = self.tools.clone();
+            let guard = self.mutating_guard.clone();
+            let is_mutating = self.tools.is_mutating(&tool_name);
 
             let handle = tokio::spawn(async move {
                 let args: Value =
                     serde_json::from_str(&args_str).unwrap_or(Value::Object(Default::default()));
 
-                match tools.execute(&tool_name, args).await {
-                    Ok(result) => result,
-                    Err(e) => format!("Tool error: {}", e),
+                if is_mutating {
+                    let _lock = guard.lock().await;
+                    match tools.execute(&tool_name, args).await {
+                        Ok(result) => result,
+                        Err(e) => format!("Tool error: {}", e),
+                    }
+                } else {
+                    match tools.execute(&tool_name, args).await {
+                        Ok(result) => result,
+                        Err(e) => format!("Tool error: {}", e),
+                    }
                 }
             });
 
@@ -320,5 +338,211 @@ impl AgentRunner {
         }
 
         results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use nanobot_core::{FunctionCall, ToolCall as CoreToolCall};
+    use nanobot_tools::trait_def::{Tool, ToolError};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A mock tool that records how many times it runs and optionally
+    /// simulates work with a small sleep.
+    struct CountingTool {
+        name: &'static str,
+        mutating: bool,
+        counter: Arc<AtomicUsize>,
+        work_duration: std::time::Duration,
+    }
+
+    impl CountingTool {
+        fn new(name: &'static str, mutating: bool, counter: Arc<AtomicUsize>) -> Self {
+            Self {
+                name,
+                mutating,
+                counter,
+                work_duration: std::time::Duration::ZERO,
+            }
+        }
+
+        fn with_work_duration(mut self, d: std::time::Duration) -> Self {
+            self.work_duration = d;
+            self
+        }
+    }
+
+    #[async_trait]
+    impl Tool for CountingTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn description(&self) -> &str {
+            "counting tool"
+        }
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+        fn is_mutating(&self) -> bool {
+            self.mutating
+        }
+        async fn execute(&self, _args: Value) -> Result<String, ToolError> {
+            if !self.work_duration.is_zero() {
+                tokio::time::sleep(self.work_duration).await;
+            }
+            let count = self.counter.fetch_add(1, Ordering::SeqCst);
+            Ok(format!("{}-{}", self.name, count))
+        }
+    }
+
+    fn make_runner(tools: ToolRegistry) -> AgentRunner {
+        let config = Arc::new(Config::default());
+        let providers = Arc::new(ProviderRegistry::new());
+        let tools = Arc::new(tools);
+        AgentRunner::new(config, providers, tools)
+    }
+
+    fn tool_call(name: &str, id: usize) -> CoreToolCall {
+        CoreToolCall {
+            id: format!("call_{}", id),
+            call_type: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: "{}".to_string(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mutating_tools_execute_serially() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let registry = ToolRegistry::new();
+        registry.register(
+            CountingTool::new("write", true, counter.clone())
+                .with_work_duration(std::time::Duration::from_millis(50)),
+        );
+
+        let runner = make_runner(registry);
+
+        // Issue 3 mutating tool calls
+        let calls = vec![
+            tool_call("write", 1),
+            tool_call("write", 2),
+            tool_call("write", 3),
+        ];
+
+        let results = runner.execute_tools(&calls).await;
+
+        // All 3 must complete
+        assert_eq!(results.len(), 3);
+        // Counter must be exactly 3
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+        // Each result should be distinct (serialized execution)
+        assert!(results.iter().all(|r| r.starts_with("write-")));
+    }
+
+    #[tokio::test]
+    async fn test_readonly_tools_execute_concurrently() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let registry = ToolRegistry::new();
+        registry.register(
+            CountingTool::new("read", false, counter.clone())
+                .with_work_duration(std::time::Duration::from_millis(50)),
+        );
+
+        let runner = make_runner(registry);
+
+        // Issue 3 read-only tool calls
+        let calls = vec![
+            tool_call("read", 1),
+            tool_call("read", 2),
+            tool_call("read", 3),
+        ];
+
+        let start = std::time::Instant::now();
+        let results = runner.execute_tools(&calls).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+        // Concurrent execution: 3 × 50ms should complete well under 150ms
+        // (allowing some scheduling overhead, but definitely under the serial time)
+        assert!(
+            elapsed < std::time::Duration::from_millis(140),
+            "Read-only tools should run concurrently, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mixed_mutating_and_readonly() {
+        let write_counter = Arc::new(AtomicUsize::new(0));
+        let read_counter = Arc::new(AtomicUsize::new(0));
+        let registry = ToolRegistry::new();
+        registry.register(
+            CountingTool::new("write", true, write_counter.clone())
+                .with_work_duration(std::time::Duration::from_millis(50)),
+        );
+        registry.register(
+            CountingTool::new("read", false, read_counter.clone())
+                .with_work_duration(std::time::Duration::from_millis(50)),
+        );
+
+        let runner = make_runner(registry);
+
+        let calls = vec![
+            tool_call("write", 1),
+            tool_call("read", 1),
+            tool_call("write", 2),
+            tool_call("read", 2),
+        ];
+
+        let results = runner.execute_tools(&calls).await;
+
+        assert_eq!(results.len(), 4);
+        assert_eq!(write_counter.load(Ordering::SeqCst), 2);
+        assert_eq!(read_counter.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_single_mutating_tool_executes() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let registry = ToolRegistry::new();
+        registry.register(CountingTool::new("exec", true, counter.clone()));
+
+        let runner = make_runner(registry);
+
+        let calls = vec![tool_call("exec", 1)];
+        let results = runner.execute_tools(&calls).await;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(results[0], "exec-0");
+    }
+
+    #[tokio::test]
+    async fn test_empty_tool_calls() {
+        let registry = ToolRegistry::new();
+        let runner = make_runner(registry);
+
+        let calls: Vec<CoreToolCall> = vec![];
+        let results = runner.execute_tools(&calls).await;
+
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_unknown_tool_returns_error_string() {
+        let registry = ToolRegistry::new();
+        let runner = make_runner(registry);
+
+        let calls = vec![tool_call("nonexistent", 1)];
+        let results = runner.execute_tools(&calls).await;
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].contains("Tool error"));
+        assert!(results[0].contains("not found"));
     }
 }

--- a/crates/nanobot-tools/src/builtins/cron.rs
+++ b/crates/nanobot-tools/src/builtins/cron.rs
@@ -120,6 +120,10 @@ impl Tool for CronTool {
         })
     }
 
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, args: Value) -> Result<String, ToolError> {
         let action = args["action"]
             .as_str()

--- a/crates/nanobot-tools/src/builtins/filesystem.rs
+++ b/crates/nanobot-tools/src/builtins/filesystem.rs
@@ -99,6 +99,10 @@ impl Tool for WriteFileTool {
         "Write content to a file. Creates parent directories if needed."
     }
 
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
     fn parameters_schema(&self) -> Value {
         json!({
             "type": "object",
@@ -178,6 +182,10 @@ impl Tool for EditFileTool {
 
     fn description(&self) -> &str {
         "Edit a file by replacing exact text matches. Use for making targeted changes to existing files."
+    }
+
+    fn is_mutating(&self) -> bool {
+        true
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/nanobot-tools/src/builtins/message.rs
+++ b/crates/nanobot-tools/src/builtins/message.rs
@@ -67,6 +67,10 @@ impl Tool for MessageTool {
         })
     }
 
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, args: Value) -> Result<String, ToolError> {
         let content = args["content"]
             .as_str()

--- a/crates/nanobot-tools/src/builtins/mod.rs
+++ b/crates/nanobot-tools/src/builtins/mod.rs
@@ -37,3 +37,45 @@ pub fn register_all_with_config(registry: &ToolRegistry, config: BuiltinsConfig)
     registry.register(cron::CronTool::new());
     registry.register(spawn::SpawnTool::new());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builtin_mutating_classification() {
+        let registry = ToolRegistry::new();
+        register_all(&registry);
+
+        // Mutating tools
+        assert!(registry.is_mutating("exec"), "exec should be mutating");
+        assert!(registry.is_mutating("write_file"), "write_file should be mutating");
+        assert!(registry.is_mutating("edit_file"), "edit_file should be mutating");
+        assert!(registry.is_mutating("cron"), "cron should be mutating");
+        assert!(registry.is_mutating("spawn"), "spawn should be mutating");
+        assert!(
+            registry.is_mutating("send_message"),
+            "send_message should be mutating"
+        );
+
+        // Read-only tools
+        assert!(
+            !registry.is_mutating("read_file"),
+            "read_file should NOT be mutating"
+        );
+        assert!(
+            !registry.is_mutating("list_dir"),
+            "list_dir should NOT be mutating"
+        );
+        assert!(
+            !registry.is_mutating("web_search"),
+            "web_search should NOT be mutating"
+        );
+        assert!(
+            !registry.is_mutating("web_fetch"),
+            "web_fetch should NOT be mutating"
+        );
+        assert!(!registry.is_mutating("grep"), "grep should NOT be mutating");
+        assert!(!registry.is_mutating("glob"), "glob should NOT be mutating");
+    }
+}

--- a/crates/nanobot-tools/src/builtins/shell.rs
+++ b/crates/nanobot-tools/src/builtins/shell.rs
@@ -253,6 +253,10 @@ impl Tool for ExecTool {
         "default"
     }
 
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, args: Value) -> Result<String, ToolError> {
         let command = args["command"]
             .as_str()

--- a/crates/nanobot-tools/src/builtins/spawn.rs
+++ b/crates/nanobot-tools/src/builtins/spawn.rs
@@ -57,6 +57,10 @@ impl Tool for SpawnTool {
         })
     }
 
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, args: Value) -> Result<String, ToolError> {
         let task = args["task"]
             .as_str()

--- a/crates/nanobot-tools/src/registry.rs
+++ b/crates/nanobot-tools/src/registry.rs
@@ -80,6 +80,14 @@ impl ToolRegistry {
         self.tools.read().keys().cloned().collect()
     }
 
+    /// Check whether a tool is mutating by name.
+    ///
+    /// Returns `false` if the tool is not found (safe default for
+    /// unknown tools — they are treated as read-only and run in parallel).
+    pub fn is_mutating(&self, name: &str) -> bool {
+        self.tools.read().get(name).map(|t| t.is_mutating()).unwrap_or(false)
+    }
+
     /// Return the number of registered tools.
     pub fn len(&self) -> usize {
         self.tools.read().len()
@@ -335,5 +343,80 @@ mod tests {
         // Unregistering nonexistent should not panic
         registry.unregister("nonexistent");
         assert_eq!(registry.len(), 1);
+    }
+
+    // ── is_mutating tests ──────────────────────────────────────────
+
+    struct MutatingMockTool {
+        tool_name: &'static str,
+        mutating: bool,
+    }
+
+    #[async_trait]
+    impl Tool for MutatingMockTool {
+        fn name(&self) -> &str {
+            self.tool_name
+        }
+        fn description(&self) -> &str {
+            "mock mutating tool"
+        }
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+        fn is_mutating(&self) -> bool {
+            self.mutating
+        }
+        async fn execute(&self, _args: Value) -> Result<String, ToolError> {
+            Ok("mock result".to_string())
+        }
+    }
+
+    #[test]
+    fn test_registry_is_mutating_default_false() {
+        let registry = ToolRegistry::new();
+        registry.register(MockTool::new("readonly"));
+        assert!(!registry.is_mutating("readonly"));
+    }
+
+    #[test]
+    fn test_registry_is_mutating_explicit_true() {
+        let registry = ToolRegistry::new();
+        registry.register(MutatingMockTool {
+            tool_name: "writer",
+            mutating: true,
+        });
+        assert!(registry.is_mutating("writer"));
+    }
+
+    #[test]
+    fn test_registry_is_mutating_explicit_false() {
+        let registry = ToolRegistry::new();
+        registry.register(MutatingMockTool {
+            tool_name: "reader",
+            mutating: false,
+        });
+        assert!(!registry.is_mutating("reader"));
+    }
+
+    #[test]
+    fn test_registry_is_mutating_unknown_tool() {
+        let registry = ToolRegistry::new();
+        // Unknown tool should default to false (not mutating)
+        assert!(!registry.is_mutating("nonexistent"));
+    }
+
+    #[test]
+    fn test_registry_is_mutating_mixed() {
+        let registry = ToolRegistry::new();
+        registry.register(MutatingMockTool {
+            tool_name: "write",
+            mutating: true,
+        });
+        registry.register(MutatingMockTool {
+            tool_name: "read",
+            mutating: false,
+        });
+        assert!(registry.is_mutating("write"));
+        assert!(!registry.is_mutating("read"));
     }
 }

--- a/crates/nanobot-tools/src/trait_def.rs
+++ b/crates/nanobot-tools/src/trait_def.rs
@@ -50,6 +50,16 @@ pub trait Tool: Send + Sync {
         true
     }
 
+    /// Whether this tool mutates external state (files, shell, etc.).
+    ///
+    /// Mutating tools are serialized so only one runs at a time, preventing
+    /// race conditions when the LLM issues multiple state-changing calls
+    /// concurrently. Read-only tools (search, read, grep) return `false`
+    /// and run in parallel.
+    fn is_mutating(&self) -> bool {
+        false
+    }
+
     /// Required environment variables for this tool.
     fn required_env_vars(&self) -> Vec<&str> {
         vec![]
@@ -148,6 +158,28 @@ mod tests {
 
         let not_available = ToolError::NotAvailable("missing key".to_string());
         assert!(not_available.to_string().contains("missing key"));
+    }
+
+    #[test]
+    fn test_tool_is_mutating_default_is_false() {
+        struct DefaultTool;
+        #[async_trait]
+        impl Tool for DefaultTool {
+            fn name(&self) -> &str {
+                "default"
+            }
+            fn description(&self) -> &str {
+                "default tool"
+            }
+            fn parameters_schema(&self) -> Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(&self, _args: Value) -> Result<String, ToolError> {
+                Ok("ok".to_string())
+            }
+        }
+        let tool = DefaultTool;
+        assert!(!tool.is_mutating());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #26. Add Arc<Mutex> guard to serialize execution of mutating tools (Write, Shell, Cron, Spawn, Message, Filesystem). 235 tests pass, 0 clippy warnings.