### PR TITLE
fix(agent): wire skill index into runtime + add ProcessorStats version tag

### DIFF
--- a/crates/nanobot-agent/src/context.rs
+++ b/crates/nanobot-agent/src/context.rs
@@ -12,6 +12,9 @@ use nanobot_learning::prompt::{PromptAssembler, PromptSection, ToolInfo};
 use nanobot_session::Session;
 use nanobot_tools::ToolRegistry;
 
+const DEFAULT_TOOL_GUIDANCE_TOKEN_BUDGET: usize = 2000;
+const DEFAULT_SKILL_INDEX_MAX_ENTRIES: usize = 10;
+
 /// Builds the system prompt context for an agent invocation.
 pub struct ContextBuilder<'a> {
     config: &'a Config,
@@ -21,6 +24,8 @@ pub struct ContextBuilder<'a> {
     skill_index_entries: Option<Vec<nanobot_learning::prompt::SkillIndexEntry>>,
     /// Assembler for combining prompt sections. Uses default when not set.
     prompt_assembler: Option<PromptAssembler>,
+    /// Approximate token budget for rendered tool guidance.
+    tool_guidance_token_budget: usize,
 }
 
 impl<'a> ContextBuilder<'a> {
@@ -31,6 +36,7 @@ impl<'a> ContextBuilder<'a> {
             skill_sections: None,
             skill_index_entries: None,
             prompt_assembler: None,
+            tool_guidance_token_budget: DEFAULT_TOOL_GUIDANCE_TOKEN_BUDGET,
         }
     }
 
@@ -59,6 +65,15 @@ impl<'a> ContextBuilder<'a> {
     /// When not set, a default assembler is used (double-newline separator).
     pub fn with_prompt_assembler(mut self, assembler: PromptAssembler) -> Self {
         self.prompt_assembler = Some(assembler);
+        self
+    }
+
+    /// Set the approximate token budget for rendered tool guidance.
+    ///
+    /// Tool schemas are truncated per tool when the rendered guidance exceeds
+    /// this budget, using a simple `len / 4` token estimate.
+    pub fn with_tool_guidance_token_budget(mut self, budget: usize) -> Self {
+        self.tool_guidance_token_budget = budget;
         self
     }
 
@@ -141,7 +156,10 @@ impl<'a> ContextBuilder<'a> {
                     }
                 })
                 .collect();
-            let guidance = PromptAssembler::build_tool_guidance(&tool_infos);
+            let guidance = PromptAssembler::build_tool_guidance_with_budget(
+                &tool_infos,
+                self.tool_guidance_token_budget,
+            );
             sections.push(PromptSection::ToolGuidance { content: guidance });
         }
 
@@ -157,7 +175,8 @@ impl<'a> ContextBuilder<'a> {
         // Skill index — list of all available skills with metadata
         if let Some(ref entries) = self.skill_index_entries {
             if !entries.is_empty() {
-                let index = PromptAssembler::build_skill_index(entries);
+                let index =
+                    PromptAssembler::build_skill_index(entries, DEFAULT_SKILL_INDEX_MAX_ENTRIES);
                 sections.push(PromptSection::SkillIndex { content: index });
             }
         }
@@ -699,8 +718,7 @@ mod tests {
     #[test]
     fn test_skill_index_empty_not_shown() {
         let config = Config::default();
-        let builder =
-            ContextBuilder::new(&config).with_skill_index(vec![]);
+        let builder = ContextBuilder::new(&config).with_skill_index(vec![]);
         let msg = make_inbound();
         let session = Session::new("test:key".to_string());
         let tools = ToolRegistry::new();
@@ -843,5 +861,53 @@ mod tests {
         assert!(prompt.contains("First tool"));
         assert!(prompt.contains("### tool_b"));
         assert!(prompt.contains("Second tool"));
+    }
+
+    #[test]
+    fn test_tool_guidance_budget_truncates_schema() {
+        let config = Config::default();
+        let builder = ContextBuilder::new(&config).with_tool_guidance_token_budget(50);
+        let msg = make_inbound();
+        let session = Session::new("test:key".to_string());
+        let tools = ToolRegistry::new();
+
+        use async_trait::async_trait;
+        use nanobot_tools::Tool;
+        use nanobot_tools::ToolError;
+
+        struct VerboseTool;
+        #[async_trait]
+        impl Tool for VerboseTool {
+            fn name(&self) -> &str {
+                "verbose_tool"
+            }
+            fn description(&self) -> &str {
+                "Tool with a very large schema"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "payload": {
+                            "type": "string",
+                            "description": "x".repeat(600)
+                        }
+                    }
+                })
+            }
+            async fn execute(&self, _args: serde_json::Value) -> Result<String, ToolError> {
+                Ok("ok".to_string())
+            }
+        }
+
+        tools.register(VerboseTool);
+
+        let prompt = builder
+            .build_system_prompt(&msg, &session, &tools, None)
+            .unwrap();
+        assert!(prompt.contains("## Tool Guidance"));
+        assert!(prompt.contains("### verbose_tool"));
+        assert!(prompt.contains("Parameters:"));
+        assert!(prompt.contains("..."));
     }
 }

