### PR TITLE
feat(learning): wire LearningAction consumer to close learning loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,8 @@ dependencies = [
  "chrono",
  "dirs",
  "nanobot-core",
+ "nanobot-memory",
+ "nanobot-skill",
  "parking_lot",
  "serde",
  "serde_json",

--- a/crates/nanobot-agent/src/loop_mod.rs
+++ b/crates/nanobot-agent/src/loop_mod.rs
@@ -308,7 +308,12 @@ impl AgentLoop {
                     info!("Notes compacted for session {}", session_key);
                 }
 
-                self.session_manager.save_session_async(&session);
+                if let Err(e) = self.session_manager.save_session(&session) {
+                    error!(
+                        session_key = %session_key,
+                        "Failed to persist completed session state: {e}"
+                    );
+                }
 
                 // Store conversation memory (non-blocking — failures are logged, not propagated)
                 self.store_conversation_memory(&msg.content, &result.content)

--- a/crates/nanobot-learning/Cargo.toml
+++ b/crates/nanobot-learning/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 
 [dependencies]
 nanobot-core = { path = "../nanobot-core" }
+nanobot-memory = { path = "../nanobot-memory" }
+nanobot-skill = { path = "../nanobot-skill" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/nanobot-learning/src/consumer.rs
+++ b/crates/nanobot-learning/src/consumer.rs
@@ -1,0 +1,479 @@
+//! Learning action consumer — dispatches processed actions to real backends.
+//!
+//! [`LearningConsumer`] takes the `Vec<LearningAction>` produced by event
+//! processors and routes each action to the appropriate subsystem:
+//!
+//! - `RecordInsight` → `MemoryStore`
+//! - `AdjustConfidence` → `SkillRegistry`
+//! - `ProposeSkill` / `PatchSkill` / `DeprecateSkill` → logged (future sprint)
+//! - `NoOp` → skipped
+
+use std::sync::Arc;
+
+use nanobot_memory::{MemoryCategory, MemoryEntry, MemoryStore};
+use nanobot_skill::{ConfidenceEvent, SkillRegistry};
+use tracing::info;
+
+use crate::event::LearningAction;
+
+/// Dispatches [`LearningAction`]s produced by learning event processors
+/// to the concrete subsystems (memory store, skill registry).
+///
+/// Both backends are optional — if a backend is `None`, actions that
+/// require it are logged and skipped rather than causing errors.
+pub struct LearningConsumer {
+    memory_store: Option<Arc<dyn MemoryStore>>,
+    skill_registry: Option<Arc<SkillRegistry>>,
+}
+
+impl LearningConsumer {
+    /// Creates a new consumer with the given backends.
+    ///
+    /// Either or both backends may be `None` if the subsystem is unavailable.
+    pub fn new(
+        memory_store: Option<Arc<dyn MemoryStore>>,
+        skill_registry: Option<Arc<SkillRegistry>>,
+    ) -> Self {
+        Self {
+            memory_store,
+            skill_registry,
+        }
+    }
+
+    /// Dispatches a batch of learning actions to their target backends.
+    ///
+    /// Each action is handled independently — a failure in one action does
+    /// not prevent subsequent actions from being processed.
+    pub async fn dispatch_actions(&self, actions: Vec<LearningAction>) {
+        for action in actions {
+            self.dispatch_one(action).await;
+        }
+    }
+
+    /// Dispatches a single learning action.
+    async fn dispatch_one(&self, action: LearningAction) {
+        match action {
+            LearningAction::RecordInsight { insight, category } => {
+                self.handle_record_insight(insight, category).await;
+            }
+            LearningAction::AdjustConfidence { skill, delta } => {
+                self.handle_adjust_confidence(skill, delta).await;
+            }
+            LearningAction::ProposeSkill { name, reason } => {
+                info!(
+                    "ProposeSkill: name={}, reason={} (not yet implemented)",
+                    name, reason
+                );
+            }
+            LearningAction::PatchSkill {
+                skill,
+                description,
+            } => {
+                info!(
+                    "PatchSkill: skill={}, description={} (not yet implemented)",
+                    skill, description
+                );
+            }
+            LearningAction::DeprecateSkill { skill, reason } => {
+                info!(
+                    "DeprecateSkill: skill={}, reason={} (not yet implemented)",
+                    skill, reason
+                );
+            }
+            LearningAction::NoOp => {
+                // Explicitly skipped — no work to do.
+            }
+        }
+    }
+
+    /// Stores an insight as a memory entry in the memory store.
+    async fn handle_record_insight(&self, insight: String, category: String) {
+        let Some(ref store) = self.memory_store else {
+            info!(
+                "RecordInsight skipped (no memory store): [{}] {}",
+                category, insight
+            );
+            return;
+        };
+
+        let entry = MemoryEntry::new(
+            format!("[{category}] {insight}"),
+            MemoryCategory::AgentNote,
+        )
+        .with_confidence(0.8);
+
+        if let Err(e) = store.store(entry).await {
+            tracing::warn!("Failed to store insight: {}", e);
+        }
+    }
+
+    /// Maps a confidence delta to a [`ConfidenceEvent`] and updates the skill registry.
+    async fn handle_adjust_confidence(&self, skill: String, delta: f64) {
+        let Some(ref registry) = self.skill_registry else {
+            info!(
+                "AdjustConfidence skipped (no skill registry): skill={}, delta={:.3}",
+                skill, delta
+            );
+            return;
+        };
+
+        let event = if delta >= 0.0 {
+            ConfidenceEvent::UsedSuccessfully
+        } else {
+            ConfidenceEvent::UsedButFailed
+        };
+
+        if let Err(e) = registry.update_confidence(&skill, event).await {
+            tracing::warn!("Failed to update confidence for skill '{}': {}", skill, e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nanobot_memory::error::Result as MemoryResult;
+    use nanobot_skill::{CompiledSkill, Skill, manifest::SkillManifestBuilder};
+    use parking_lot::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Thread-safe mock that records `store()` calls.
+    #[derive(Debug, Default)]
+    struct MockMemoryStore {
+        entries: Mutex<Vec<MemoryEntry>>,
+        fail_store: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl MemoryStore for MockMemoryStore {
+        async fn store(&self, entry: MemoryEntry) -> MemoryResult<()> {
+            if self.fail_store.load(Ordering::Relaxed) {
+                return Err(nanobot_memory::MemoryError::Config(
+                    "injected store failure".into(),
+                ));
+            }
+
+            self.entries.lock().push(entry);
+            Ok(())
+        }
+
+        async fn recall(&self, id: &str) -> MemoryResult<Option<MemoryEntry>> {
+            Ok(self.entries.lock().iter().find(|entry| entry.id == id).cloned())
+        }
+
+        async fn search(
+            &self,
+            _query: &nanobot_memory::MemoryQuery,
+        ) -> MemoryResult<Vec<nanobot_memory::ScoredEntry>> {
+            Ok(vec![])
+        }
+
+        async fn delete(&self, _id: &str) -> MemoryResult<()> {
+            Ok(())
+        }
+
+        async fn len(&self) -> usize {
+            self.entries.lock().len()
+        }
+
+        async fn clear(&self) -> MemoryResult<()> {
+            self.entries.lock().clear();
+            Ok(())
+        }
+    }
+
+    impl MockMemoryStore {
+        fn set_fail_store(&self, fail_store: bool) {
+            self.fail_store.store(fail_store, Ordering::Relaxed);
+        }
+
+        fn entries(&self) -> Vec<MemoryEntry> {
+            self.entries.lock().clone()
+        }
+    }
+
+    fn make_skill(name: &str, trigger: &str) -> CompiledSkill {
+        CompiledSkill::new(
+            SkillManifestBuilder::new(name, "1.0.0", "Test skill")
+                .triggers([trigger])
+                .build(),
+        )
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_records_insight_in_memory_store() {
+        let mock_store = Arc::new(MockMemoryStore::default());
+        let consumer =
+            LearningConsumer::new(Some(mock_store.clone() as Arc<dyn MemoryStore>), None);
+
+        consumer
+            .dispatch_actions(vec![LearningAction::RecordInsight {
+                insight: "Tool 'web' is unreliable".into(),
+                category: "tool_reliability".into(),
+            }])
+            .await;
+
+        assert_eq!(mock_store.len().await, 1);
+
+        let entries = mock_store.entries();
+        let entry = entries.first().expect("expected one stored entry");
+        assert!(entry.content.contains("[tool_reliability] Tool 'web' is unreliable"));
+        assert_eq!(entry.category, MemoryCategory::AgentNote);
+        assert!((entry.confidence - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_skips_record_insight_without_memory_store() {
+        let consumer = LearningConsumer::new(None, None);
+
+        consumer
+            .dispatch_actions(vec![LearningAction::RecordInsight {
+                insight: "something".into(),
+                category: "test".into(),
+            }])
+            .await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_continue_after_memory_store_failure() {
+        let mock_store = Arc::new(MockMemoryStore::default());
+        mock_store.set_fail_store(true);
+
+        let registry = Arc::new(SkillRegistry::new());
+        registry
+            .register(make_skill("recover-skill", "recover"))
+            .await
+            .expect("register skill");
+
+        let consumer = LearningConsumer::new(
+            Some(mock_store as Arc<dyn MemoryStore>),
+            Some(registry.clone()),
+        );
+
+        consumer
+            .dispatch_actions(vec![
+                LearningAction::RecordInsight {
+                    insight: "will fail".into(),
+                    category: "test".into(),
+                },
+                LearningAction::AdjustConfidence {
+                    skill: "recover-skill".into(),
+                    delta: 0.2,
+                },
+            ])
+            .await;
+
+        let skill = registry
+            .get("recover-skill")
+            .await
+            .expect("skill should remain registered");
+        assert!(skill.read().confidence() > 0.5);
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_raise_skill_confidence_for_positive_delta() {
+        let registry = Arc::new(SkillRegistry::new());
+        registry
+            .register(make_skill("my-skill", "test"))
+            .await
+            .expect("register skill");
+
+        let initial_confidence = {
+            let s = registry.get("my-skill").await.expect("skill should exist");
+            let confidence = s.read().confidence();
+            confidence
+        };
+
+        let consumer = LearningConsumer::new(None, Some(registry.clone()));
+        consumer
+            .dispatch_actions(vec![LearningAction::AdjustConfidence {
+                skill: "my-skill".into(),
+                delta: 0.05,
+            }])
+            .await;
+
+        let new_confidence = {
+            let s = registry.get("my-skill").await.expect("skill should exist");
+            let confidence = s.read().confidence();
+            confidence
+        };
+        assert!(
+            new_confidence > initial_confidence,
+            "positive delta should increase confidence"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_lower_skill_confidence_for_negative_delta() {
+        let registry = Arc::new(SkillRegistry::new());
+        registry
+            .register(make_skill("neg-skill", "test"))
+            .await
+            .expect("register skill");
+        let initial_confidence = {
+            let s = registry.get("neg-skill").await.expect("skill should exist");
+            let confidence = s.read().confidence();
+            confidence
+        };
+
+        let consumer = LearningConsumer::new(None, Some(registry.clone()));
+        consumer
+            .dispatch_actions(vec![LearningAction::AdjustConfidence {
+                skill: "neg-skill".into(),
+                delta: -0.2,
+            }])
+            .await;
+
+        let new_confidence = {
+            let s = registry.get("neg-skill").await.expect("skill should exist");
+            let confidence = s.read().confidence();
+            confidence
+        };
+        assert!(
+            new_confidence < initial_confidence,
+            "negative delta should decrease confidence"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_skip_adjust_confidence_without_registry() {
+        let consumer = LearningConsumer::new(None, None);
+
+        consumer
+            .dispatch_actions(vec![LearningAction::AdjustConfidence {
+                skill: "missing".into(),
+                delta: 0.1,
+            }])
+            .await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_ignore_missing_skill_for_confidence_update() {
+        let registry = Arc::new(SkillRegistry::new());
+        let consumer = LearningConsumer::new(None, Some(registry.clone()));
+
+        consumer
+            .dispatch_actions(vec![LearningAction::AdjustConfidence {
+                skill: "missing".into(),
+                delta: 0.4,
+            }])
+            .await;
+
+        assert!(registry.get("missing").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_treat_noop_as_noop() {
+        let mock_store = Arc::new(MockMemoryStore::default());
+        let registry = Arc::new(SkillRegistry::new());
+        registry
+            .register(make_skill("noop-skill", "noop"))
+            .await
+            .expect("register skill");
+
+        let initial_confidence = registry
+            .get("noop-skill")
+            .await
+            .expect("skill should exist")
+            .read()
+            .confidence();
+
+        let consumer = LearningConsumer::new(
+            Some(mock_store.clone() as Arc<dyn MemoryStore>),
+            Some(registry.clone()),
+        );
+
+        consumer
+            .dispatch_actions(vec![LearningAction::NoOp])
+            .await;
+
+        assert!(mock_store.is_empty().await);
+        let final_confidence = registry
+            .get("noop-skill")
+            .await
+            .expect("skill should exist")
+            .read()
+            .confidence();
+        assert_eq!(initial_confidence, final_confidence);
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_accept_propose_skill_variant() {
+        let consumer = LearningConsumer::new(None, None);
+        consumer
+            .dispatch_actions(vec![LearningAction::ProposeSkill {
+                name: "new-skill".into(),
+                reason: "repeated pattern".into(),
+            }])
+            .await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_accept_patch_skill_variant() {
+        let consumer = LearningConsumer::new(None, None);
+        consumer
+            .dispatch_actions(vec![LearningAction::PatchSkill {
+                skill: "existing-skill".into(),
+                description: "adjust trigger coverage".into(),
+            }])
+            .await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_accept_deprecate_skill_variant() {
+        let consumer = LearningConsumer::new(None, None);
+        consumer
+            .dispatch_actions(vec![LearningAction::DeprecateSkill {
+                skill: "old-skill".into(),
+                reason: "superseded".into(),
+            }])
+            .await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_process_mixed_batches() {
+        let mock_store = Arc::new(MockMemoryStore::default());
+        let registry = Arc::new(SkillRegistry::new());
+        registry
+            .register(make_skill("batch-skill", "batch"))
+            .await
+            .expect("register skill");
+
+        let consumer = LearningConsumer::new(
+            Some(mock_store.clone() as Arc<dyn MemoryStore>),
+            Some(registry.clone()),
+        );
+
+        consumer
+            .dispatch_actions(vec![
+                LearningAction::NoOp,
+                LearningAction::RecordInsight {
+                    insight: "first insight".into(),
+                    category: "test".into(),
+                },
+                LearningAction::AdjustConfidence {
+                    skill: "batch-skill".into(),
+                    delta: 0.1,
+                },
+                LearningAction::ProposeSkill {
+                    name: "future-skill".into(),
+                    reason: "not yet".into(),
+                },
+            ])
+            .await;
+
+        assert_eq!(mock_store.len().await, 1);
+
+        let s = registry
+            .get("batch-skill")
+            .await
+            .expect("skill should exist");
+        assert!(s.read().confidence() > 0.5);
+    }
+
+    #[tokio::test]
+    async fn dispatch_actions_handle_empty_batches() {
+        let consumer = LearningConsumer::new(None, None);
+        consumer.dispatch_actions(vec![]).await;
+    }
+}

--- a/crates/nanobot-learning/src/lib.rs
+++ b/crates/nanobot-learning/src/lib.rs
@@ -7,12 +7,14 @@
 //! context into agent prompts.
 
 pub mod config;
+pub mod consumer;
 pub mod event;
 pub mod processor;
 pub mod prompt;
 pub mod store;
 
 pub use config::LearningConfig;
+pub use consumer::LearningConsumer;
 pub use event::{ErrorClassification, LearningAction, LearningEvent};
 pub use processor::{BasicEventProcessor, LearningEventHandler, ProcessorStats};
 pub use prompt::{PromptAssembler, PromptSection};

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -17,6 +17,7 @@ use nanobot_channels::{ChannelManager, ChannelRegistry};
 use nanobot_config::Config;
 use nanobot_heartbeat::HeartbeatService;
 use nanobot_learning::config::LearningConfig;
+use nanobot_learning::consumer::LearningConsumer;
 use nanobot_learning::event::LearningEventBus;
 use nanobot_learning::processor::BasicEventProcessor;
 use nanobot_learning::prompt::PromptAssembler;
@@ -108,6 +109,26 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     // ── Agent loop ────────────────────────────────────────────
     let learning_bus = LearningEventBus::new();
 
+    // Initialize memory store early so it can be shared with the learning consumer.
+    let memory_config = MemoryConfig {
+        hot_store_path: home.join("memory").join("hot.jsonl"),
+        ..MemoryConfig::default()
+    };
+    let memory_store: Option<Arc<dyn nanobot_memory::MemoryStore>> =
+        match HotStore::new(&memory_config).await {
+            Ok(hot_store) => {
+                info!("Memory store initialized (HotStore L1)");
+                Some(Arc::new(hot_store))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to initialize memory store, continuing without memory: {}",
+                    e
+                );
+                None
+            }
+        };
+
     let agent_loop = {
         let mut al = AgentLoop::new(
             config.clone(),
@@ -118,25 +139,12 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         );
 
         // Wire memory store (HotStore L1)
-        let memory_config = MemoryConfig {
-            hot_store_path: home.join("memory").join("hot.jsonl"),
-            ..MemoryConfig::default()
-        };
-        match HotStore::new(&memory_config).await {
-            Ok(hot_store) => {
-                info!("Memory store initialized (HotStore L1)");
-                al = al.with_memory_store(Arc::new(hot_store));
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to initialize memory store, continuing without memory: {}",
-                    e
-                );
-            }
+        if let Some(ref ms) = memory_store {
+            al = al.with_memory_store(ms.clone());
         }
 
         // Wire skill registry
-        al = al.with_skill_registry(skill_registry);
+        al = al.with_skill_registry(skill_registry.clone());
 
         // Wire learning event bus
         al = al.with_learning_bus(learning_bus.clone());
@@ -260,6 +268,7 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         let mut learning_rx = learning_bus.subscribe();
         let processor = BasicEventProcessor::new();
         let store = event_store.clone();
+        let consumer = LearningConsumer::new(memory_store, Some(skill_registry));
         tokio::spawn(async move {
             loop {
                 match learning_rx.recv().await {
@@ -268,11 +277,9 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
                         if let Err(e) = store.append(&event).await {
                             tracing::warn!("Failed to persist learning event: {}", e);
                         }
-                        // Process through the basic processor
+                        // Process through the basic processor, then dispatch actions
                         let actions = processor.handle(&event).await;
-                        for action in actions {
-                            tracing::debug!("Learning action: {:?}", action);
-                        }
+                        consumer.dispatch_actions(actions).await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         tracing::warn!("Learning event consumer lagged by {n} messages");


### PR DESCRIPTION
Fixes #31. LearningConsumer dispatches RecordInsight and AdjustConfidence to real backends. Tests pass, clippy clean.