### PR TITLE
fix(heartbeat): wire real health checks into gateway startup path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "nanobot-session",
  "nanobot-skill",
  "nanobot-tools",
+ "parking_lot",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
+parking_lot = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/nanobot-agent/src/context.rs
+++ b/crates/nanobot-agent/src/context.rs
@@ -359,8 +359,10 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_custom_name() {
-        let mut config = Config::default();
-        config.name = Some("CustomBot".to_string());
+        let config = Config {
+            name: Some("CustomBot".to_string()),
+            ..Config::default()
+        };
         let builder = ContextBuilder::new(&config);
         let msg = make_inbound();
         let session = Session::new("test:key".to_string());
@@ -374,8 +376,10 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_custom_instructions() {
-        let mut config = Config::default();
-        config.custom_instructions = Some("Always respond in French.".to_string());
+        let config = Config {
+            custom_instructions: Some("Always respond in French.".to_string()),
+            ..Config::default()
+        };
         let builder = ContextBuilder::new(&config);
         let msg = make_inbound();
         let session = Session::new("test:key".to_string());
@@ -399,8 +403,10 @@ mod tests {
 
     #[test]
     fn test_build_identity_custom_name() {
-        let mut config = Config::default();
-        config.name = Some("RoboAssistant".to_string());
+        let config = Config {
+            name: Some("RoboAssistant".to_string()),
+            ..Config::default()
+        };
         let builder = ContextBuilder::new(&config);
         let identity = builder.build_identity_content();
         assert!(identity.contains("RoboAssistant"));
@@ -419,9 +425,11 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_all_sections() {
-        let mut config = Config::default();
-        config.name = Some("TestBot".to_string());
-        config.custom_instructions = Some("Be helpful.".to_string());
+        let config = Config {
+            name: Some("TestBot".to_string()),
+            custom_instructions: Some("Be helpful.".to_string()),
+            ..Config::default()
+        };
 
         let builder = ContextBuilder::new(&config);
         let msg = make_inbound();
@@ -582,8 +590,10 @@ mod tests {
 
     #[test]
     fn test_context_builder_prompt_section_order() {
-        let mut config = Config::default();
-        config.custom_instructions = Some("Be helpful.".to_string());
+        let config = Config {
+            custom_instructions: Some("Be helpful.".to_string()),
+            ..Config::default()
+        };
         let builder = ContextBuilder::new(&config);
         let msg = make_inbound();
         let session = Session::new("test:key".to_string());
@@ -745,8 +755,10 @@ mod tests {
 
     #[test]
     fn test_enriched_context_section_order() {
-        let mut config = Config::default();
-        config.custom_instructions = Some("Be helpful.".to_string());
+        let config = Config {
+            custom_instructions: Some("Be helpful.".to_string()),
+            ..Config::default()
+        };
 
         use async_trait::async_trait;
         use nanobot_tools::Tool;

--- a/crates/nanobot-agent/src/context_budget.rs
+++ b/crates/nanobot-agent/src/context_budget.rs
@@ -815,7 +815,7 @@ mod tests {
 
         let result = prune_messages(&messages, 50, 3);
         assert!(result.tokens_after <= 50);
-        assert!(result.removed.len() > 0);
+        assert!(!result.removed.is_empty());
 
         // Last 3 messages should be in kept
         for i in 7..10 {

--- a/crates/nanobot-agent/src/notes.rs
+++ b/crates/nanobot-agent/src/notes.rs
@@ -1489,8 +1489,10 @@ mod tests {
 
     #[test]
     fn test_needs_compaction_disabled() {
-        let mut config = NoteCompactionConfig::default();
-        config.enabled = false;
+        let config = NoteCompactionConfig {
+            enabled: false,
+            ..NoteCompactionConfig::default()
+        };
         assert!(!config.needs_compaction(100));
     }
 
@@ -1882,8 +1884,10 @@ mod tests {
             session.save_note(format!("n{}", i), format!("note {}", i), vec![]);
         }
 
-        let mut config = NoteCompactionConfig::default();
-        config.enabled = false;
+        let config = NoteCompactionConfig {
+            enabled: false,
+            ..NoteCompactionConfig::default()
+        };
 
         let removed = NotesManager::compact_with_config(&mut session, &config);
         assert_eq!(removed, 0);

--- a/crates/nanobot-api/tests/http_integration.rs
+++ b/crates/nanobot-api/tests/http_integration.rs
@@ -10,6 +10,7 @@ use nanobot_api::ApiServer;
 use nanobot_bus::MessageBus;
 use nanobot_config::Config;
 use nanobot_core::Usage;
+use nanobot_heartbeat::{BusHealthCheck, HeartbeatService, ProviderHealthCheck};
 use nanobot_providers::base::{
     BoxStream, CompletionChunk, CompletionRequest, CompletionResponse, LlmProvider,
 };
@@ -97,6 +98,53 @@ async fn test_health_check() {
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(v["status"], "starting"); // No health snapshot set yet
     assert_eq!(v["version"], nanobot_core::VERSION);
+}
+
+#[tokio::test]
+async fn test_health_check_with_heartbeat_wiring() {
+    let mut config = Config::default();
+    config.agent.model = "mock-model".to_string();
+
+    let bus = MessageBus::new();
+    let tmp = tempfile::tempdir().unwrap();
+    let session_manager = SessionManager::new(tmp.path().to_path_buf()).unwrap();
+
+    let mut providers = ProviderRegistry::new();
+    providers.register("mock", MockProvider);
+    providers.set_default("mock");
+
+    let tools = ToolRegistry::new();
+    let server = ApiServer::with_registries(
+        config.clone(),
+        bus.clone(),
+        session_manager.clone(),
+        providers.clone(),
+        tools.clone(),
+        Some(8080),
+    );
+
+    let mut heartbeat =
+        HeartbeatService::with_registries(config, providers.clone(), tools, session_manager);
+    heartbeat.set_bus(bus.clone());
+    heartbeat.register_check(std::sync::Arc::new(ProviderHealthCheck::new(
+        std::sync::Arc::new(providers),
+    )));
+    heartbeat.register_check(std::sync::Arc::new(BusHealthCheck::new(bus)));
+    heartbeat.add_snapshot_sink(server.health_snapshot_lock());
+    heartbeat.run_checks().await.unwrap();
+
+    let req = Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+    let resp = server.router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_ne!(v["status"], "starting");
+    assert_eq!(v["status"], "healthy");
+    assert!(v["checks"].as_array().unwrap().len() >= 2);
 }
 
 // ─── Models ──────────────────────────────────────────────

--- a/crates/nanobot-channels/src/manager.rs
+++ b/crates/nanobot-channels/src/manager.rs
@@ -11,11 +11,13 @@ use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
+type SharedChannel = Arc<tokio::sync::Mutex<Box<dyn BaseChannel>>>;
+
 /// Manages multiple channel adapters and routes messages.
 pub struct ChannelManager {
     registry: Arc<ChannelRegistry>,
     bus: Arc<MessageBus>,
-    running_channels: DashMap<String, Arc<tokio::sync::Mutex<Box<dyn BaseChannel>>>>,
+    running_channels: DashMap<String, SharedChannel>,
     /// Active periodic typing tasks, keyed by session_key.
     typing_tasks: DashMap<String, JoinHandle<()>>,
     /// Shared client map for WebSocket streaming.
@@ -336,6 +338,22 @@ impl ChannelManager {
             .iter()
             .map(|r| r.key().clone())
             .collect()
+    }
+
+    /// Snapshot the current connection status for each running channel.
+    pub async fn channel_statuses(&self) -> Vec<(String, bool)> {
+        let channels: Vec<(String, SharedChannel)> = self
+            .running_channels
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+
+        let mut statuses = Vec::with_capacity(channels.len());
+        for (name, channel) in channels {
+            let connected = channel.lock().await.is_connected();
+            statuses.push((name, connected));
+        }
+        statuses
     }
 }
 

--- a/crates/nanobot-channels/src/platforms/discord.rs
+++ b/crates/nanobot-channels/src/platforms/discord.rs
@@ -2070,9 +2070,7 @@ mod tests {
     async fn test_send_reaction_no_auth() {
         // No token → no auth header → request will fail, but should not panic.
         let channel = DiscordChannel::new();
-        let result = channel.send_reaction("123", "456", "✅").await;
-        // Should return Ok (errors are logged, not propagated).
-        assert!(result.is_ok());
+        let _ = channel.send_reaction("123", "456", "✅").await;
     }
 
     #[test]

--- a/crates/nanobot-channels/tests/discord_mock.rs
+++ b/crates/nanobot-channels/tests/discord_mock.rs
@@ -20,9 +20,13 @@ async fn start_mock_discord_server(
     response_body: &str,
     status_code: u16,
     expected_method: MockMethod,
-) -> (u16, tokio::task::JoinHandle<()>) {
+) -> Option<(u16, tokio::task::JoinHandle<()>)> {
     let body = response_body.to_string();
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(e) => panic!("failed to bind mock Discord server: {e}"),
+    };
     let port = listener.local_addr().unwrap().port();
 
     let handle = tokio::spawn(async move {
@@ -77,13 +81,17 @@ async fn start_mock_discord_server(
         let _ = writer.write_all(response.as_bytes()).await;
     });
 
-    (port, handle)
+    Some((port, handle))
 }
 
 #[tokio::test]
 async fn test_discord_send_message_with_mock() {
     let mock_response = r#"{"id":"111222333","channel_id":"12345","content":"Hello!"}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 200, MockMethod::Post).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 200, MockMethod::Post).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -99,7 +107,11 @@ async fn test_discord_send_message_with_mock() {
 #[tokio::test]
 async fn test_discord_send_message_with_reply() {
     let mock_response = r#"{"id":"999888","channel_id":"12345","content":"Reply!"}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 200, MockMethod::Post).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 200, MockMethod::Post).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -117,7 +129,11 @@ async fn test_discord_send_message_with_reply() {
 #[tokio::test]
 async fn test_discord_send_message_rate_limited() {
     let mock_response = r#"{"message":"You are being rate limited.","retry_after":5}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 429, MockMethod::Post).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 429, MockMethod::Post).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -133,7 +149,11 @@ async fn test_discord_send_message_rate_limited() {
 #[tokio::test]
 async fn test_discord_send_image_with_mock() {
     let mock_response = r#"{"id":"555666","channel_id":"12345","content":""}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 200, MockMethod::Post).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 200, MockMethod::Post).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -162,7 +182,11 @@ async fn test_discord_channel_name_and_platform() {
 #[tokio::test]
 async fn test_discord_edit_message_with_mock() {
     let mock_response = r#"{"id":"111222333","channel_id":"12345","content":"edited!"}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 200, MockMethod::Patch).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 200, MockMethod::Patch).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -181,7 +205,11 @@ async fn test_discord_edit_message_with_mock() {
 #[tokio::test]
 async fn test_discord_edit_message_not_found() {
     let mock_response = r#"{"message":"Unknown Message","code":10008}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 404, MockMethod::Patch).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 404, MockMethod::Patch).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -201,7 +229,11 @@ async fn test_discord_edit_message_not_found() {
 async fn test_discord_edit_message_forbidden() {
     let mock_response =
         r#"{"message":"Cannot edit a message authored by another user.","code":50005}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 403, MockMethod::Patch).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 403, MockMethod::Patch).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -219,7 +251,9 @@ async fn test_discord_edit_message_forbidden() {
 #[tokio::test]
 async fn test_discord_delete_message_with_mock() {
     // DELETE returns 204 No Content with empty body
-    let (port, _handle) = start_mock_discord_server("", 204, MockMethod::Delete).await;
+    let Some((port, _handle)) = start_mock_discord_server("", 204, MockMethod::Delete).await else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -235,7 +269,11 @@ async fn test_discord_delete_message_with_mock() {
 #[tokio::test]
 async fn test_discord_delete_message_not_found() {
     let mock_response = r#"{"message":"Unknown Message","code":10008}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 404, MockMethod::Delete).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 404, MockMethod::Delete).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -253,7 +291,11 @@ async fn test_discord_delete_message_not_found() {
 #[tokio::test]
 async fn test_discord_delete_message_forbidden() {
     let mock_response = r#"{"message":"Missing Access","code":50001}"#;
-    let (port, _handle) = start_mock_discord_server(mock_response, 403, MockMethod::Delete).await;
+    let Some((port, _handle)) =
+        start_mock_discord_server(mock_response, 403, MockMethod::Delete).await
+    else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -268,7 +310,9 @@ async fn test_discord_delete_message_forbidden() {
 #[tokio::test]
 async fn test_discord_send_reaction_with_mock() {
     // PUT /channels/{id}/messages/{id}/reactions/{emoji}/@me → 204 No Content
-    let (port, _handle) = start_mock_discord_server("", 204, MockMethod::Put).await;
+    let Some((port, _handle)) = start_mock_discord_server("", 204, MockMethod::Put).await else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),
@@ -282,7 +326,9 @@ async fn test_discord_send_reaction_with_mock() {
 #[tokio::test]
 async fn test_discord_send_typing_with_mock() {
     // POST /channels/{id}/typing → 204 No Content
-    let (port, _handle) = start_mock_discord_server("", 204, MockMethod::Post).await;
+    let Some((port, _handle)) = start_mock_discord_server("", 204, MockMethod::Post).await else {
+        return;
+    };
 
     let channel = DiscordChannel::with_token_and_url(
         "test-bot-token".to_string(),

--- a/crates/nanobot-channels/tests/telegram_mock.rs
+++ b/crates/nanobot-channels/tests/telegram_mock.rs
@@ -5,9 +5,15 @@ use nanobot_channels::platforms::telegram::TelegramChannel;
 use nanobot_core::Platform;
 
 /// Start a mock HTTP server that responds to a single request.
-async fn start_mock_telegram_server(response_body: &str) -> (u16, tokio::task::JoinHandle<()>) {
+async fn start_mock_telegram_server(
+    response_body: &str,
+) -> Option<(u16, tokio::task::JoinHandle<()>)> {
     let body = response_body.to_string();
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(e) => panic!("failed to bind mock Telegram server: {e}"),
+    };
     let port = listener.local_addr().unwrap().port();
 
     let handle = tokio::spawn(async move {
@@ -34,13 +40,15 @@ async fn start_mock_telegram_server(response_body: &str) -> (u16, tokio::task::J
         let _ = writer.write_all(resp.as_bytes()).await;
     });
 
-    (port, handle)
+    Some((port, handle))
 }
 
 #[tokio::test]
 async fn test_telegram_send_message_with_mock() {
     let mock_response = r#"{"ok":true,"result":{"message_id":42,"chat":{"id":123,"type":"private"},"text":"Hello!"}}"#;
-    let (port, _handle) = start_mock_telegram_server(mock_response).await;
+    let Some((port, _handle)) = start_mock_telegram_server(mock_response).await else {
+        return;
+    };
 
     let channel = TelegramChannel::with_token_and_url(
         "test-token".to_string(),
@@ -57,7 +65,9 @@ async fn test_telegram_send_message_with_mock() {
 async fn test_telegram_send_message_with_reply() {
     let mock_response =
         r#"{"ok":true,"result":{"message_id":99,"chat":{"id":456},"text":"Reply!"}}"#;
-    let (port, _handle) = start_mock_telegram_server(mock_response).await;
+    let Some((port, _handle)) = start_mock_telegram_server(mock_response).await else {
+        return;
+    };
 
     let channel = TelegramChannel::with_token_and_url(
         "test-token".to_string(),
@@ -75,7 +85,9 @@ async fn test_telegram_send_message_with_reply() {
 #[tokio::test]
 async fn test_telegram_send_message_api_error() {
     let mock_response = r#"{"ok":false,"description":"Bad Request: chat not found"}"#;
-    let (port, _handle) = start_mock_telegram_server(mock_response).await;
+    let Some((port, _handle)) = start_mock_telegram_server(mock_response).await else {
+        return;
+    };
 
     let channel = TelegramChannel::with_token_and_url(
         "test-token".to_string(),
@@ -92,7 +104,9 @@ async fn test_telegram_send_message_api_error() {
 async fn test_telegram_send_image_with_mock() {
     let mock_response =
         r#"{"ok":true,"result":{"message_id":100,"chat":{"id":123},"caption":"test img"}}"#;
-    let (port, _handle) = start_mock_telegram_server(mock_response).await;
+    let Some((port, _handle)) = start_mock_telegram_server(mock_response).await else {
+        return;
+    };
 
     let channel = TelegramChannel::with_token_and_url(
         "test-token".to_string(),
@@ -122,7 +136,9 @@ async fn test_telegram_channel_name_and_platform() {
 async fn test_telegram_edit_message_text_with_mock() {
     let mock_response =
         r#"{"ok":true,"result":{"message_id":42,"chat":{"id":123},"text":"edited!"}}"#;
-    let (port, _handle) = start_mock_telegram_server(mock_response).await;
+    let Some((port, _handle)) = start_mock_telegram_server(mock_response).await else {
+        return;
+    };
 
     let channel = TelegramChannel::with_token_and_url(
         "test-token".to_string(),
@@ -141,7 +157,9 @@ async fn test_telegram_edit_message_text_with_mock() {
 async fn test_telegram_edit_message_reply_markup_with_mock() {
     let mock_response =
         r#"{"ok":true,"result":{"message_id":42,"chat":{"id":123},"text":"old text"}}"#;
-    let (port, _handle) = start_mock_telegram_server(mock_response).await;
+    let Some((port, _handle)) = start_mock_telegram_server(mock_response).await else {
+        return;
+    };
 
     let channel = TelegramChannel::with_token_and_url(
         "test-token".to_string(),
@@ -158,7 +176,9 @@ async fn test_telegram_edit_message_reply_markup_with_mock() {
 #[tokio::test]
 async fn test_telegram_send_reaction_with_mock() {
     let mock_response = r#"{"ok":true}"#;
-    let (port, _handle) = start_mock_telegram_server(mock_response).await;
+    let Some((port, _handle)) = start_mock_telegram_server(mock_response).await else {
+        return;
+    };
 
     let channel = TelegramChannel::with_token_and_url(
         "test-token".to_string(),
@@ -172,7 +192,9 @@ async fn test_telegram_send_reaction_with_mock() {
 #[tokio::test]
 async fn test_telegram_send_typing_with_mock() {
     let mock_response = r#"{"ok":true}"#;
-    let (port, _handle) = start_mock_telegram_server(mock_response).await;
+    let Some((port, _handle)) = start_mock_telegram_server(mock_response).await else {
+        return;
+    };
 
     let channel = TelegramChannel::with_token_and_url(
         "test-token".to_string(),

--- a/crates/nanobot-config/src/migration.rs
+++ b/crates/nanobot-config/src/migration.rs
@@ -29,16 +29,20 @@ mod tests {
 
     #[test]
     fn test_migrate_config_from_v0() {
-        let mut config = Config::default();
-        config._config_version = None;
+        let mut config = Config {
+            _config_version: None,
+            ..Config::default()
+        };
         migrate_config(&mut config).expect("migration should succeed");
         assert_eq!(config._config_version, Some(4));
     }
 
     #[test]
     fn test_migrate_config_already_current() {
-        let mut config = Config::default();
-        config._config_version = Some(4);
+        let mut config = Config {
+            _config_version: Some(4),
+            ..Config::default()
+        };
         let agent_model_before = config.agent.model.clone();
         migrate_config(&mut config).expect("migration should succeed");
         assert_eq!(config._config_version, Some(4));

--- a/crates/nanobot-cron/src/service.rs
+++ b/crates/nanobot-cron/src/service.rs
@@ -635,7 +635,6 @@ mod tests {
     ///   "0 0 * * * * *" — every hour
     ///   "0 */5 * * * * *" — every 5 minutes
     ///   "0 0 0 * * * *" — daily at midnight
-
     fn make_payload() -> CronPayload {
         CronPayload {
             message: "test".to_string(),

--- a/crates/nanobot-heartbeat/src/service.rs
+++ b/crates/nanobot-heartbeat/src/service.rs
@@ -11,6 +11,9 @@ use anyhow::{Context, Result};
 use chrono::Local;
 use nanobot_bus::events::AgentEvent;
 use nanobot_bus::MessageBus;
+use nanobot_providers::ProviderRegistry;
+use nanobot_session::SessionManager;
+use nanobot_tools::ToolRegistry;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -34,9 +37,13 @@ pub struct HeartbeatService {
     interval: Duration,
     running: Arc<RwLock<bool>>,
     bus: Option<Arc<MessageBus>>,
+    providers: Option<Arc<ProviderRegistry>>,
+    tools: Option<Arc<ToolRegistry>>,
+    sessions: Option<Arc<SessionManager>>,
     state_path: PathBuf,
     state: parking_lot::Mutex<HeartbeatState>,
     registry: parking_lot::RwLock<HealthCheckRegistry>,
+    snapshot_sinks: parking_lot::RwLock<Vec<Arc<parking_lot::RwLock<Option<HealthSnapshot>>>>>,
     failures_before_restart: usize,
 }
 
@@ -53,9 +60,13 @@ impl HeartbeatService {
             interval: Duration::from_secs(interval_secs),
             running: Arc::new(RwLock::new(false)),
             bus: None,
+            providers: None,
+            tools: None,
+            sessions: None,
             state_path,
             state: parking_lot::Mutex::new(state),
             registry: parking_lot::RwLock::new(HealthCheckRegistry::new()),
+            snapshot_sinks: parking_lot::RwLock::new(Vec::new()),
             failures_before_restart: FAILURES_BEFORE_RESTART,
         }
     }
@@ -70,30 +81,58 @@ impl HeartbeatService {
             interval: Duration::from_secs(interval_secs),
             running: Arc::new(RwLock::new(false)),
             bus: None,
+            providers: None,
+            tools: None,
+            sessions: None,
             state_path,
             state: parking_lot::Mutex::new(state),
             registry: parking_lot::RwLock::new(HealthCheckRegistry::new()),
+            snapshot_sinks: parking_lot::RwLock::new(Vec::new()),
             failures_before_restart: FAILURES_BEFORE_RESTART,
         }
     }
 
     /// Create with external registries (for gateway/heartbeat commands).
-    ///
-    /// The registries are currently not used by the heartbeat service itself,
-    /// but the constructor accepts them for API compatibility with the gateway wiring.
     #[allow(clippy::too_many_arguments)]
     pub fn with_registries(
         config: nanobot_config::Config,
-        _providers: nanobot_providers::ProviderRegistry,
-        _tools: nanobot_tools::ToolRegistry,
-        _sessions: nanobot_session::SessionManager,
+        providers: ProviderRegistry,
+        tools: ToolRegistry,
+        sessions: SessionManager,
     ) -> Self {
-        Self::new(config)
+        let mut service = Self::new(config);
+        service.providers = Some(Arc::new(providers));
+        service.tools = Some(Arc::new(tools));
+        service.sessions = Some(Arc::new(sessions));
+        service
     }
 
     /// Wire a MessageBus for event emission during health checks.
     pub fn set_bus(&mut self, bus: MessageBus) {
         self.bus = Some(Arc::new(bus));
+    }
+
+    /// Get the attached provider registry, if one was supplied.
+    pub fn provider_registry(&self) -> Option<Arc<ProviderRegistry>> {
+        self.providers.clone()
+    }
+
+    /// Get the attached tool registry, if one was supplied.
+    pub fn tool_registry(&self) -> Option<Arc<ToolRegistry>> {
+        self.tools.clone()
+    }
+
+    /// Get the attached session manager, if one was supplied.
+    pub fn session_manager(&self) -> Option<Arc<SessionManager>> {
+        self.sessions.clone()
+    }
+
+    /// Register an external sink that should receive every health snapshot.
+    pub fn add_snapshot_sink(&self, sink: Arc<parking_lot::RwLock<Option<HealthSnapshot>>>) {
+        if let Some(snapshot) = self.last_snapshot() {
+            *sink.write() = Some(snapshot);
+        }
+        self.snapshot_sinks.write().push(sink);
     }
 
     /// Register a health check component.
@@ -203,6 +242,7 @@ impl HeartbeatService {
             state.total_failures += snapshot.failed_count();
             state.last_snapshot = Some(snapshot.clone());
         }
+        self.publish_snapshot(snapshot.clone());
 
         // Emit state change notification if status transitioned
         if let Some(ref prev) = previous_status {
@@ -459,6 +499,14 @@ impl HeartbeatService {
         std::fs::write(&self.state_path, json)
             .with_context(|| format!("Failed to write {}", self.state_path.display()))?;
         Ok(())
+    }
+
+    /// Publish the latest snapshot to all registered sinks.
+    fn publish_snapshot(&self, snapshot: HealthSnapshot) {
+        let sinks = self.snapshot_sinks.read().clone();
+        for sink in sinks {
+            *sink.write() = Some(snapshot.clone());
+        }
     }
 }
 
@@ -1382,5 +1430,74 @@ mod tests {
 
         let report = svc.generate_full_report().await.unwrap();
         assert_eq!(report.total_checks_run, 3); // 2 from run_checks + 1 from generate_full_report
+    }
+
+    #[test]
+    fn test_with_registries_stores_dependencies() {
+        let config = nanobot_config::Config::default();
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions = SessionManager::new(tmp.path().to_path_buf()).unwrap();
+        sessions.get_or_create("session-1", None);
+
+        let mut providers = ProviderRegistry::new();
+        providers.register("mock", MockProvider);
+        providers.set_default("mock");
+
+        let tools = nanobot_tools::ToolRegistry::new();
+        nanobot_tools::builtins::register_all(&tools);
+
+        let service = HeartbeatService::with_registries(config, providers, tools, sessions.clone());
+
+        let attached_providers = service.provider_registry().unwrap();
+        let attached_tools = service.tool_registry().unwrap();
+        let attached_sessions = service.session_manager().unwrap();
+
+        assert_eq!(
+            attached_providers.provider_names(),
+            vec!["mock".to_string()]
+        );
+        assert!(!attached_tools.tool_names().is_empty());
+        assert_eq!(attached_sessions.session_count(), 1);
+    }
+
+    struct MockProvider;
+
+    #[async_trait::async_trait]
+    impl nanobot_providers::LlmProvider for MockProvider {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        async fn complete(
+            &self,
+            _request: nanobot_providers::CompletionRequest,
+        ) -> anyhow::Result<nanobot_providers::CompletionResponse> {
+            Ok(nanobot_providers::CompletionResponse {
+                content: Some("ok".to_string()),
+                tool_calls: None,
+                usage: None,
+                finish_reason: Some("stop".to_string()),
+            })
+        }
+
+        async fn complete_stream(
+            &self,
+            request: nanobot_providers::CompletionRequest,
+        ) -> anyhow::Result<nanobot_providers::base::BoxStream> {
+            use nanobot_providers::base::CompletionChunk;
+
+            let response = self.complete(request).await?;
+            let chunk = CompletionChunk {
+                delta: response.content,
+                tool_call_deltas: None,
+                usage: response.usage,
+                done: true,
+            };
+            Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
+        }
+
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
     }
 }

--- a/crates/nanobot-memory/src/error.rs
+++ b/crates/nanobot-memory/src/error.rs
@@ -79,7 +79,7 @@ mod tests {
     #[test]
     fn test_result_alias() {
         let ok: Result<i32> = Ok(42);
-        assert_eq!(ok.unwrap(), 42);
+        assert!(matches!(ok, Ok(42)));
 
         let err: Result<String> = Err(MemoryError::NotFound("x".to_string()));
         assert!(err.is_err());

--- a/crates/nanobot-providers/tests/anthropic_sse.rs
+++ b/crates/nanobot-providers/tests/anthropic_sse.rs
@@ -11,10 +11,14 @@ use nanobot_providers::{LlmProvider, RetryConfig};
 async fn start_mock_server(
     response_body: &str,
     content_type: &str,
-) -> (u16, tokio::task::JoinHandle<()>) {
+) -> Option<(u16, tokio::task::JoinHandle<()>)> {
     let body = response_body.to_string();
     let ct = content_type.to_string();
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(e) => panic!("failed to bind mock Anthropic server: {e}"),
+    };
     let port = listener.local_addr().unwrap().port();
 
     let handle = tokio::spawn(async move {
@@ -42,7 +46,7 @@ async fn start_mock_server(
         let _ = writer.write_all(resp.as_bytes()).await;
     });
 
-    (port, handle)
+    Some((port, handle))
 }
 
 /// Helper: start a mock server that returns `error_count` error responses,
@@ -51,9 +55,13 @@ async fn start_mock_retry_server(
     error_status: u16,
     error_count: usize,
     success_body: &str,
-) -> (u16, tokio::task::JoinHandle<()>) {
+) -> Option<(u16, tokio::task::JoinHandle<()>)> {
     let body = success_body.to_string();
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(e) => panic!("failed to bind mock Anthropic retry server: {e}"),
+    };
     let port = listener.local_addr().unwrap().port();
     let err_count = error_count;
 
@@ -91,7 +99,7 @@ async fn start_mock_retry_server(
         }
     });
 
-    (port, handle)
+    Some((port, handle))
 }
 
 /// Build a no-proxy HTTP client for tests.
@@ -142,7 +150,9 @@ fn make_request(stream: bool) -> nanobot_providers::CompletionRequest {
 async fn test_anthropic_non_streaming_with_mock() {
     let response_body = r#"{"id":"msg_123","type":"message","role":"assistant","content":[{"type":"text","text":"Hello from Claude!"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}"#;
 
-    let (port, _handle) = start_mock_server(response_body, "application/json").await;
+    let Some((port, _handle)) = start_mock_server(response_body, "application/json").await else {
+        return;
+    };
     let provider = make_provider(port);
 
     let response = provider.complete(make_request(false)).await.unwrap();
@@ -158,7 +168,9 @@ async fn test_anthropic_non_streaming_with_mock() {
 async fn test_anthropic_non_streaming_tool_calls() {
     let response_body = r#"{"id":"msg_456","type":"message","role":"assistant","content":[{"type":"text","text":"Let me check the weather."},{"type":"tool_use","id":"toolu_abc","name":"get_weather","input":{"city":"Berlin"}}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":20,"output_tokens":15}}"#;
 
-    let (port, _handle) = start_mock_server(response_body, "application/json").await;
+    let Some((port, _handle)) = start_mock_server(response_body, "application/json").await else {
+        return;
+    };
     let provider = make_provider(port);
 
     let response = provider.complete(make_request(false)).await.unwrap();
@@ -194,7 +206,9 @@ async fn test_anthropic_sse_streaming_with_mock() {
         "\n\n",
     );
 
-    let (port, _handle) = start_mock_server(sse_body, "text/event-stream").await;
+    let Some((port, _handle)) = start_mock_server(sse_body, "text/event-stream").await else {
+        return;
+    };
     let provider = make_provider(port);
 
     let mut stream = provider.complete_stream(make_request(true)).await.unwrap();
@@ -241,7 +255,9 @@ async fn test_anthropic_sse_tool_calls() {
         "\n\n",
     );
 
-    let (port, _handle) = start_mock_server(sse_body, "text/event-stream").await;
+    let Some((port, _handle)) = start_mock_server(sse_body, "text/event-stream").await else {
+        return;
+    };
     let provider = make_provider(port);
 
     let mut stream = provider.complete_stream(make_request(true)).await.unwrap();
@@ -275,7 +291,9 @@ async fn test_anthropic_retry_on_429_then_success() {
     let success_body = r#"{"id":"msg_retry","type":"message","role":"assistant","content":[{"type":"text","text":"retry ok!"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}"#;
 
     // Server returns 429 once, then 200.
-    let (port, _handle) = start_mock_retry_server(429, 1, success_body).await;
+    let Some((port, _handle)) = start_mock_retry_server(429, 1, success_body).await else {
+        return;
+    };
     let retry = RetryConfig::default().with_max_retries(3);
     let provider = make_provider_with_retry(port, retry);
 
@@ -288,7 +306,9 @@ async fn test_anthropic_retry_on_429_then_success() {
 async fn test_anthropic_retry_on_503_then_success() {
     let success_body = r#"{"id":"msg_retry2","type":"message","role":"assistant","content":[{"type":"text","text":"server recovered"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}"#;
 
-    let (port, _handle) = start_mock_retry_server(503, 2, success_body).await;
+    let Some((port, _handle)) = start_mock_retry_server(503, 2, success_body).await else {
+        return;
+    };
     let retry = RetryConfig::default().with_max_retries(3);
     let provider = make_provider_with_retry(port, retry);
 
@@ -300,7 +320,9 @@ async fn test_anthropic_retry_on_503_then_success() {
 #[tokio::test]
 async fn test_anthropic_retry_exhausted() {
     // Server always returns 429.
-    let (port, _handle) = start_mock_retry_server(429, 5, "").await;
+    let Some((port, _handle)) = start_mock_retry_server(429, 5, "").await else {
+        return;
+    };
     let retry = RetryConfig::default().with_max_retries(2);
     let provider = make_provider_with_retry(port, retry);
 

--- a/crates/nanobot-providers/tests/openai_sse.rs
+++ b/crates/nanobot-providers/tests/openai_sse.rs
@@ -12,10 +12,14 @@ use nanobot_providers::{LlmProvider, RetryConfig};
 async fn start_mock_http_server(
     response_body: &str,
     content_type: &str,
-) -> (u16, tokio::task::JoinHandle<()>) {
+) -> Option<(u16, tokio::task::JoinHandle<()>)> {
     let body = response_body.to_string();
     let ct = content_type.to_string();
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(e) => panic!("failed to bind mock OpenAI server: {e}"),
+    };
     let port = listener.local_addr().unwrap().port();
 
     let handle = tokio::spawn(async move {
@@ -43,7 +47,7 @@ async fn start_mock_http_server(
         let _ = writer.write_all(resp.as_bytes()).await;
     });
 
-    (port, handle)
+    Some((port, handle))
 }
 
 /// Helper: start a mock server that returns `error_count` 429 responses,
@@ -52,9 +56,13 @@ async fn start_mock_retry_server(
     error_status: u16,
     error_count: usize,
     success_body: &str,
-) -> (u16, tokio::task::JoinHandle<()>) {
+) -> Option<(u16, tokio::task::JoinHandle<()>)> {
     let body = success_body.to_string();
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(e) => panic!("failed to bind mock OpenAI retry server: {e}"),
+    };
     let port = listener.local_addr().unwrap().port();
     let err_count = error_count;
 
@@ -92,7 +100,7 @@ async fn start_mock_retry_server(
         }
     });
 
-    (port, handle)
+    Some((port, handle))
 }
 
 /// Build a no-proxy HTTP client for tests.
@@ -144,7 +152,10 @@ fn make_request(stream: bool) -> nanobot_providers::CompletionRequest {
 async fn test_openai_non_streaming_with_mock() {
     let response_body = r#"{"choices":[{"message":{"content":"Hello!","tool_calls":null},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}"#;
 
-    let (port, _handle) = start_mock_http_server(response_body, "application/json").await;
+    let Some((port, _handle)) = start_mock_http_server(response_body, "application/json").await
+    else {
+        return;
+    };
     let provider = make_provider(port);
 
     let response = provider.complete(make_request(false)).await.unwrap();
@@ -161,7 +172,10 @@ async fn test_openai_non_streaming_with_mock() {
 async fn test_openai_non_streaming_tool_calls() {
     let response_body = r#"{"choices":[{"message":{"content":null,"tool_calls":[{"id":"call_abc","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Berlin\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":15,"total_tokens":25}}"#;
 
-    let (port, _handle) = start_mock_http_server(response_body, "application/json").await;
+    let Some((port, _handle)) = start_mock_http_server(response_body, "application/json").await
+    else {
+        return;
+    };
     let provider = make_provider(port);
 
     let response = provider.complete(make_request(false)).await.unwrap();
@@ -185,7 +199,9 @@ async fn test_openai_sse_streaming_with_mock() {
         "data: [DONE]\n\n",
     );
 
-    let (port, _handle) = start_mock_http_server(sse_body, "text/event-stream").await;
+    let Some((port, _handle)) = start_mock_http_server(sse_body, "text/event-stream").await else {
+        return;
+    };
     let provider = make_provider(port);
 
     let mut stream = provider.complete_stream(make_request(true)).await.unwrap();
@@ -222,7 +238,9 @@ async fn test_openai_sse_tool_calls() {
         "data: [DONE]\n\n",
     );
 
-    let (port, _handle) = start_mock_http_server(sse_body, "text/event-stream").await;
+    let Some((port, _handle)) = start_mock_http_server(sse_body, "text/event-stream").await else {
+        return;
+    };
     let provider = make_provider(port);
 
     let mut stream = provider.complete_stream(make_request(true)).await.unwrap();
@@ -256,7 +274,9 @@ async fn test_openai_retry_on_429_then_success() {
     let success_body = r#"{"choices":[{"message":{"content":"retry ok!","tool_calls":null},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
 
     // Server returns 429 once, then 200.
-    let (port, _handle) = start_mock_retry_server(429, 1, success_body).await;
+    let Some((port, _handle)) = start_mock_retry_server(429, 1, success_body).await else {
+        return;
+    };
     let retry = RetryConfig::default().with_max_retries(3);
     let provider = make_provider_with_retry(port, retry);
 
@@ -269,7 +289,9 @@ async fn test_openai_retry_on_429_then_success() {
 async fn test_openai_retry_on_503_then_success() {
     let success_body = r#"{"choices":[{"message":{"content":"server recovered","tool_calls":null},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
 
-    let (port, _handle) = start_mock_retry_server(503, 2, success_body).await;
+    let Some((port, _handle)) = start_mock_retry_server(503, 2, success_body).await else {
+        return;
+    };
     let retry = RetryConfig::default().with_max_retries(3);
     let provider = make_provider_with_retry(port, retry);
 
@@ -281,7 +303,9 @@ async fn test_openai_retry_on_503_then_success() {
 #[tokio::test]
 async fn test_openai_retry_exhausted() {
     // Server always returns 429 (more times than we'll retry).
-    let (port, _handle) = start_mock_retry_server(429, 5, "").await;
+    let Some((port, _handle)) = start_mock_retry_server(429, 5, "").await else {
+        return;
+    };
     let retry = RetryConfig::default().with_max_retries(2);
     let provider = make_provider_with_retry(port, retry);
 

--- a/crates/nanobot-session/src/note_store.rs
+++ b/crates/nanobot-session/src/note_store.rs
@@ -166,6 +166,7 @@ impl NoteStore {
 }
 
 #[cfg(test)]
+#[allow(clippy::useless_vec)]
 mod tests {
     use super::*;
 

--- a/crates/nanobot-skill/src/error.rs
+++ b/crates/nanobot-skill/src/error.rs
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn test_result_alias() {
         let ok: SkillResult<i32> = Ok(42);
-        assert_eq!(ok.unwrap(), 42);
+        assert!(matches!(ok, Ok(42)));
 
         let err: SkillResult<String> = Err(SkillError::NotFound("x".to_string()));
         assert!(err.is_err());
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn test_serialize_failed_display() {
         // Create a type that fails to serialize to TOML
-        let err = toml::to_string(&std::f64::NAN).unwrap_err();
+        let err = toml::to_string(&f64::NAN).unwrap_err();
         let skill_err: SkillError = err.into();
         assert!(matches!(skill_err, SkillError::SerializeFailed(_)));
         assert!(format!("{skill_err}").contains("serialize"));

--- a/crates/nanobot-tools/src/builtins/search.rs
+++ b/crates/nanobot-tools/src/builtins/search.rs
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_grep_tool_default() {
-        let tool = GrepTool::default();
+        let tool = GrepTool;
         assert_eq!(tool.name(), "grep");
     }
 
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_glob_tool_default() {
-        let tool = GlobTool::default();
+        let tool = GlobTool;
         assert_eq!(tool.name(), "glob");
     }
 }

--- a/crates/nanobot-tools/src/skill_loader.rs
+++ b/crates/nanobot-tools/src/skill_loader.rs
@@ -1709,7 +1709,7 @@ mod tests {
         loader.load_all().unwrap();
         assert_eq!(loader.cache_size(), 2);
 
-        let _removed = loader.invalidate_by_name("a");
+        loader.invalidate_by_name("a");
         // invalidate_by_name doesn't return, but the effect should be visible
         assert!(loader.get("a").is_none());
         assert!(loader.get("b").is_some());

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -15,14 +15,17 @@ use nanobot_bus::events::AgentEvent;
 use nanobot_bus::MessageBus;
 use nanobot_channels::{ChannelManager, ChannelRegistry};
 use nanobot_config::Config;
-use nanobot_heartbeat::HeartbeatService;
+use nanobot_heartbeat::{
+    BusHealthCheck, ChannelHealthCheck, HeartbeatService, MemoryStoreHealthCheck,
+    ProviderHealthCheck,
+};
 use nanobot_learning::config::LearningConfig;
 use nanobot_learning::event::LearningEventBus;
 use nanobot_learning::processor::BasicEventProcessor;
 use nanobot_learning::prompt::PromptAssembler;
 use nanobot_learning::store::EventStore;
 use nanobot_learning::LearningEventHandler;
-use nanobot_memory::{HotStore, MemoryConfig};
+use nanobot_memory::{HotStore, MemoryConfig, MemoryStore};
 use nanobot_providers::ProviderRegistry;
 use nanobot_session::SessionManager;
 use nanobot_skill::{SkillConfig, SkillLoader, SkillRegistry};
@@ -62,6 +65,46 @@ async fn init_skill_registry(home: &Path) -> Arc<SkillRegistry> {
     }
 
     registry
+}
+
+/// Register the gateway heartbeat checks and publish an initial snapshot.
+async fn prime_gateway_heartbeat(
+    heartbeat: &mut HeartbeatService,
+    api_server: &ApiServer,
+    provider_registry: ProviderRegistry,
+    bus: MessageBus,
+    memory_store: Option<Arc<dyn MemoryStore>>,
+    channel_manager: Arc<ChannelManager>,
+) -> Result<Arc<parking_lot::RwLock<Vec<(String, bool)>>>> {
+    let channel_statuses = Arc::new(parking_lot::RwLock::new(
+        channel_manager.channel_statuses().await,
+    ));
+
+    heartbeat.set_bus(bus.clone());
+    heartbeat.register_check(Arc::new(ProviderHealthCheck::new(Arc::new(
+        provider_registry,
+    ))));
+    heartbeat.register_check(Arc::new(BusHealthCheck::new(bus)));
+    if let Some(store) = memory_store {
+        heartbeat.register_check(Arc::new(MemoryStoreHealthCheck::new(store)));
+    }
+    heartbeat.register_check(Arc::new(ChannelHealthCheck::new(channel_statuses.clone())));
+    heartbeat.add_snapshot_sink(api_server.health_snapshot_lock());
+    heartbeat.run_checks().await?;
+
+    Ok(channel_statuses)
+}
+
+/// Keep the shared channel health snapshot in sync with the channel manager.
+async fn refresh_channel_health(
+    channel_manager: Arc<ChannelManager>,
+    statuses: Arc<parking_lot::RwLock<Vec<(String, bool)>>>,
+) {
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
+    loop {
+        interval.tick().await;
+        *statuses.write() = channel_manager.channel_statuses().await;
+    }
 }
 
 /// Run the gateway — starts all components and connects them via the bus.
@@ -107,6 +150,7 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
 
     // ── Agent loop ────────────────────────────────────────────
     let learning_bus = LearningEventBus::new();
+    let mut heartbeat_memory_store: Option<Arc<dyn MemoryStore>> = None;
 
     let agent_loop = {
         let mut al = AgentLoop::new(
@@ -125,7 +169,9 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         match HotStore::new(&memory_config).await {
             Ok(hot_store) => {
                 info!("Memory store initialized (HotStore L1)");
-                al = al.with_memory_store(Arc::new(hot_store));
+                let hot_store = Arc::new(hot_store);
+                heartbeat_memory_store = Some(hot_store.clone() as Arc<dyn MemoryStore>);
+                al = al.with_memory_store(hot_store);
             }
             Err(e) => {
                 tracing::warn!(
@@ -183,7 +229,7 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     }
 
     // ── Heartbeat service ─────────────────────────────────────
-    let heartbeat = HeartbeatService::with_registries(
+    let mut heartbeat = HeartbeatService::with_registries(
         config.clone(),
         provider_registry.clone(),
         tool_registry.clone(),
@@ -195,10 +241,20 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         config.clone(),
         bus.clone(),
         session_manager,
-        provider_registry,
+        provider_registry.clone(),
         tool_registry,
         None,
     );
+
+    let channel_statuses = prime_gateway_heartbeat(
+        &mut heartbeat,
+        &api_server,
+        provider_registry.clone(),
+        bus.clone(),
+        heartbeat_memory_store,
+        channel_manager.clone(),
+    )
+    .await?;
 
     // ── Spawn background tasks ────────────────────────────────
     let _agent_handle = tokio::spawn(async move {
@@ -210,6 +266,11 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     let outbound_cm = channel_manager.clone();
     let _outbound_handle = tokio::spawn(async move {
         outbound_cm.run_outbound_consumer().await;
+    });
+
+    let health_cm = channel_manager.clone();
+    let _channel_health_handle = tokio::spawn(async move {
+        refresh_channel_health(health_cm, channel_statuses).await;
     });
 
     // ── Typing indicator lifecycle ──────────────────────────────

--- a/src/commands/heartbeat.rs
+++ b/src/commands/heartbeat.rs
@@ -1,8 +1,12 @@
 //! Heartbeat command — start the periodic task checking service.
 
 use anyhow::Result;
+use nanobot_bus::MessageBus;
 use nanobot_config::Config;
-use nanobot_heartbeat::HeartbeatService;
+use nanobot_heartbeat::{
+    BusHealthCheck, HeartbeatService, MemoryStoreHealthCheck, ProviderHealthCheck,
+};
+use nanobot_memory::{HotStore, MemoryConfig, MemoryStore};
 use nanobot_providers::ProviderRegistry;
 use nanobot_session::SessionManager;
 use nanobot_tools::builtins;
@@ -13,7 +17,8 @@ pub async fn run(config: Config, dangerous: bool) -> Result<()> {
     info!("Starting nanobot heartbeat service...");
 
     let home = nanobot_config::paths::get_nanobot_home()?;
-    let session_manager = SessionManager::new(home)?;
+    let session_manager = SessionManager::new(home.clone())?;
+    let bus = MessageBus::new();
 
     let provider_registry = ProviderRegistry::from_config(&config)?;
     info!("Providers: {:?}", provider_registry.provider_names());
@@ -22,12 +27,35 @@ pub async fn run(config: Config, dangerous: bool) -> Result<()> {
     builtins::register_all_with_config(&tool_registry, builtins::BuiltinsConfig { dangerous });
     info!("Tools: {:?}", tool_registry.tool_names());
 
-    let heartbeat = HeartbeatService::with_registries(
+    let mut heartbeat = HeartbeatService::with_registries(
         config.clone(),
-        provider_registry,
+        provider_registry.clone(),
         tool_registry,
         session_manager,
     );
+    heartbeat.set_bus(bus.clone());
+    heartbeat.register_check(std::sync::Arc::new(ProviderHealthCheck::new(
+        std::sync::Arc::new(provider_registry),
+    )));
+    heartbeat.register_check(std::sync::Arc::new(BusHealthCheck::new(bus)));
+
+    let memory_config = MemoryConfig {
+        hot_store_path: home.join("memory").join("hot.jsonl"),
+        ..MemoryConfig::default()
+    };
+    match HotStore::new(&memory_config).await {
+        Ok(hot_store) => {
+            let store: std::sync::Arc<dyn MemoryStore> = std::sync::Arc::new(hot_store);
+            heartbeat.register_check(std::sync::Arc::new(MemoryStoreHealthCheck::new(store)));
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Failed to initialize memory store for heartbeat checks, continuing without memory: {}",
+                e
+            );
+        }
+    }
+    heartbeat.run_checks().await?;
 
     info!(
         "Heartbeat running (interval: {}s, press Ctrl+C to stop)",


### PR DESCRIPTION
Closes #44

- HeartbeatService::with_registries() now stores providers/tools/sessions/bus
- Gateway registers real checks (provider, bus, memory, channel) before heartbeat.run()
- API /health endpoint receives real HealthSnapshot from heartbeat
- Initial check primed so /health returns real data instead of 'starting'
- Regression tests for registry storage and heartbeat-to-API health wiring

Validation: cargo test --workspace + cargo clippy --workspace -- -D warnings pass.