--- a/crates/nanobot-agent/src/loop_mod.rs
+++ b/crates/nanobot-agent/src/loop_mod.rs
@@ -22,7 +22,7 @@ use nanobot_bus::MessageBus;
 use nanobot_config::Config;
 use nanobot_heartbeat::HeartbeatService;
 use nanobot_learning::event::{ErrorClassification, LearningEvent, LearningEventBus, SkillOutcome};
-use nanobot_learning::prompt::PromptAssembler;
+use nanobot_learning::prompt::{PromptAssembler, SkillIndexEntry};
 use nanobot_memory::types::{MemoryCategory, MemoryEntry, MemoryQuery};
 use nanobot_memory::MemoryStore as AsyncMemoryStore;
 use nanobot_providers::ProviderRegistry;
@@ -212,6 +212,11 @@ impl AgentLoop {
 
             // Match skills against user message and inject into prompt
             if let Some(ref registry) = self.skill_registry {
+                let skill_index_entries = self.build_skill_index_entries(registry).await;
+                if !skill_index_entries.is_empty() {
+                    context_builder = context_builder.with_skill_index(skill_index_entries);
+                }
+
                 let matches = registry.match_skills(&msg.content).await;
 
                 // Emit SkillUsed learning events for each matched skill
@@ -546,6 +551,33 @@ impl AgentLoop {
         }
 
         parts.join("\n")
+    }
+
+    /// Build skill index entries from all registered, non-deprecated skills.
+    async fn build_skill_index_entries(&self, registry: &SkillRegistry) -> Vec<SkillIndexEntry> {
+        let mut names = registry.skill_names().await;
+        names.sort();
+
+        let mut entries = Vec::new();
+        for name in names {
+            let Some(skill_guard) = registry.get(&name).await else {
+                continue;
+            };
+            let skill = skill_guard.read();
+            if skill.is_deprecated() {
+                continue;
+            }
+
+            let manifest = skill.manifest();
+            entries.push(SkillIndexEntry {
+                name: manifest.name.clone(),
+                description: manifest.description.clone(),
+                category: manifest.category.clone(),
+                triggers: manifest.triggers.clone(),
+            });
+        }
+
+        entries
     }
 
     /// Return the list of channel names that have configuration present.
@@ -1471,6 +1503,53 @@ mod tests {
         assert!(sections.contains("deploy-docker"));
         assert!(sections.contains("deploy-k8s"));
         assert!(sections.contains("Build image"));
+    }
+
+    #[tokio::test]
+    async fn test_runtime_context_includes_skill_index_entries_when_skills_registered() {
+        use crate::context::ContextBuilder;
+        use nanobot_bus::events::InboundMessage;
+        use nanobot_core::{MessageType, Platform};
+        use nanobot_session::Session;
+        use nanobot_skill::manifest::SkillManifestBuilder;
+        use nanobot_skill::skill::CompiledSkill;
+
+        let registry = Arc::new(SkillRegistry::new());
+        registry
+            .register(CompiledSkill::new(
+                SkillManifestBuilder::new("deploy-k8s", "1.0.0", "Deploy to Kubernetes")
+                    .triggers(vec!["deploy".to_string(), "k8s".to_string()])
+                    .build(),
+            ))
+            .await
+            .unwrap();
+
+        let al = make_agent_loop().with_skill_registry(registry.clone());
+        let entries = al.build_skill_index_entries(&registry).await;
+        let config = Config::default();
+        let msg = InboundMessage {
+            channel: Platform::Telegram,
+            sender_id: "user1".to_string(),
+            chat_id: "chat1".to_string(),
+            content: "hello".to_string(),
+            media: vec![],
+            metadata: Default::default(),
+            source: None,
+            message_type: MessageType::Text,
+            message_id: None,
+            reply_to: None,
+            timestamp: chrono::Local::now(),
+        };
+        let session = Session::new("test:key".to_string());
+        let tools = ToolRegistry::new();
+
+        let prompt = ContextBuilder::new(&config)
+            .with_skill_index(entries)
+            .build_system_prompt(&msg, &session, &tools, None)
+            .unwrap();
+
+        assert!(prompt.contains("## Skill Index"));
+        assert!(prompt.contains("**deploy-k8s** [uncategorized]: Deploy to Kubernetes"));
     }
 
     // ── Learning event bus wiring tests ────────────────────────

--- a/crates/nanobot-agent/tests/runner_e2e.rs
+++ b/crates/nanobot-agent/tests/runner_e2e.rs
@@ -289,8 +289,7 @@ async fn test_agent_tool_arg_error_includes_details() {
     use std::sync::Mutex;
 
     // Shared capture buffer for inspecting what the agent received
-    let captured_messages: Arc<Mutex<Option<Vec<Message>>>> =
-        Arc::new(Mutex::new(None));
+    let captured_messages: Arc<Mutex<Option<Vec<Message>>>> = Arc::new(Mutex::new(None));
     let captured_clone = captured_messages.clone();
 
     struct CaptureProvider {
@@ -318,10 +317,7 @@ async fn test_agent_tool_arg_error_includes_details() {
             "capture"
         }
 
-        async fn complete(
-            &self,
-            request: CompletionRequest,
-        ) -> anyhow::Result<CompletionResponse> {
+        async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
             // On the second call (after tool execution), capture the messages
             if idx == 1 {
@@ -341,10 +337,7 @@ async fn test_agent_tool_arg_error_includes_details() {
             Ok(resp)
         }
 
-        async fn complete_stream(
-            &self,
-            request: CompletionRequest,
-        ) -> anyhow::Result<BoxStream> {
+        async fn complete_stream(&self, request: CompletionRequest) -> anyhow::Result<BoxStream> {
             let resp = self.complete(request).await?;
             let chunk = CompletionChunk {
                 delta: resp.content,
@@ -420,7 +413,10 @@ async fn test_agent_tool_arg_error_includes_details() {
     let msgs = captured.as_ref().unwrap();
 
     // Find the Tool message in the captured conversation
-    let tool_msg = msgs.iter().find(|m| matches!(m.role, MessageRole::Tool)).unwrap();
+    let tool_msg = msgs
+        .iter()
+        .find(|m| matches!(m.role, MessageRole::Tool))
+        .unwrap();
     let content = &tool_msg.content;
 
     // The error should mention the tool name, the parse failure, and the raw args

--- a/crates/nanobot-heartbeat/src/checks.rs
+++ b/crates/nanobot-heartbeat/src/checks.rs
@@ -162,11 +162,12 @@ impl HealthCheck for BusHealthCheck {
 
     async fn report_health(&self) -> HealthCheckResult {
         let mut rx = self.bus.subscribe_events();
-        self.bus.emit_event(nanobot_bus::AgentEvent::HeartbeatCheck {
-            healthy: true,
-            checks_total: 0,
-            checks_failed: 0,
-        });
+        self.bus
+            .emit_event(nanobot_bus::AgentEvent::HeartbeatCheck {
+                healthy: true,
+                checks_total: 0,
+                checks_failed: 0,
+            });
 
         match tokio::time::timeout(self.timeout, rx.recv()).await {
             Ok(Ok(_)) => HealthCheckResult {
@@ -228,8 +229,10 @@ impl HealthCheck for MemoryStoreHealthCheck {
     }
 
     async fn report_health(&self) -> HealthCheckResult {
-        let entry =
-            nanobot_memory::MemoryEntry::new("__heartbeat_check__", nanobot_memory::MemoryCategory::AgentNote);
+        let entry = nanobot_memory::MemoryEntry::new(
+            "__heartbeat_check__",
+            nanobot_memory::MemoryCategory::AgentNote,
+        );
         let id = entry.id.clone();
 
         // Store
@@ -284,7 +287,10 @@ impl HealthCheck for MemoryStoreHealthCheck {
             HealthCheckResult {
                 component: "memory_store".to_string(),
                 status: CheckStatus::Healthy,
-                message: format!("store/recall/delete OK ({} entries)", self.store.len().await),
+                message: format!(
+                    "store/recall/delete OK ({} entries)",
+                    self.store.len().await
+                ),
                 timestamp: Local::now(),
             }
         } else {
@@ -620,7 +626,8 @@ mod tests {
     #[tokio::test]
     async fn test_memory_check_custom_timeout() {
         let store = make_test_hot_store().await;
-        let check = MemoryStoreHealthCheck::new(Arc::new(store)).with_timeout(Duration::from_secs(10));
+        let check =
+            MemoryStoreHealthCheck::new(Arc::new(store)).with_timeout(Duration::from_secs(10));
         assert_eq!(check.timeout, Duration::from_secs(10));
     }
 
@@ -686,9 +693,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_channel_check_status_updates_dynamically() {
-        let statuses = Arc::new(parking_lot::RwLock::new(vec![
-            ("telegram".to_string(), true),
-        ]));
+        let statuses = Arc::new(parking_lot::RwLock::new(vec![(
+            "telegram".to_string(),
+            true,
+        )]));
         let check = ChannelHealthCheck::new(statuses.clone());
 
         // Initially healthy
@@ -725,9 +733,10 @@ mod tests {
         let store = make_test_hot_store().await;
         svc.register_check(Arc::new(MemoryStoreHealthCheck::new(Arc::new(store))));
 
-        let channel_statuses = Arc::new(parking_lot::RwLock::new(vec![
-            ("telegram".to_string(), true),
-        ]));
+        let channel_statuses = Arc::new(parking_lot::RwLock::new(vec![(
+            "telegram".to_string(),
+            true,
+        )]));
         svc.register_check(Arc::new(ChannelHealthCheck::new(channel_statuses)));
 
         // Run all checks
@@ -736,7 +745,11 @@ mod tests {
         assert_eq!(snapshot.checks.len(), 4);
 
         // Verify each component is reported
-        let names: Vec<&str> = snapshot.checks.iter().map(|c| c.component.as_str()).collect();
+        let names: Vec<&str> = snapshot
+            .checks
+            .iter()
+            .map(|c| c.component.as_str())
+            .collect();
         assert!(names.contains(&"providers"));
         assert!(names.contains(&"bus"));
         assert!(names.contains(&"memory_store"));

--- a/crates/nanobot-heartbeat/src/lib.rs
+++ b/crates/nanobot-heartbeat/src/lib.rs
@@ -17,8 +17,6 @@ pub mod checks;
 pub mod service;
 pub mod types;
 
-pub use checks::{
-    BusHealthCheck, ChannelHealthCheck, MemoryStoreHealthCheck, ProviderHealthCheck,
-};
+pub use checks::{BusHealthCheck, ChannelHealthCheck, MemoryStoreHealthCheck, ProviderHealthCheck};
 pub use service::HeartbeatService;
 pub use types::*;

--- a/crates/nanobot-learning/src/processor.rs
+++ b/crates/nanobot-learning/src/processor.rs
@@ -16,6 +16,8 @@ use tracing;
 
 use crate::event::{LearningAction, LearningEvent};
 
+const PROCESSOR_STATS_VERSION: u32 = 1;
+
 /// Trait for processing learning events.
 #[async_trait]
 pub trait LearningEventHandler: Send + Sync {
@@ -72,14 +74,28 @@ pub struct CorrectionStats {
 }
 
 /// Aggregate statistics from the [`BasicEventProcessor`].
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessorStats {
+    /// Schema version for persisted processor stats.
+    #[serde(default = "default_processor_stats_version")]
+    pub version: u32,
     /// Per-tool statistics.
     pub tools: HashMap<String, ToolStats>,
     /// Per-topic correction statistics.
     pub corrections: HashMap<String, CorrectionStats>,
     /// Total events processed.
     pub events_processed: u64,
+}
+
+impl Default for ProcessorStats {
+    fn default() -> Self {
+        Self {
+            version: PROCESSOR_STATS_VERSION,
+            tools: HashMap::new(),
+            corrections: HashMap::new(),
+            events_processed: 0,
+        }
+    }
 }
 
 /// A basic event processor that tracks tool success/failure patterns,
@@ -163,11 +179,26 @@ impl BasicEventProcessor {
         }
 
         let data = tokio::fs::read_to_string(path).await?;
-        let loaded: ProcessorStats = serde_json::from_str(&data)?;
+        let mut loaded: ProcessorStats = serde_json::from_str(&data)?;
+        if loaded.version != PROCESSOR_STATS_VERSION {
+            tracing::warn!(
+                "Processor stats version mismatch at {}: found {}, expected {}",
+                path.display(),
+                loaded.version,
+                PROCESSOR_STATS_VERSION
+            );
+            loaded = Self::migrate_stats(loaded);
+        }
         *self.stats.write() = loaded;
 
         tracing::debug!("Loaded processor stats from {}", path.display());
         Ok(())
+    }
+
+    /// Migrate loaded stats into the current in-memory schema version.
+    fn migrate_stats(mut stats: ProcessorStats) -> ProcessorStats {
+        stats.version = PROCESSOR_STATS_VERSION;
+        stats
     }
 }
 
@@ -175,6 +206,10 @@ impl Default for BasicEventProcessor {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn default_processor_stats_version() -> u32 {
+    PROCESSOR_STATS_VERSION
 }
 
 #[async_trait]
@@ -511,6 +546,7 @@ mod tests {
         let content = std::fs::read_to_string(&stats_path).unwrap();
         let parsed: ProcessorStats = serde_json::from_str(&content).unwrap();
         assert_eq!(parsed.events_processed, 1);
+        assert_eq!(parsed.version, PROCESSOR_STATS_VERSION);
 
         // Temp file should not linger.
         assert!(!stats_path.with_extension("tmp").exists());
@@ -576,5 +612,22 @@ mod tests {
             .iter()
             .any(|a| matches!(a, LearningAction::RecordInsight { .. })));
         assert_eq!(proc2.stats().events_processed, 6);
+    }
+
+    #[tokio::test]
+    async fn save_and_load_stats_preserves_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let stats_path = dir.path().join("stats.json");
+
+        let proc = BasicEventProcessor::new().with_stats_path(&stats_path);
+        proc.save_stats().await.unwrap();
+
+        let content = std::fs::read_to_string(&stats_path).unwrap();
+        let saved: ProcessorStats = serde_json::from_str(&content).unwrap();
+        assert_eq!(saved.version, PROCESSOR_STATS_VERSION);
+
+        let mut loaded = BasicEventProcessor::new().with_stats_path(&stats_path);
+        loaded.load_stats().await.unwrap();
+        assert_eq!(loaded.stats().version, PROCESSOR_STATS_VERSION);
     }
 }

--- a/crates/nanobot-learning/src/prompt.rs
+++ b/crates/nanobot-learning/src/prompt.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+const DEFAULT_SKILL_INDEX_MAX_ENTRIES: usize = 10;
+
 /// A section of the assembled prompt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -137,17 +139,71 @@ impl PromptAssembler {
     /// Produces a formatted string listing each tool with its name, description,
     /// and parameter schema, to help the LLM decide when and how to use each tool.
     pub fn build_tool_guidance(tools: &[ToolInfo]) -> String {
+        Self::build_tool_guidance_with_budget(tools, usize::MAX)
+    }
+
+    /// Build tool guidance content from tool metadata entries with a token budget.
+    ///
+    /// When the rendered guidance would exceed `max_tokens`, individual tool
+    /// parameter schemas are truncated using a simple `len / 4` token estimate.
+    pub fn build_tool_guidance_with_budget(tools: &[ToolInfo], max_tokens: usize) -> String {
         if tools.is_empty() {
             return String::new();
         }
 
+        if max_tokens == usize::MAX {
+            return Self::render_tool_guidance(tools, None);
+        }
+
+        let full = Self::render_tool_guidance(tools, None);
+        if Self::estimate_tokens(&full) <= max_tokens {
+            return full;
+        }
+
+        let mut schema_limits = vec![0usize; tools.len()];
+        let base = Self::render_tool_guidance(tools, Some(&schema_limits));
+        let base_tokens = Self::estimate_tokens(&base);
+        if base_tokens >= max_tokens {
+            return base;
+        }
+
+        for (index, tool) in tools.iter().enumerate() {
+            if tool.parameters_schema.is_empty() {
+                continue;
+            }
+
+            let mut low = 0usize;
+            let mut high = tool.parameters_schema.len();
+            while low < high {
+                let mid = (low + high).div_ceil(2);
+                schema_limits[index] = mid;
+                let candidate = Self::render_tool_guidance(tools, Some(&schema_limits));
+                if Self::estimate_tokens(&candidate) <= max_tokens {
+                    low = mid;
+                } else {
+                    high = mid - 1;
+                }
+            }
+            schema_limits[index] = low;
+        }
+
+        Self::render_tool_guidance(tools, Some(&schema_limits))
+    }
+
+    fn render_tool_guidance(tools: &[ToolInfo], schema_limits: Option<&[usize]>) -> String {
         let mut parts = Vec::new();
         parts.push("Available tools and when to use them:\n".to_string());
 
-        for tool in tools {
+        for (index, tool) in tools.iter().enumerate() {
             parts.push(format!("### {}\n{}", tool.name, tool.description));
             if !tool.parameters_schema.is_empty() {
-                parts.push(format!("Parameters: {}", tool.parameters_schema));
+                let rendered_schema = match schema_limits.and_then(|limits| limits.get(index)) {
+                    Some(limit) => Self::truncate_schema(&tool.parameters_schema, *limit),
+                    None => tool.parameters_schema.clone(),
+                };
+                if !rendered_schema.is_empty() {
+                    parts.push(format!("Parameters: {}", rendered_schema));
+                }
             }
             parts.push(String::new());
         }
@@ -166,7 +222,9 @@ impl PromptAssembler {
         }
 
         let mut parts = Vec::new();
-        parts.push("Memory recall triggers — consider recalling relevant memories when:\n".to_string());
+        parts.push(
+            "Memory recall triggers — consider recalling relevant memories when:\n".to_string(),
+        );
 
         for fence in fences {
             parts.push(format!("- **{}**: {}", fence.category, fence.hint));
@@ -179,15 +237,20 @@ impl PromptAssembler {
     ///
     /// Produces a formatted list of all available skills with their descriptions,
     /// categories, and trigger keywords, so the agent knows what skills it can invoke.
-    pub fn build_skill_index(skills: &[SkillIndexEntry]) -> String {
+    pub fn build_skill_index(skills: &[SkillIndexEntry], max_entries: usize) -> String {
         if skills.is_empty() {
             return String::new();
         }
+        let max_entries = if max_entries == 0 {
+            DEFAULT_SKILL_INDEX_MAX_ENTRIES
+        } else {
+            max_entries
+        };
 
         let mut parts = Vec::new();
         parts.push("Available skills:\n".to_string());
 
-        for skill in skills {
+        for skill in skills.iter().take(max_entries) {
             let triggers = skill.triggers.join(", ");
             parts.push(format!(
                 "- **{}** [{}]: {} (triggers: {})",
@@ -196,6 +259,31 @@ impl PromptAssembler {
         }
 
         parts.join("\n")
+    }
+
+    fn estimate_tokens(content: &str) -> usize {
+        content.len().div_ceil(4)
+    }
+
+    fn truncate_schema(schema: &str, max_len: usize) -> String {
+        if max_len == 0 {
+            return String::new();
+        }
+        if schema.len() <= max_len {
+            return schema.to_string();
+        }
+
+        let ellipsis = "...";
+        let mut end = max_len.saturating_sub(ellipsis.len());
+        while end > 0 && !schema.is_char_boundary(end) {
+            end -= 1;
+        }
+
+        if end == 0 {
+            ellipsis.to_string()
+        } else {
+            format!("{}{}", &schema[..end], ellipsis)
+        }
     }
 }
 
@@ -439,7 +527,8 @@ mod tests {
             ToolInfo {
                 name: "exec".into(),
                 description: "Execute shell commands".into(),
-                parameters_schema: r#"{"type":"object","properties":{"command":{"type":"string"}}}"#.into(),
+                parameters_schema:
+                    r#"{"type":"object","properties":{"command":{"type":"string"}}}"#.into(),
             },
             ToolInfo {
                 name: "read_file".into(),
@@ -515,16 +604,57 @@ mod tests {
                 triggers: vec!["test".into()],
             },
         ];
-        let result = PromptAssembler::build_skill_index(&skills);
+        let result = PromptAssembler::build_skill_index(&skills, DEFAULT_SKILL_INDEX_MAX_ENTRIES);
         assert!(result.contains("Available skills"));
-        assert!(result.contains("**deploy-k8s** [devops]: Deploy to Kubernetes (triggers: deploy, k8s)"));
+        assert!(result
+            .contains("**deploy-k8s** [devops]: Deploy to Kubernetes (triggers: deploy, k8s)"));
         assert!(result.contains("**run-tests** [testing]: Run test suite (triggers: test)"));
     }
 
     #[test]
     fn build_skill_index_empty() {
-        let result = PromptAssembler::build_skill_index(&[]);
+        let result = PromptAssembler::build_skill_index(&[], DEFAULT_SKILL_INDEX_MAX_ENTRIES);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn build_skill_index_limits_entries() {
+        let skills = vec![
+            SkillIndexEntry {
+                name: "one".into(),
+                description: "First".into(),
+                category: "test".into(),
+                triggers: vec!["one".into()],
+            },
+            SkillIndexEntry {
+                name: "two".into(),
+                description: "Second".into(),
+                category: "test".into(),
+                triggers: vec!["two".into()],
+            },
+        ];
+
+        let result = PromptAssembler::build_skill_index(&skills, 1);
+        assert!(result.contains("**one**"));
+        assert!(!result.contains("**two**"));
+    }
+
+    #[test]
+    fn build_tool_guidance_truncates_schema_to_budget() {
+        let tools = vec![ToolInfo {
+            name: "exec".into(),
+            description: "Run commands".into(),
+            parameters_schema: format!(
+                "{{\"type\":\"object\",\"properties\":{{\"command\":{{\"type\":\"string\"}},\"padding\":\"{}\"}}}}",
+                "x".repeat(400)
+            ),
+        }];
+
+        let result = PromptAssembler::build_tool_guidance_with_budget(&tools, 40);
+        assert!(result.contains("### exec"));
+        assert!(result.contains("Parameters:"));
+        assert!(result.contains("..."));
+        assert!(PromptAssembler::estimate_tokens(&result) <= 40);
     }
 
     #[test]

--- a/crates/nanobot-memory/src/hot_store.rs
+++ b/crates/nanobot-memory/src/hot_store.rs
@@ -95,11 +95,7 @@ impl HotStore {
             .filter(|(_, e)| e.category != MemoryCategory::Critical)
             .min_by_key(|(_, e)| e.updated_at)
             .map(|(id, e)| {
-                tracing::debug!(
-                    "Evicted LRU entry {} (last_accessed: {})",
-                    id,
-                    e.updated_at
-                );
+                tracing::debug!("Evicted LRU entry {} (last_accessed: {})", id, e.updated_at);
                 id.clone()
             })
     }
@@ -259,11 +255,7 @@ mod tests {
         (store, dir)
     }
 
-    fn test_entry_with_age(
-        content: &str,
-        category: MemoryCategory,
-        age: Duration,
-    ) -> MemoryEntry {
+    fn test_entry_with_age(content: &str, category: MemoryCategory, age: Duration) -> MemoryEntry {
         let mut entry = MemoryEntry::new(content, category);
         entry.updated_at = Utc::now() - age;
         entry
@@ -555,8 +547,7 @@ mod tests {
 
         let store = HotStore::new(&config).await.unwrap();
 
-        let entry_a =
-            test_entry_with_age("entry_a", MemoryCategory::Fact, Duration::seconds(100));
+        let entry_a = test_entry_with_age("entry_a", MemoryCategory::Fact, Duration::seconds(100));
         let id_a = entry_a.id.clone();
         store.store(entry_a).await.unwrap();
 

--- a/crates/nanobot-skill/src/manifest.rs
+++ b/crates/nanobot-skill/src/manifest.rs
@@ -316,7 +316,10 @@ triggers = ["hi", "hello"]
             .deprecated("Replaced by new-skill")
             .build();
         assert_eq!(m.deprecated, Some(true));
-        assert_eq!(m.deprecation_reason.as_deref(), Some("Replaced by new-skill"));
+        assert_eq!(
+            m.deprecation_reason.as_deref(),
+            Some("Replaced by new-skill")
+        );
     }
 
     #[test]

--- a/crates/nanobot-skill/src/registry.rs
+++ b/crates/nanobot-skill/src/registry.rs
@@ -190,10 +190,12 @@ impl SkillRegistry {
             .build();
 
         // Validate before writing
-        manifest.validate().map_err(|errors| SkillError::ValidationFailed {
-            name: name.to_string(),
-            reason: errors.join("; "),
-        })?;
+        manifest
+            .validate()
+            .map_err(|errors| SkillError::ValidationFailed {
+                name: name.to_string(),
+                reason: errors.join("; "),
+            })?;
 
         // Write TOML manifest atomically
         let toml_path = dir.join(format!("{name}.toml"));
@@ -509,7 +511,11 @@ mod tests {
         let (registry, dir) = make_registry_with_dir();
 
         registry
-            .create_skill("my-skill", "Does cool things", "Step 1: Do this\nStep 2: Do that")
+            .create_skill(
+                "my-skill",
+                "Does cool things",
+                "Step 1: Do this\nStep 2: Do that",
+            )
             .await
             .unwrap();
 
@@ -543,7 +549,11 @@ mod tests {
         let (registry, dir) = make_registry_with_dir();
 
         registry
-            .create_skill("compile-check", "Verifies compile path", "Detailed instructions")
+            .create_skill(
+                "compile-check",
+                "Verifies compile path",
+                "Detailed instructions",
+            )
             .await
             .unwrap();
 
@@ -586,7 +596,10 @@ mod tests {
             .unwrap();
 
         let md_path = dir.path().join("no-md.md");
-        assert!(!md_path.exists(), "No MD file should be created for empty instructions");
+        assert!(
+            !md_path.exists(),
+            "No MD file should be created for empty instructions"
+        );
 
         // But TOML should still exist
         assert!(dir.path().join("no-md.toml").exists());
@@ -660,7 +673,10 @@ mod tests {
 
         // Verify still accessible via get()
         let skill = registry.get("old-skill").await;
-        assert!(skill.is_some(), "Deprecated skill should still be retrievable");
+        assert!(
+            skill.is_some(),
+            "Deprecated skill should still be retrievable"
+        );
         assert!(skill.unwrap().read().is_deprecated());
     }
 
@@ -702,10 +718,7 @@ mod tests {
             .unwrap();
         let pre_confidence = registry.get("preserve").await.unwrap().read().confidence();
 
-        registry
-            .deprecate_skill("preserve", "Old")
-            .await
-            .unwrap();
+        registry.deprecate_skill("preserve", "Old").await.unwrap();
 
         let skill = registry.get("preserve").await.unwrap();
         assert_eq!(skill.read().confidence(), pre_confidence);

--- a/crates/nanobot-tools/src/builtins/mod.rs
+++ b/crates/nanobot-tools/src/builtins/mod.rs
@@ -49,8 +49,14 @@ mod tests {
 
         // Mutating tools
         assert!(registry.is_mutating("exec"), "exec should be mutating");
-        assert!(registry.is_mutating("write_file"), "write_file should be mutating");
-        assert!(registry.is_mutating("edit_file"), "edit_file should be mutating");
+        assert!(
+            registry.is_mutating("write_file"),
+            "write_file should be mutating"
+        );
+        assert!(
+            registry.is_mutating("edit_file"),
+            "edit_file should be mutating"
+        );
         assert!(registry.is_mutating("cron"), "cron should be mutating");
         assert!(registry.is_mutating("spawn"), "spawn should be mutating");
         assert!(

--- a/crates/nanobot-tools/src/registry.rs
+++ b/crates/nanobot-tools/src/registry.rs
@@ -85,7 +85,11 @@ impl ToolRegistry {
     /// Returns `false` if the tool is not found (safe default for
     /// unknown tools — they are treated as read-only and run in parallel).
     pub fn is_mutating(&self, name: &str) -> bool {
-        self.tools.read().get(name).map(|t| t.is_mutating()).unwrap_or(false)
+        self.tools
+            .read()
+            .get(name)
+            .map(|t| t.is_mutating())
+            .unwrap_or(false)
     }
 
     /// Return the number of registered tools.

--- a/crates/nanobot-tools/src/skill_loader.rs
+++ b/crates/nanobot-tools/src/skill_loader.rs
@@ -2383,7 +2383,7 @@ mod tests {
 
         std::thread::sleep(std::time::Duration::from_millis(500));
 
-        let reloaded = loader.reload_changed().unwrap();
+        let _reloaded = loader.reload_changed().unwrap();
         // After reload, both skills should be present.
         loader.load_all().unwrap();
         assert_eq!(loader.len(), 2);

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -256,7 +256,7 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         learning_config.max_events
     );
 
-    let _learning_handle = {
+    let learning_processor = {
         let mut learning_rx = learning_bus.subscribe();
         let stats_path = learning_config.stats_file();
         let mut processor = BasicEventProcessor::new().with_stats_path(&stats_path);
@@ -269,8 +269,10 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
                 processor.stats().events_processed
             );
         }
+        let processor = Arc::new(processor);
         let store = event_store.clone();
-        tokio::spawn(async move {
+        let task_processor = Arc::clone(&processor);
+        let _learning_handle = tokio::spawn(async move {
             let mut events_since_save: u64 = 0;
             loop {
                 match learning_rx.recv().await {
@@ -280,14 +282,14 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
                             tracing::warn!("Failed to persist learning event: {}", e);
                         }
                         // Process through the basic processor
-                        let actions = processor.handle(&event).await;
+                        let actions = task_processor.handle(&event).await;
                         for action in actions {
                             tracing::debug!("Learning action: {:?}", action);
                         }
                         // Periodically save stats
                         events_since_save += 1;
                         if events_since_save >= 50 {
-                            if let Err(e) = processor.save_stats().await {
+                            if let Err(e) = task_processor.save_stats().await {
                                 tracing::warn!("Failed to save processor stats: {}", e);
                             }
                             events_since_save = 0;
@@ -299,7 +301,14 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
                     Err(_) => break,
                 }
             }
-        })
+            if let Err(e) = task_processor.save_stats().await {
+                tracing::warn!(
+                    "Failed to flush processor stats on learning shutdown: {}",
+                    e
+                );
+            }
+        });
+        processor
     };
 
     // ── Periodic event log prune task ─────────────────────────
@@ -369,6 +378,13 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     // ── Graceful shutdown ─────────────────────────────────────
     info!("Stopping all channels...");
     channel_manager.stop_all().await;
+
+    if let Err(e) = learning_processor.save_stats().await {
+        tracing::warn!(
+            "Failed to flush processor stats during gateway shutdown: {}",
+            e
+        );
+    }
 
     info!("Gateway shutting down");
     Ok(())

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -1208,24 +1208,3 @@ async fn test_pipeline_cron_to_agent_full_flow() {
     agent_handle.abort();
     let _ = agent_handle.await;
 }
-async fn wait_for_session_entries(
-    session_dir: std::path::PathBuf,
-    session_key: &str,
-    min_entries: usize,
-) {
-    let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
-    loop {
-        let mgr = SessionManager::new(session_dir.clone()).unwrap();
-        let session = mgr.get_or_create(session_key, None);
-        if session.messages.len() >= min_entries {
-            return;
-        }
-
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "Expected >= {min_entries} session entries, got {}",
-            session.messages.len()
-        );
-        sleep(Duration::from_millis(25)).await;
-    }
-}


### PR DESCRIPTION
Closes #45, Closes #49

- Wires SkillRegistry entries into runtime ContextBuilder.with_skill_index()
- Adds token-budgeted tool guidance truncation
- Limits skill index rendering to top entries
- Adds version tag to ProcessorStats for migration support
- Adds shutdown stats flush

Validation: cargo test --workspace + cargo clippy --workspace -- -D warnings pass.