### PR TITLE
feat(learning): execute LearningActions in gateway consumer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 parking_lot = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/nanobot-agent/src/context.rs
+++ b/crates/nanobot-agent/src/context.rs
@@ -22,6 +22,8 @@ pub struct ContextBuilder<'a> {
     skill_sections: Option<String>,
     /// Optional skill index entries for listing available skills.
     skill_index_entries: Option<Vec<nanobot_learning::prompt::SkillIndexEntry>>,
+    /// Optional prompt adjustment content learned from prior turns.
+    prompt_adjustment: Option<String>,
     /// Assembler for combining prompt sections. Uses default when not set.
     prompt_assembler: Option<PromptAssembler>,
     /// Approximate token budget for rendered tool guidance.
@@ -35,6 +37,7 @@ impl<'a> ContextBuilder<'a> {
             config,
             skill_sections: None,
             skill_index_entries: None,
+            prompt_adjustment: None,
             prompt_assembler: None,
             tool_guidance_token_budget: DEFAULT_TOOL_GUIDANCE_TOKEN_BUDGET,
         }
@@ -56,6 +59,12 @@ impl<'a> ContextBuilder<'a> {
         entries: Vec<nanobot_learning::prompt::SkillIndexEntry>,
     ) -> Self {
         self.skill_index_entries = Some(entries);
+        self
+    }
+
+    /// Attach prompt adjustment guidance learned from previous turns.
+    pub fn with_prompt_adjustment(mut self, adjustment: String) -> Self {
+        self.prompt_adjustment = Some(adjustment);
         self
     }
 
@@ -134,6 +143,16 @@ impl<'a> ContextBuilder<'a> {
             if !skill_sections.is_empty() {
                 sections.push(PromptSection::Skills {
                     content: skill_sections.clone(),
+                });
+            }
+        }
+
+        // Learned prompt adjustments from prior turns.
+        if let Some(ref adjustment) = self.prompt_adjustment {
+            if !adjustment.is_empty() {
+                sections.push(PromptSection::Custom {
+                    label: "Learning Adjustment".to_string(),
+                    content: adjustment.clone(),
                 });
             }
         }

--- a/crates/nanobot-agent/src/loop_mod.rs
+++ b/crates/nanobot-agent/src/loop_mod.rs
@@ -32,7 +32,7 @@ use nanobot_skill::SkillRegistry;
 use nanobot_tools::ToolRegistry;
 use std::collections::HashSet;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 use tracing::{error, info, warn};
 
 /// The main agent loop that processes messages from the bus.
@@ -59,6 +59,8 @@ pub struct AgentLoop {
     learning_bus: Option<LearningEventBus>,
     /// Optional prompt assembler for dynamic system prompt construction.
     prompt_assembler: Option<PromptAssembler>,
+    /// Optional receiver for learned prompt adjustments.
+    prompt_adjustments_rx: Option<watch::Receiver<Option<String>>>,
 }
 
 impl AgentLoop {
@@ -86,6 +88,7 @@ impl AgentLoop {
             memory_store: None,
             learning_bus: None,
             prompt_assembler: None,
+            prompt_adjustments_rx: None,
         }
     }
 
