### PR TITLE
fix(heartbeat): use configured model name in provider health check

### DIFF
--- a/crates/kestrel-agent/src/heartbeat.rs
+++ b/crates/kestrel-agent/src/heartbeat.rs
@@ -1282,6 +1282,9 @@ mod tests {
         fn name(&self) -> &str {
             "mock"
         }
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
         async fn complete(
             &self,
             _req: kestrel_providers::base::CompletionRequest,

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -942,6 +942,10 @@ mod tests {
             "mock"
         }
 
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
+
         async fn complete(
             &self,
             _request: CompletionRequest,

--- a/crates/kestrel-agent/src/subagent.rs
+++ b/crates/kestrel-agent/src/subagent.rs
@@ -1098,6 +1098,10 @@ mod tests {
             "mock"
         }
 
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
+
         async fn complete(&self, _req: CompletionRequest) -> Result<CompletionResponse> {
             let idx = self.call_count.fetch_add(1, Ordering::SeqCst) as usize;
             self.responses
@@ -1141,6 +1145,10 @@ mod tests {
     impl LlmProvider for DelayedProvider {
         fn name(&self) -> &str {
             "mock-delayed"
+        }
+
+        fn default_model(&self) -> &str {
+            "mock-model"
         }
 
         async fn complete(&self, _req: CompletionRequest) -> Result<CompletionResponse> {
@@ -1515,6 +1523,9 @@ mod tests {
         impl LlmProvider for FailOnSecond {
             fn name(&self) -> &str {
                 "fail-second"
+            }
+            fn default_model(&self) -> &str {
+                "mock-model"
             }
             async fn complete(&self, _req: CompletionRequest) -> Result<CompletionResponse> {
                 let n = self.call_count.fetch_add(1, Ordering::SeqCst);

--- a/crates/kestrel-agent/tests/pipeline_e2e.rs
+++ b/crates/kestrel-agent/tests/pipeline_e2e.rs
@@ -42,6 +42,10 @@ impl LlmProvider for MockProvider {
         "mock"
     }
 
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
+
     async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
         let resp = self
@@ -366,6 +370,9 @@ async fn test_pipeline_provider_error_handled() {
     impl LlmProvider for FailingProvider {
         fn name(&self) -> &str {
             "failing"
+        }
+        fn default_model(&self) -> &str {
+            "mock-model"
         }
         async fn complete(
             &self,

--- a/crates/kestrel-agent/tests/runner_e2e.rs
+++ b/crates/kestrel-agent/tests/runner_e2e.rs
@@ -40,6 +40,10 @@ impl LlmProvider for MockProvider {
         "mock"
     }
 
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
+
     async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
         let resp = self
@@ -315,6 +319,10 @@ async fn test_agent_tool_arg_error_includes_details() {
     impl LlmProvider for CaptureProvider {
         fn name(&self) -> &str {
             "capture"
+        }
+
+        fn default_model(&self) -> &str {
+            "mock-model"
         }
 
         async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {

--- a/crates/kestrel-agent/tests/self_evolution_e2e.rs
+++ b/crates/kestrel-agent/tests/self_evolution_e2e.rs
@@ -101,6 +101,10 @@ impl LlmProvider for MockProvider {
         "mock"
     }
 
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
+
     async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         // Capture system prompt for later verification
         if let Some(sys) = request.messages.first() {
@@ -778,6 +782,9 @@ async fn test_self_evolution_provider_error() {
     impl LlmProvider for FailingProvider {
         fn name(&self) -> &str {
             "failing"
+        }
+        fn default_model(&self) -> &str {
+            "mock-model"
         }
         async fn complete(
             &self,

--- a/crates/kestrel-api/src/server.rs
+++ b/crates/kestrel-api/src/server.rs
@@ -936,6 +936,9 @@ mod tests {
         fn name(&self) -> &str {
             "mock"
         }
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             Ok(CompletionResponse {
                 content: Some("Mock response".to_string()),

--- a/crates/kestrel-api/tests/http_integration.rs
+++ b/crates/kestrel-api/tests/http_integration.rs
@@ -27,6 +27,9 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
     async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         Ok(CompletionResponse {
             content: Some("Mock integration response".to_string()),

--- a/crates/kestrel-heartbeat/src/checks.rs
+++ b/crates/kestrel-heartbeat/src/checks.rs
@@ -72,7 +72,7 @@ impl HealthCheck for ProviderHealthCheck {
         for name in &names {
             if let Some(provider) = self.providers.get_provider_by_name(name) {
                 let request = kestrel_providers::CompletionRequest {
-                    model: name.clone(),
+                    model: provider.default_model().to_string(),
                     messages: vec![kestrel_core::Message {
                         role: kestrel_core::MessageRole::User,
                         content: "health check".to_string(),
@@ -411,6 +411,9 @@ mod tests {
         fn name(&self) -> &str {
             "mock_healthy"
         }
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
         async fn complete(
             &self,
             _request: kestrel_providers::CompletionRequest,
@@ -450,6 +453,9 @@ mod tests {
         fn name(&self) -> &str {
             "mock_failing"
         }
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
         async fn complete(
             &self,
             _request: kestrel_providers::CompletionRequest,
@@ -481,6 +487,9 @@ mod tests {
     impl kestrel_providers::LlmProvider for MockSlowProvider {
         fn name(&self) -> &str {
             "mock_slow"
+        }
+        fn default_model(&self) -> &str {
+            "mock-model"
         }
         async fn complete(
             &self,
@@ -529,6 +538,71 @@ mod tests {
         let result = check.report_health().await;
         assert_eq!(result.status, CheckStatus::Healthy);
         assert!(result.message.contains("1/1"));
+    }
+
+    #[tokio::test]
+    async fn test_provider_check_uses_default_model() {
+        struct CapturingProvider {
+            last_model: Arc<parking_lot::Mutex<Option<String>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl kestrel_providers::LlmProvider for CapturingProvider {
+            fn name(&self) -> &str {
+                "capturing"
+            }
+
+            fn default_model(&self) -> &str {
+                "configured-model"
+            }
+
+            async fn complete(
+                &self,
+                request: kestrel_providers::CompletionRequest,
+            ) -> anyhow::Result<kestrel_providers::CompletionResponse> {
+                *self.last_model.lock() = Some(request.model);
+                Ok(kestrel_providers::CompletionResponse {
+                    content: Some("ok".to_string()),
+                    tool_calls: None,
+                    usage: None,
+                    finish_reason: None,
+                })
+            }
+
+            async fn complete_stream(
+                &self,
+                request: kestrel_providers::CompletionRequest,
+            ) -> anyhow::Result<kestrel_providers::base::BoxStream> {
+                let resp = self.complete(request).await?;
+                let chunk = kestrel_providers::base::CompletionChunk {
+                    delta: resp.content,
+                    tool_call_deltas: None,
+                    usage: None,
+                    done: true,
+                };
+                Ok(Box::pin(futures::stream::once(async move { Ok(chunk) })))
+            }
+
+            fn supports_model(&self, _model: &str) -> bool {
+                true
+            }
+        }
+
+        let last_model = Arc::new(parking_lot::Mutex::new(None));
+        let mut registry = ProviderRegistry::new();
+        registry.register(
+            "openai",
+            CapturingProvider {
+                last_model: last_model.clone(),
+            },
+        );
+
+        let result = ProviderHealthCheck::new(Arc::new(registry))
+            .report_health()
+            .await;
+
+        assert_eq!(result.status, CheckStatus::Healthy);
+        assert_eq!(last_model.lock().as_deref(), Some("configured-model"));
     }
 
     #[tokio::test]

--- a/crates/kestrel-heartbeat/src/service.rs
+++ b/crates/kestrel-heartbeat/src/service.rs
@@ -1468,6 +1468,10 @@ mod tests {
             "mock"
         }
 
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
+
         async fn complete(
             &self,
             _request: kestrel_providers::CompletionRequest,

--- a/crates/kestrel-providers/src/anthropic.rs
+++ b/crates/kestrel-providers/src/anthropic.rs
@@ -351,6 +351,10 @@ impl LlmProvider for AnthropicProvider {
         "anthropic"
     }
 
+    fn default_model(&self) -> &str {
+        &self.config.model
+    }
+
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse> {
         let url = format!("{}/v1/messages", self.base_url());
         let body = self.build_request_body(&request);

--- a/crates/kestrel-providers/src/base.rs
+++ b/crates/kestrel-providers/src/base.rs
@@ -18,6 +18,9 @@ pub trait LlmProvider: Send + Sync {
     /// The provider name (e.g., "openai", "anthropic").
     fn name(&self) -> &str;
 
+    /// Returns the provider's configured default model name.
+    fn default_model(&self) -> &str;
+
     /// Perform a non-streaming completion.
     async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse>;
 

--- a/crates/kestrel-providers/src/middleware.rs
+++ b/crates/kestrel-providers/src/middleware.rs
@@ -185,6 +185,10 @@ impl LlmProvider for ProviderMiddleware {
         self.inner.name()
     }
 
+    fn default_model(&self) -> &str {
+        self.inner.default_model()
+    }
+
     async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         // 1. Circuit breaker check (fail-fast if open)
         if let Some(ref cb) = self.config.circuit_breaker {
@@ -309,6 +313,10 @@ mod tests {
             "mock_middleware"
         }
 
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
+
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             let n = self.call_count.fetch_add(1, Ordering::SeqCst);
             let fail_until = self.fail_until.load(Ordering::SeqCst);
@@ -366,6 +374,10 @@ mod tests {
     impl LlmProvider for MockProvider503 {
         fn name(&self) -> &str {
             "mock_503"
+        }
+
+        fn default_model(&self) -> &str {
+            "mock-model"
         }
 
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {

--- a/crates/kestrel-providers/src/openai_compat.rs
+++ b/crates/kestrel-providers/src/openai_compat.rs
@@ -358,6 +358,10 @@ impl LlmProvider for OpenAiCompatProvider {
         "openai_compat"
     }
 
+    fn default_model(&self) -> &str {
+        &self.config.model
+    }
+
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse> {
         let url = format!("{}/chat/completions", self.config.base_url);
         let body = self.build_request_body(&request);

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -163,7 +163,7 @@ impl ProviderRegistry {
             let provider = OpenAiCompatProvider::new(OpenAiCompatConfig {
                 api_key: custom.api_key.clone().unwrap_or_default(),
                 base_url: custom.base_url.clone(),
-                model: String::new(),
+                model: custom.model_patterns.first().cloned().unwrap_or_default(),
                 organization: None,
                 no_proxy: custom.no_proxy.unwrap_or(false),
             })?;
@@ -262,6 +262,9 @@ mod tests {
     impl LlmProvider for MockProvider {
         fn name(&self) -> &str {
             &self.provider_name
+        }
+        fn default_model(&self) -> &str {
+            &self.supported_model
         }
         async fn complete(
             &self,

--- a/tests/e2e_integration_test.rs
+++ b/tests/e2e_integration_test.rs
@@ -63,6 +63,10 @@ impl LlmProvider for MockProvider {
         "mock"
     }
 
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
+
     async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         let idx = self.call_count.fetch_add(1, Ordering::SeqCst) as usize;
         let resp = self.responses.get(idx).cloned().unwrap_or_else(|| {

--- a/tests/full_integration_test.rs
+++ b/tests/full_integration_test.rs
@@ -66,6 +66,10 @@ impl LlmProvider for MockProvider {
         "mock"
     }
 
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
+
     fn supports_model(&self, _model: &str) -> bool {
         true
     }

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -82,6 +82,10 @@ impl LlmProvider for MockProvider {
         "mock"
     }
 
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
+
     async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
         let idx = self.call_count.fetch_add(1, Ordering::SeqCst) as usize;
         self.responses.get(idx).cloned().ok_or_else(|| {
@@ -742,6 +746,9 @@ async fn test_pipeline_subagent_error_isolation() {
         fn name(&self) -> &str {
             "fail-mock"
         }
+        fn default_model(&self) -> &str {
+            "mock-model"
+        }
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             Err(anyhow::anyhow!("Simulated sub-agent failure"))
         }
@@ -769,6 +776,9 @@ async fn test_pipeline_subagent_error_isolation() {
     impl LlmProvider for AlternatingProvider {
         fn name(&self) -> &str {
             "alt-mock"
+        }
+        fn default_model(&self) -> &str {
+            "mock-model"
         }
         async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
             let n = self.call_count.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
## Summary

Fixes #69

The health check in `kestrel-heartbeat/src/checks.rs` was using `name.clone()` (the provider registry key, e.g. `"openai"`) as the model name in the completion request. This caused the health check to always fail because `"openai"` is not a valid model identifier for any LLM API.

## Root Cause

`checks.rs` L75:
```rust
// Before (bug):
model: name.clone(),  // sends "openai" as model name

// After (fix):
model: provider.default_model().to_string(),  // sends "glm-5-turbo" (the configured model)
```

## Changes

1. **`kestrel-providers/src/base.rs`**: Added `default_model()` method to `LlmProvider` trait — returns the provider's configured default model name
2. **`kestrel-providers/src/openai_compat.rs`**: Implemented `default_model()` — returns `self.config.model`
3. **`kestrel-providers/src/anthropic.rs`**: Implemented `default_model()` — returns configured model
4. **`kestrel-providers/src/registry.rs`**: Fixed `build_from_config()` to populate model from `model_patterns.first()` instead of empty string
5. **`kestrel-providers/src/middleware.rs`**: Implemented `default_model()` — delegates to inner provider
6. **`kestrel-heartbeat/src/checks.rs`**: Uses `provider.default_model()` instead of `name.clone()`
7. **All consumers** (agent loop, subagent, API server, heartbeat service): Added `default_model()` implementations
8. **All test mocks**: Added `default_model()` returning `"mock-model"`
9. **New test**: `test_provider_check_uses_default_model()` — a `CapturingProvider` that verifies the health check sends the correct model name

## Testing

- `cargo check --workspace` ✓
- `cargo clippy --workspace` ✓ (0 warnings)
- 18 files changed, 170 insertions(+), 2 deletions(-)