@@ -208,6 +211,15 @@ impl AgentLoop {
             // Attach prompt assembler if configured
             if let Some(ref assembler) = self.prompt_assembler {
                 context_builder = context_builder.with_prompt_assembler(assembler.clone());
+            }
+
+            if let Some(ref prompt_adjustments_rx) = self.prompt_adjustments_rx {
+                let adjustment = prompt_adjustments_rx.borrow().clone();
+                if let Some(adjustment) = adjustment {
+                    if !adjustment.is_empty() {
+                        context_builder = context_builder.with_prompt_adjustment(adjustment);
+                    }
+                }
             }
 
             // Match skills against user message and inject into prompt
@@ -738,6 +750,17 @@ impl AgentLoop {
     /// system prompt construction.
     pub fn with_prompt_assembler(mut self, assembler: PromptAssembler) -> Self {
         self.prompt_assembler = Some(assembler);
+        self
+    }
+
+    /// Attach a watch receiver for learned prompt adjustments.
+    ///
+    /// The latest non-empty adjustment is injected into the next system prompt.
+    pub fn with_prompt_adjustments(
+        mut self,
+        prompt_adjustments_rx: watch::Receiver<Option<String>>,
+    ) -> Self {
+        self.prompt_adjustments_rx = Some(prompt_adjustments_rx);
         self
     }
 

--- a/crates/nanobot-core/src/constants.rs
+++ b/crates/nanobot-core/src/constants.rs
@@ -58,6 +58,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)]
     fn test_defaults_sensible() {
         // Iterations should be positive and reasonable
         assert!(DEFAULT_MAX_ITERATIONS > 0);

--- a/crates/nanobot-core/src/error.rs
+++ b/crates/nanobot-core/src/error.rs
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn test_result_alias() {
         let ok_val: Result<i32> = Ok(42);
-        assert_eq!(ok_val.unwrap(), 42);
+        assert!(matches!(ok_val, Ok(42)));
 
         let err_val: Result<String> = Err(NanobotError::Config("test".to_string()));
         assert!(err_val.is_err());

--- a/crates/nanobot-session/src/note_store.rs
+++ b/crates/nanobot-session/src/note_store.rs
@@ -261,7 +261,7 @@ mod tests {
         store
             .save_notes(
                 "session:a",
-                &vec![Note::new(
+                &[Note::new(
                     "API Design".to_string(),
                     "Use REST endpoints".to_string(),
                     vec!["architecture".to_string()],
@@ -271,7 +271,7 @@ mod tests {
         store
             .save_notes(
                 "session:b",
-                &vec![Note::new(
+                &[Note::new(
                     "Database".to_string(),
                     "Use PostgreSQL".to_string(),
                     vec!["backend".to_string()],
@@ -281,7 +281,7 @@ mod tests {
         store
             .save_notes(
                 "session:c",
-                &vec![Note::new(
+                &[Note::new(
                     "Frontend".to_string(),
                     "Use React".to_string(),
                     vec!["frontend".to_string()],
@@ -307,7 +307,7 @@ mod tests {
         store
             .save_notes(
                 "session:a",
-                &vec![
+                &[
                     Note::new(
                         "n1".to_string(),
                         "a".to_string(),
@@ -320,7 +320,7 @@ mod tests {
         store
             .save_notes(
                 "session:b",
-                &vec![Note::new(
+                &[Note::new(
                     "n3".to_string(),
                     "c".to_string(),
                     vec!["decision".to_string()],
@@ -343,7 +343,7 @@ mod tests {
         store
             .save_notes(
                 "session:x",
-                &vec![Note::new(
+                &[Note::new(
                     "n1".to_string(),
                     "a".to_string(),
                     vec!["Backend".to_string()],
@@ -389,7 +389,7 @@ mod tests {
         store
             .save_notes(
                 "session:a",
-                &vec![Note::new(
+                &[Note::new(
                     "Note A".to_string(),
                     "Content A".to_string(),
                     vec!["alpha".to_string()],
@@ -401,7 +401,7 @@ mod tests {
         store
             .save_notes(
                 "session:b",
-                &vec![Note::new(
+                &[Note::new(
                     "Note B".to_string(),
                     "Content B".to_string(),
                     vec!["beta".to_string()],
@@ -413,7 +413,7 @@ mod tests {
         store
             .save_notes(
                 "session:a",
-                &vec![Note::new(
+                &[Note::new(
                     "Note A Modified".to_string(),
                     "New content".to_string(),
                     vec!["alpha".to_string(), "updated".to_string()],

--- a/crates/nanobot-skill/src/registry.rs
+++ b/crates/nanobot-skill/src/registry.rs
@@ -144,6 +144,19 @@ impl SkillRegistry {
         Ok(())
     }
 
+    /// Adjust the confidence of a registered skill by a raw delta.
+    ///
+    /// The resulting confidence is clamped to the inclusive range `0.0..=1.0`.
+    pub async fn adjust_confidence(&self, name: &str, delta: f64) -> SkillResult<()> {
+        let skills = self.skills.read().await;
+        let skill = skills
+            .get(name)
+            .ok_or_else(|| SkillError::NotFound(name.to_string()))?;
+        let mut guard = skill.write();
+        guard.confidence = (guard.confidence + delta).clamp(0.0, 1.0);
+        Ok(())
+    }
+
     /// Create a new skill with a TOML manifest and Markdown instructions file.
     ///
     /// Writes a `<name>.toml` manifest and a `<name>.md` instructions file to the

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -338,7 +338,7 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
                 info!("Memory store initialized (HotStore L1)");
                 let hot_store: Arc<dyn MemoryStore> = Arc::new(hot_store);
                 heartbeat_memory_store = Some(hot_store.clone());
-                learning_memory_store = Some(hot_store);
+                learning_memory_store = Some(hot_store.clone());
                 al = al.with_memory_store(hot_store);
             }
             Err(e) => {
@@ -505,7 +505,6 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
                 processor.stats().events_processed
             );
         }
-        let processor = Arc::new(processor);
         let store = event_store.clone();
         let memory_store = learning_memory_store.clone();
         let skill_registry = skill_registry.clone();
@@ -597,7 +596,6 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     }
     if let Err(e) = learning_handle.await {
         tracing::warn!("Learning consumer task join failed: {}", e);
-    }
     }
 
     info!("Gateway shutting down");

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -126,7 +126,9 @@ impl GatewayLearningProcessor for BasicEventProcessor {
     }
 
     async fn save_stats(&self) -> Result<()> {
-        BasicEventProcessor::save_stats(self).await.map_err(Into::into)
+        BasicEventProcessor::save_stats(self)
+            .await
+            .map_err(Into::into)
     }
 }
 
@@ -157,8 +159,7 @@ async fn execute_learning_action(
             .with_context(|| format!("failed to deprecate skill '{skill}'")),
         LearningAction::RecordInsight { insight, category } => {
             if category == "prompt_adjustment" {
-                prompt_adjustment_tx
-                    .send_replace(Some(insight.clone()));
+                prompt_adjustment_tx.send_replace(Some(insight.clone()));
                 return Ok(());
             }
 
@@ -612,8 +613,8 @@ mod tests {
     use nanobot_skill::manifest::SkillManifestBuilder;
     use nanobot_skill::skill::CompiledSkill;
     use nanobot_skill::Skill;
-    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
     use tempfile::tempdir;
 
     #[derive(Default)]
@@ -638,9 +639,17 @@ mod tests {
     #[async_trait]
     impl MemoryStore for MockMemoryStore {
         async fn store(&self, entry: MemoryEntry) -> nanobot_memory::error::Result<()> {
-            if self.fail_count.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
-                if count > 0 { Some(count - 1) } else { None }
-            }).is_ok() {
+            if self
+                .fail_count
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                    if count > 0 {
+                        Some(count - 1)
+                    } else {
+                        None
+                    }
+                })
+                .is_ok()
+            {
                 return Err(nanobot_memory::MemoryError::Io(std::io::Error::other(
                     "mock store failure",
                 )));

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -8,7 +8,8 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
 use nanobot_agent::AgentLoop;
 use nanobot_api::ApiServer;
 use nanobot_bus::events::AgentEvent;
@@ -20,16 +21,17 @@ use nanobot_heartbeat::{
     ProviderHealthCheck,
 };
 use nanobot_learning::config::LearningConfig;
-use nanobot_learning::event::LearningEventBus;
+use nanobot_learning::event::{LearningAction, LearningEvent, LearningEventBus};
 use nanobot_learning::processor::BasicEventProcessor;
 use nanobot_learning::prompt::PromptAssembler;
 use nanobot_learning::store::EventStore;
 use nanobot_learning::LearningEventHandler;
-use nanobot_memory::{HotStore, MemoryConfig, MemoryStore};
+use nanobot_memory::{HotStore, MemoryCategory, MemoryConfig, MemoryEntry, MemoryStore};
 use nanobot_providers::ProviderRegistry;
 use nanobot_session::SessionManager;
 use nanobot_skill::{SkillConfig, SkillLoader, SkillRegistry};
 use nanobot_tools::builtins;
+use tokio::sync::{broadcast, watch};
 use tracing::info;
 
 /// Initialize the skill registry by loading TOML manifests from the skills directory.
@@ -107,6 +109,167 @@ async fn refresh_channel_health(
     }
 }
 
+/// Async interface used by the learning consumer task.
+#[async_trait]
+trait GatewayLearningProcessor: Send {
+    /// Process a learning event into concrete actions.
+    async fn process_event(&mut self, event: &LearningEvent) -> Vec<LearningAction>;
+
+    /// Persist processor stats.
+    async fn save_stats(&self) -> Result<()>;
+}
+
+#[async_trait]
+impl GatewayLearningProcessor for BasicEventProcessor {
+    async fn process_event(&mut self, event: &LearningEvent) -> Vec<LearningAction> {
+        self.handle(event).await
+    }
+
+    async fn save_stats(&self) -> Result<()> {
+        BasicEventProcessor::save_stats(self).await.map_err(Into::into)
+    }
+}
+
+/// Execute a single learning action against the shared runtime state.
+async fn execute_learning_action(
+    action: &LearningAction,
+    memory_store: Option<&Arc<dyn MemoryStore>>,
+    skill_registry: &SkillRegistry,
+    prompt_adjustment_tx: &watch::Sender<Option<String>>,
+) -> Result<()> {
+    match action {
+        LearningAction::NoOp => Ok(()),
+        LearningAction::AdjustConfidence { skill, delta } => skill_registry
+            .adjust_confidence(skill, *delta)
+            .await
+            .with_context(|| format!("failed to adjust confidence for skill '{skill}'")),
+        LearningAction::ProposeSkill { name, reason } => skill_registry
+            .create_skill(name, reason, "")
+            .await
+            .with_context(|| format!("failed to create skill '{name}'")),
+        LearningAction::PatchSkill { skill, description } => skill_registry
+            .update_skill_instructions(skill, description)
+            .await
+            .with_context(|| format!("failed to patch skill '{skill}'")),
+        LearningAction::DeprecateSkill { skill, reason } => skill_registry
+            .deprecate_skill(skill, reason)
+            .await
+            .with_context(|| format!("failed to deprecate skill '{skill}'")),
+        LearningAction::RecordInsight { insight, category } => {
+            if category == "prompt_adjustment" {
+                prompt_adjustment_tx
+                    .send_replace(Some(insight.clone()));
+                return Ok(());
+            }
+
+            let store = memory_store.context("memory store not configured")?;
+            let entry = build_memory_entry(insight, category);
+            store
+                .store(entry)
+                .await
+                .with_context(|| format!("failed to store insight in category '{category}'"))
+        }
+    }
+}
+
+/// Execute all learning actions, logging individual failures and continuing.
+async fn execute_learning_actions(
+    actions: &[LearningAction],
+    memory_store: Option<&Arc<dyn MemoryStore>>,
+    skill_registry: &SkillRegistry,
+    prompt_adjustment_tx: &watch::Sender<Option<String>>,
+) {
+    for action in actions {
+        if let Err(e) =
+            execute_learning_action(action, memory_store, skill_registry, prompt_adjustment_tx)
+                .await
+        {
+            tracing::error!("Failed to execute learning action {:?}: {}", action, e);
+        }
+    }
+}
+
+/// Convert an insight action into a memory entry for persistence.
+fn build_memory_entry(insight: &str, category: &str) -> MemoryEntry {
+    MemoryEntry::new(insight, map_memory_category(category)).with_confidence(0.8)
+}
+
+/// Map a learning insight category to the closest memory category.
+fn map_memory_category(category: &str) -> MemoryCategory {
+    match category {
+        "user_profile" => MemoryCategory::UserProfile,
+        "preference" => MemoryCategory::Preference,
+        "environment" => MemoryCategory::Environment,
+        "project_convention" => MemoryCategory::ProjectConvention,
+        "tool_reliability" => MemoryCategory::ToolDiscovery,
+        "error_lesson" => MemoryCategory::ErrorLesson,
+        "workflow_pattern" => MemoryCategory::WorkflowPattern,
+        "critical" => MemoryCategory::Critical,
+        _ => MemoryCategory::AgentNote,
+    }
+}
+
+/// Run the gateway learning consumer until shutdown is requested.
+async fn run_learning_consumer<P>(
+    learning_rx: &mut broadcast::Receiver<LearningEvent>,
+    shutdown_rx: &mut watch::Receiver<bool>,
+    event_store: EventStore,
+    processor: &mut P,
+    memory_store: Option<Arc<dyn MemoryStore>>,
+    skill_registry: Arc<SkillRegistry>,
+    prompt_adjustment_tx: watch::Sender<Option<String>>,
+) where
+    P: GatewayLearningProcessor,
+{
+    let mut events_since_save: u64 = 0;
+
+    loop {
+        tokio::select! {
+            changed = shutdown_rx.changed() => {
+                match changed {
+                    Ok(()) if *shutdown_rx.borrow() => break,
+                    Ok(()) => {}
+                    Err(_) => break,
+                }
+            }
+            received = learning_rx.recv() => {
+                match received {
+                    Ok(event) => {
+                        if let Err(e) = event_store.append(&event).await {
+                            tracing::warn!("Failed to persist learning event: {}", e);
+                        }
+
+                        let actions = processor.process_event(&event).await;
+                        execute_learning_actions(
+                            &actions,
+                            memory_store.as_ref(),
+                            skill_registry.as_ref(),
+                            &prompt_adjustment_tx,
+                        )
+                        .await;
+
+                        events_since_save += 1;
+                        if events_since_save >= 50 {
+                            if let Err(e) = processor.save_stats().await {
+                                tracing::warn!("Failed to save processor stats: {}", e);
+                            }
+                            events_since_save = 0;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!("Learning event consumer lagged by {n} messages");
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        }
+    }
+
+    if let Err(e) = processor.save_stats().await {
+        tracing::warn!("Failed to save processor stats during shutdown: {}", e);
+    }
+}
+
 /// Run the gateway — starts all components and connects them via the bus.
 ///
 /// PID file management is handled by the `daemon start` command, not here.
@@ -152,6 +315,9 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     let learning_bus = LearningEventBus::new();
     let mut heartbeat_memory_store: Option<Arc<dyn MemoryStore>> = None;
 
+    let (prompt_adjustment_tx, prompt_adjustment_rx) = watch::channel(None::<String>);
+    let mut learning_memory_store: Option<Arc<dyn MemoryStore>> = None;
+
     let agent_loop = {
         let mut al = AgentLoop::new(
             config.clone(),
@@ -169,8 +335,9 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         match HotStore::new(&memory_config).await {
             Ok(hot_store) => {
                 info!("Memory store initialized (HotStore L1)");
-                let hot_store = Arc::new(hot_store);
-                heartbeat_memory_store = Some(hot_store.clone() as Arc<dyn MemoryStore>);
+                let hot_store: Arc<dyn MemoryStore> = Arc::new(hot_store);
+                heartbeat_memory_store = Some(hot_store.clone());
+                learning_memory_store = Some(hot_store);
                 al = al.with_memory_store(hot_store);
             }
             Err(e) => {
@@ -182,13 +349,14 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         }
 
         // Wire skill registry
-        al = al.with_skill_registry(skill_registry);
+        al = al.with_skill_registry(skill_registry.clone());
 
         // Wire learning event bus
         al = al.with_learning_bus(learning_bus.clone());
 
         // Wire prompt assembler for dynamic system prompt construction
         al = al.with_prompt_assembler(PromptAssembler::new());
+        al = al.with_prompt_adjustments(prompt_adjustment_rx.clone());
         info!("Prompt assembler wired into agent loop");
 
         al
@@ -322,7 +490,8 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         learning_config.max_events
     );
 
-    let learning_processor = {
+    let (learning_shutdown_tx, mut learning_shutdown_rx) = watch::channel(false);
+    let learning_handle = {
         let mut learning_rx = learning_bus.subscribe();
         let stats_path = learning_config.stats_file();
         let mut processor = BasicEventProcessor::new().with_stats_path(&stats_path);
@@ -337,44 +506,21 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         }
         let processor = Arc::new(processor);
         let store = event_store.clone();
-        let task_processor = Arc::clone(&processor);
-        let _learning_handle = tokio::spawn(async move {
-            let mut events_since_save: u64 = 0;
-            loop {
-                match learning_rx.recv().await {
-                    Ok(event) => {
-                        // Persist to event store
-                        if let Err(e) = store.append(&event).await {
-                            tracing::warn!("Failed to persist learning event: {}", e);
-                        }
-                        // Process through the basic processor
-                        let actions = task_processor.handle(&event).await;
-                        for action in actions {
-                            tracing::debug!("Learning action: {:?}", action);
-                        }
-                        // Periodically save stats
-                        events_since_save += 1;
-                        if events_since_save >= 50 {
-                            if let Err(e) = task_processor.save_stats().await {
-                                tracing::warn!("Failed to save processor stats: {}", e);
-                            }
-                            events_since_save = 0;
-                        }
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!("Learning event consumer lagged by {n} messages");
-                    }
-                    Err(_) => break,
-                }
-            }
-            if let Err(e) = task_processor.save_stats().await {
-                tracing::warn!(
-                    "Failed to flush processor stats on learning shutdown: {}",
-                    e
-                );
-            }
-        });
-        processor
+        let memory_store = learning_memory_store.clone();
+        let skill_registry = skill_registry.clone();
+        let prompt_adjustment_tx = prompt_adjustment_tx.clone();
+        tokio::spawn(async move {
+            run_learning_consumer(
+                &mut learning_rx,
+                &mut learning_shutdown_rx,
+                store,
+                &mut processor,
+                memory_store,
+                skill_registry,
+                prompt_adjustment_tx,
+            )
+            .await;
+        })
     };
 
     // ── Periodic event log prune task ─────────────────────────
@@ -445,11 +591,12 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     info!("Stopping all channels...");
     channel_manager.stop_all().await;
 
-    if let Err(e) = learning_processor.save_stats().await {
-        tracing::warn!(
-            "Failed to flush processor stats during gateway shutdown: {}",
-            e
-        );
+    if learning_shutdown_tx.send(true).is_err() {
+        tracing::warn!("Learning consumer shutdown channel closed unexpectedly");
+    }
+    if let Err(e) = learning_handle.await {
+        tracing::warn!("Learning consumer task join failed: {}", e);
+    }
     }
 
     info!("Gateway shutting down");
@@ -459,6 +606,98 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use nanobot_learning::event::SkillOutcome;
+    use nanobot_memory::{MemoryQuery, ScoredEntry};
+    use nanobot_skill::manifest::SkillManifestBuilder;
+    use nanobot_skill::skill::CompiledSkill;
+    use nanobot_skill::Skill;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::tempdir;
+
+    #[derive(Default)]
+    struct MockMemoryStore {
+        stored: Mutex<Vec<MemoryEntry>>,
+        fail_count: AtomicUsize,
+    }
+
+    impl MockMemoryStore {
+        fn with_fail_count(fail_count: usize) -> Self {
+            Self {
+                stored: Mutex::new(Vec::new()),
+                fail_count: AtomicUsize::new(fail_count),
+            }
+        }
+
+        fn stored_entries(&self) -> Vec<MemoryEntry> {
+            self.stored.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl MemoryStore for MockMemoryStore {
+        async fn store(&self, entry: MemoryEntry) -> nanobot_memory::error::Result<()> {
+            if self.fail_count.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                if count > 0 { Some(count - 1) } else { None }
+            }).is_ok() {
+                return Err(nanobot_memory::MemoryError::Io(std::io::Error::other(
+                    "mock store failure",
+                )));
+            }
+            self.stored.lock().unwrap().push(entry);
+            Ok(())
+        }
+
+        async fn recall(&self, _id: &str) -> nanobot_memory::error::Result<Option<MemoryEntry>> {
+            Ok(None)
+        }
+
+        async fn search(
+            &self,
+            _query: &MemoryQuery,
+        ) -> nanobot_memory::error::Result<Vec<ScoredEntry>> {
+            Ok(Vec::new())
+        }
+
+        async fn delete(&self, _id: &str) -> nanobot_memory::error::Result<()> {
+            Ok(())
+        }
+
+        async fn len(&self) -> usize {
+            self.stored.lock().unwrap().len()
+        }
+
+        async fn clear(&self) -> nanobot_memory::error::Result<()> {
+            self.stored.lock().unwrap().clear();
+            Ok(())
+        }
+    }
+
+    struct MockProcessor {
+        actions: Vec<LearningAction>,
+        save_stats_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl GatewayLearningProcessor for MockProcessor {
+        async fn process_event(&mut self, _event: &LearningEvent) -> Vec<LearningAction> {
+            self.actions.clone()
+        }
+
+        async fn save_stats(&self) -> Result<()> {
+            self.save_stats_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn make_compiled_skill(name: &str) -> CompiledSkill {
+        CompiledSkill::new(
+            SkillManifestBuilder::new(name, "1.0.0", format!("Skill {name}"))
+                .triggers(vec![name.to_string()])
+                .build(),
+        )
+    }
 
     /// Write a valid TOML skill manifest to a directory.
     fn write_skill(dir: &Path, name: &str, triggers: &[&str]) -> std::path::PathBuf {
@@ -577,5 +816,101 @@ mod tests {
 
         assert_eq!(m.steps, vec!["Apply manifests", "Verify rollout"]);
         assert_eq!(m.pitfalls, vec!["Do not deploy on Fridays"]);
+    }
+
+    #[tokio::test]
+    async fn test_record_insight_action_stores_memory() {
+        let store_impl = Arc::new(MockMemoryStore::default());
+        let memory_store: Arc<dyn MemoryStore> = store_impl.clone();
+        let skill_registry = SkillRegistry::new();
+        let (prompt_tx, _prompt_rx) = watch::channel(None::<String>);
+
+        execute_learning_action(
+            &LearningAction::RecordInsight {
+                insight: "remember this".into(),
+                category: "environment".into(),
+            },
+            Some(&memory_store),
+            &skill_registry,
+            &prompt_tx,
+        )
+        .await
+        .unwrap();
+
+        let entries = store_impl.stored_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].content, "remember this");
+        assert_eq!(entries[0].category, MemoryCategory::Environment);
+    }
+
+    #[tokio::test]
+    async fn test_failed_action_does_not_stop_subsequent_actions() {
+        let store_impl = Arc::new(MockMemoryStore::with_fail_count(1));
+        let memory_store: Arc<dyn MemoryStore> = store_impl.clone();
+        let skill_registry = SkillRegistry::new();
+        skill_registry
+            .register(make_compiled_skill("deploy"))
+            .await
+            .unwrap();
+        let (prompt_tx, _prompt_rx) = watch::channel(None::<String>);
+
+        let actions = vec![
+            LearningAction::RecordInsight {
+                insight: "first write fails".into(),
+                category: "environment".into(),
+            },
+            LearningAction::AdjustConfidence {
+                skill: "deploy".into(),
+                delta: 0.2,
+            },
+        ];
+
+        execute_learning_actions(&actions, Some(&memory_store), &skill_registry, &prompt_tx).await;
+
+        let skill = skill_registry.get("deploy").await.unwrap();
+        assert!(skill.read().confidence() > 0.5);
+        assert!(store_impl.stored_entries().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_learning_consumer_shutdown_saves_stats() {
+        let learning_bus = LearningEventBus::new();
+        let mut learning_rx = learning_bus.subscribe();
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let save_stats_calls = Arc::new(AtomicUsize::new(0));
+        let mut processor = MockProcessor {
+            actions: vec![LearningAction::NoOp],
+            save_stats_calls: save_stats_calls.clone(),
+        };
+        let event_dir = tempdir().unwrap();
+        let event_store = EventStore::new(event_dir.path().join("events.jsonl"), 10);
+        let skill_registry = Arc::new(SkillRegistry::new());
+        let (prompt_tx, _prompt_rx) = watch::channel(None::<String>);
+
+        let handle = tokio::spawn(async move {
+            run_learning_consumer(
+                &mut learning_rx,
+                &mut shutdown_rx,
+                event_store,
+                &mut processor,
+                None,
+                skill_registry,
+                prompt_tx,
+            )
+            .await;
+        });
+
+        learning_bus.publish(LearningEvent::SkillUsed {
+            skill_name: "deploy".into(),
+            match_score: 0.8,
+            outcome: SkillOutcome::Helpful,
+            timestamp: Utc::now(),
+        });
+        tokio::task::yield_now().await;
+
+        shutdown_tx.send(true).unwrap();
+        handle.await.unwrap();
+
+        assert!(save_stats_calls.load(Ordering::SeqCst) >= 1);
     }
 }


### PR DESCRIPTION
Closes #46

- RecordInsight persists to memory store via HotStore
- AdjustConfidence/ProposeSkill/PatchSkill/DeprecateSkill mutate SkillRegistry
- Prompt adjustments routed through watch channel
- Each action isolated behind own error handler
- Shutdown stats persistence
- Gateway tests for memory execution, failure isolation, shutdown flush
- Includes pre-existing clippy warning fixes across workspace

Validated: cargo test --workspace passes.