### PR TITLE
feat(channels): add online notification on Telegram connect

### DIFF
--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -528,6 +528,7 @@ impl Default for CallbackRouter {
 pub struct TelegramChannel {
     token: Option<String>,
     connected: bool,
+    online_notified: bool,
     message_handler: Option<tokio::sync::mpsc::Sender<InboundMessage>>,
     running: Arc<AtomicBool>,
     client: reqwest::Client,
@@ -539,6 +540,9 @@ pub struct TelegramChannel {
     session_keys: Arc<ParkMutex<Vec<String>>>,
     /// Proxy URL for client rebuild on persistent failures.
     proxy_config: Option<String>,
+    online_notify: bool,
+    notify_chat_id: Option<String>,
+    online_message_template: String,
 }
 
 impl TelegramChannel {
@@ -627,6 +631,7 @@ impl TelegramChannel {
         Self {
             token: std::env::var("TELEGRAM_BOT_TOKEN").ok(),
             connected: false,
+            online_notified: false,
             message_handler: None,
             running: Arc::new(AtomicBool::new(false)),
             client: Self::build_client(None),
@@ -634,6 +639,9 @@ impl TelegramChannel {
             router: Arc::new(tokio::sync::Mutex::new(CallbackRouter::new())),
             session_keys: Arc::new(ParkMutex::new(Vec::new())),
             proxy_config: None,
+            online_notify: false,
+            notify_chat_id: None,
+            online_message_template: String::new(),
         }
     }
 
@@ -643,6 +651,17 @@ impl TelegramChannel {
     /// `TELEGRAM_BOT_TOKEN` env var) and configures the HTTP client proxy
     /// accordingly.
     pub fn new_with_config(config: &kestrel_config::schema::TelegramConfig) -> Self {
+        Self::new_with_notifications_config(
+            config,
+            &kestrel_config::schema::NotificationsConfig::default(),
+        )
+    }
+
+    /// Create a new TelegramChannel using Telegram and notification config.
+    pub fn new_with_notifications_config(
+        config: &kestrel_config::schema::TelegramConfig,
+        notifications: &kestrel_config::schema::NotificationsConfig,
+    ) -> Self {
         let token = if config.token.is_empty() {
             std::env::var("TELEGRAM_BOT_TOKEN").ok()
         } else {
@@ -652,6 +671,7 @@ impl TelegramChannel {
         Self {
             token,
             connected: false,
+            online_notified: false,
             message_handler: None,
             running: Arc::new(AtomicBool::new(false)),
             client: Self::build_client(proxy),
@@ -659,6 +679,9 @@ impl TelegramChannel {
             router: Arc::new(tokio::sync::Mutex::new(CallbackRouter::new())),
             session_keys: Arc::new(ParkMutex::new(Vec::new())),
             proxy_config: proxy.map(|s| s.to_string()),
+            online_notify: notifications.online_notify,
+            notify_chat_id: notifications.notify_chat_id.clone(),
+            online_message_template: notifications.online_message.clone(),
         }
     }
 
@@ -668,6 +691,7 @@ impl TelegramChannel {
         Self {
             token: Some(token),
             connected: false,
+            online_notified: false,
             message_handler: None,
             running: Arc::new(AtomicBool::new(false)),
             client: reqwest::Client::builder()
@@ -678,7 +702,46 @@ impl TelegramChannel {
             router: Arc::new(tokio::sync::Mutex::new(CallbackRouter::new())),
             session_keys: Arc::new(ParkMutex::new(Vec::new())),
             proxy_config: None,
+            online_notify: false,
+            notify_chat_id: None,
+            online_message_template: String::new(),
         }
+    }
+
+    /// Create with config-driven notification settings and a custom base URL.
+    ///
+    /// This is intended for tests that need to exercise connect-time behavior
+    /// against a local mock Telegram API.
+    pub fn with_config_and_url(
+        config: &kestrel_config::schema::TelegramConfig,
+        notifications: &kestrel_config::schema::NotificationsConfig,
+        base_url: String,
+    ) -> Self {
+        let mut channel = Self::new_with_notifications_config(config, notifications);
+        channel.base_url_override = Some(base_url);
+        channel.client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        channel
+    }
+
+    fn format_online_message(template: &str, channel: &str) -> String {
+        template
+            .replace("{version}", env!("CARGO_PKG_VERSION"))
+            .replace("{channel}", channel)
+    }
+
+    fn online_notification_payload(&self) -> Option<(String, String)> {
+        if !self.online_notify || self.online_notified {
+            return None;
+        }
+
+        let chat_id = self.notify_chat_id.clone()?;
+        Some((
+            chat_id,
+            Self::format_online_message(&self.online_message_template, "Telegram"),
+        ))
     }
 
     /// Build the API URL for a given method.
@@ -1448,6 +1511,32 @@ impl BaseChannel for TelegramChannel {
         self.running.store(true, Ordering::Relaxed);
         self.connected = true;
 
+        if let Some((chat_id, message)) = self.online_notification_payload() {
+            self.online_notified = true;
+            let client = self.client.clone();
+            let url = self.api_url("sendMessage");
+            tokio::spawn(async move {
+                let chat_id_num = match chat_id.parse::<i64>() {
+                    Ok(chat_id_num) => chat_id_num,
+                    Err(_) => {
+                        warn!("Invalid Telegram online notification chat_id: {chat_id}");
+                        return;
+                    }
+                };
+
+                let body = SendMessageBody {
+                    chat_id: chat_id_num,
+                    text: message,
+                    reply_to_message_id: None,
+                    reply_markup: None,
+                };
+
+                if let Err(e) = client.post(&url).json(&body).send().await {
+                    warn!("Failed to send Telegram online notification: {e}");
+                }
+            });
+        }
+
         // Register built-in callback handlers (e.g. /menu, settings, history).
         {
             let mut r = self.router.lock().await;
@@ -2093,6 +2182,46 @@ mod tests {
     fn test_running_flag_default() {
         let channel = TelegramChannel::new();
         assert!(!channel.running.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_format_online_message() {
+        let message = TelegramChannel::format_online_message(
+            "Kestrel v{version} online: {channel}",
+            "Telegram",
+        );
+        assert_eq!(
+            message,
+            format!("Kestrel v{} online: Telegram", env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    #[test]
+    fn test_online_notification_payload_requires_chat_id_and_flag() {
+        let config = kestrel_config::schema::TelegramConfig {
+            token: "123456:ABC-DEF".to_string(),
+            enabled: true,
+            allowed_users: vec![],
+            admin_users: vec![],
+            streaming: false,
+            proxy: None,
+        };
+        let notifications = kestrel_config::schema::NotificationsConfig {
+            online_notify: true,
+            notify_chat_id: Some("123".to_string()),
+            online_message: "Kestrel {version} {channel}".to_string(),
+        };
+        let mut channel = TelegramChannel::new_with_notifications_config(&config, &notifications);
+
+        let payload = channel.online_notification_payload().unwrap();
+        assert_eq!(payload.0, "123");
+        assert_eq!(
+            payload.1,
+            format!("Kestrel {} Telegram", env!("CARGO_PKG_VERSION"))
+        );
+
+        channel.online_notified = true;
+        assert!(channel.online_notification_payload().is_none());
     }
 
     #[test]
@@ -3540,6 +3669,8 @@ mod tests {
             channel.proxy_config.as_deref(),
             Some("http://proxy.example.com:8080")
         );
+        assert!(channel.online_notify);
+        assert!(channel.notify_chat_id.is_none());
     }
 
     #[test]
@@ -3569,5 +3700,29 @@ mod tests {
         let channel = TelegramChannel::new_with_config(&config);
         // Empty proxy should be treated as None
         assert!(channel.proxy_config.is_none());
+    }
+
+    #[test]
+    fn test_new_with_notifications_config_uses_notification_settings() {
+        let config = kestrel_config::schema::TelegramConfig {
+            token: "123456:ABC-DEF".to_string(),
+            enabled: true,
+            allowed_users: vec![],
+            admin_users: vec![],
+            streaming: false,
+            proxy: None,
+        };
+        let notifications = kestrel_config::schema::NotificationsConfig {
+            online_notify: true,
+            notify_chat_id: Some("-100123".to_string()),
+            online_message: "Online {channel} {version}".to_string(),
+        };
+        let channel = TelegramChannel::new_with_notifications_config(&config, &notifications);
+        assert!(channel.online_notify);
+        assert_eq!(channel.notify_chat_id.as_deref(), Some("-100123"));
+        assert_eq!(
+            channel.online_message_template,
+            "Online {channel} {version}"
+        );
     }
 }

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1527,6 +1527,7 @@ impl BaseChannel for TelegramChannel {
                 let body = SendMessageBody {
                     chat_id: chat_id_num,
                     text: message,
+                    parse_mode: None,
                     reply_to_message_id: None,
                     reply_markup: None,
                 };

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -528,7 +528,7 @@ impl Default for CallbackRouter {
 pub struct TelegramChannel {
     token: Option<String>,
     connected: bool,
-    online_notified: bool,
+    online_notified: Arc<AtomicBool>,
     message_handler: Option<tokio::sync::mpsc::Sender<InboundMessage>>,
     running: Arc<AtomicBool>,
     client: reqwest::Client,
@@ -631,7 +631,7 @@ impl TelegramChannel {
         Self {
             token: std::env::var("TELEGRAM_BOT_TOKEN").ok(),
             connected: false,
-            online_notified: false,
+            online_notified: Arc::new(AtomicBool::new(false)),
             message_handler: None,
             running: Arc::new(AtomicBool::new(false)),
             client: Self::build_client(None),
@@ -671,7 +671,7 @@ impl TelegramChannel {
         Self {
             token,
             connected: false,
-            online_notified: false,
+            online_notified: Arc::new(AtomicBool::new(false)),
             message_handler: None,
             running: Arc::new(AtomicBool::new(false)),
             client: Self::build_client(proxy),
@@ -691,7 +691,7 @@ impl TelegramChannel {
         Self {
             token: Some(token),
             connected: false,
-            online_notified: false,
+            online_notified: Arc::new(AtomicBool::new(false)),
             message_handler: None,
             running: Arc::new(AtomicBool::new(false)),
             client: reqwest::Client::builder()
@@ -733,7 +733,7 @@ impl TelegramChannel {
     }
 
     fn online_notification_payload(&self) -> Option<(String, String)> {
-        if !self.online_notify || self.online_notified {
+        if !self.online_notify || self.online_notified.load(Ordering::Relaxed) {
             return None;
         }
 
@@ -1512,9 +1512,9 @@ impl BaseChannel for TelegramChannel {
         self.connected = true;
 
         if let Some((chat_id, message)) = self.online_notification_payload() {
-            self.online_notified = true;
             let client = self.client.clone();
             let url = self.api_url("sendMessage");
+            let notified = self.online_notified.clone();
             tokio::spawn(async move {
                 let chat_id_num = match chat_id.parse::<i64>() {
                     Ok(chat_id_num) => chat_id_num,
@@ -1531,8 +1531,19 @@ impl BaseChannel for TelegramChannel {
                     reply_markup: None,
                 };
 
-                if let Err(e) = client.post(&url).json(&body).send().await {
-                    warn!("Failed to send Telegram online notification: {e}");
+                match client.post(&url).json(&body).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        notified.store(true, Ordering::Relaxed);
+                    }
+                    Ok(resp) => {
+                        warn!(
+                            "Telegram online notification failed with status: {}",
+                            resp.status()
+                        );
+                    }
+                    Err(e) => {
+                        warn!("Failed to send Telegram online notification: {e}");
+                    }
                 }
             });
         }
@@ -1572,6 +1583,7 @@ impl BaseChannel for TelegramChannel {
     async fn disconnect(&mut self) -> Result<()> {
         self.running.store(false, Ordering::Relaxed);
         self.connected = false;
+        self.online_notified.store(false, Ordering::Relaxed);
         info!("Telegram channel disconnected");
         Ok(())
     }
@@ -2211,7 +2223,7 @@ mod tests {
             notify_chat_id: Some("123".to_string()),
             online_message: "Kestrel {version} {channel}".to_string(),
         };
-        let mut channel = TelegramChannel::new_with_notifications_config(&config, &notifications);
+        let channel = TelegramChannel::new_with_notifications_config(&config, &notifications);
 
         let payload = channel.online_notification_payload().unwrap();
         assert_eq!(payload.0, "123");
@@ -2220,7 +2232,7 @@ mod tests {
             format!("Kestrel {} Telegram", env!("CARGO_PKG_VERSION"))
         );
 
-        channel.online_notified = true;
+        channel.online_notified.store(true, Ordering::Relaxed);
         assert!(channel.online_notification_payload().is_none());
     }
 
@@ -3723,6 +3735,151 @@ mod tests {
         assert_eq!(
             channel.online_message_template,
             "Online {channel} {version}"
+        );
+    }
+
+    /// Helper: spawn a minimal HTTP mock server on a random port.
+    /// Returns `(base_url, join_handle)`. Abort the handle to stop.
+    async fn spawn_mock_server(
+        getme_status: u16,
+        getme_body: &'static str,
+        send_status: u16,
+        send_body: &'static str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let base_url = format!("http://127.0.0.1:{port}");
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    continue;
+                };
+                let getme_status = getme_status;
+                let getme_body = getme_body;
+                let send_status = send_status;
+                let send_body = send_body;
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = vec![0u8; 4096];
+                    let _ = stream.read(&mut buf).await;
+                    let request = String::from_utf8_lossy(&buf);
+                    let path = request.lines().next().unwrap_or("");
+
+                    let (status, body) = if path.contains("getMe") {
+                        (getme_status, getme_body)
+                    } else if path.contains("sendMessage") {
+                        (send_status, send_body)
+                    } else {
+                        (404, "not found")
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 {status} OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.shutdown().await;
+                });
+            }
+        });
+
+        (base_url, handle)
+    }
+
+    /// Test: online_notified stays false when sendMessage returns non-success status.
+    #[tokio::test]
+    async fn test_online_notified_not_set_on_send_failure() {
+        let (base_url, _server) = spawn_mock_server(
+            200,
+            r#"{"ok":true,"result":{"id":1,"username":"bot"}}"#,
+            502,
+            r#"{"ok":false,"description":"Bad Gateway"}"#,
+        )
+        .await;
+
+        let config = kestrel_config::schema::TelegramConfig {
+            token: "123:ABC".to_string(),
+            enabled: true,
+            allowed_users: vec![],
+            admin_users: vec![],
+            streaming: false,
+            proxy: None,
+        };
+        let notifications = kestrel_config::schema::NotificationsConfig {
+            online_notify: true,
+            notify_chat_id: Some("999".to_string()),
+            online_message: "Online {channel}".to_string(),
+        };
+        let mut channel =
+            TelegramChannel::with_config_and_url(&config, &notifications, base_url.clone());
+        let (tx, _rx) = tokio::sync::mpsc::channel(10);
+        channel.set_message_handler(tx);
+
+        let notified = channel.online_notified.clone();
+        channel.connect().await.unwrap();
+
+        // Give the spawned task time to complete.
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        assert!(
+            !notified.load(Ordering::Relaxed),
+            "online_notified should remain false after send failure"
+        );
+    }
+
+    /// Test: online_notified is set to true after successful sendMessage.
+    #[tokio::test]
+    async fn test_online_notified_set_on_success() {
+        let (base_url, _server) = spawn_mock_server(
+            200,
+            r#"{"ok":true,"result":{"id":1,"username":"bot"}}"#,
+            200,
+            r#"{"ok":true,"result":{"message_id":1}}"#,
+        )
+        .await;
+
+        let config = kestrel_config::schema::TelegramConfig {
+            token: "123:ABC".to_string(),
+            enabled: true,
+            allowed_users: vec![],
+            admin_users: vec![],
+            streaming: false,
+            proxy: None,
+        };
+        let notifications = kestrel_config::schema::NotificationsConfig {
+            online_notify: true,
+            notify_chat_id: Some("999".to_string()),
+            online_message: "Online {channel}".to_string(),
+        };
+        let mut channel =
+            TelegramChannel::with_config_and_url(&config, &notifications, base_url.clone());
+        let (tx, _rx) = tokio::sync::mpsc::channel(10);
+        channel.set_message_handler(tx);
+
+        let notified = channel.online_notified.clone();
+        channel.connect().await.unwrap();
+
+        // Give the spawned task time to complete.
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        assert!(
+            notified.load(Ordering::Relaxed),
+            "online_notified should be true after successful send"
+        );
+    }
+
+    /// Test: disconnect resets online_notified, so a subsequent reconnect retries.
+    #[tokio::test]
+    async fn test_disconnect_resets_online_notified() {
+        let mut channel = TelegramChannel::new();
+        channel.online_notified.store(true, Ordering::Relaxed);
+        assert!(channel.online_notified.load(Ordering::Relaxed));
+
+        channel.disconnect().await.unwrap();
+        assert!(
+            !channel.online_notified.load(Ordering::Relaxed),
+            "disconnect should reset online_notified to false"
         );
     }
 }

--- a/crates/kestrel-channels/src/registry.rs
+++ b/crates/kestrel-channels/src/registry.rs
@@ -11,18 +11,63 @@ pub struct ChannelRegistry {
 }
 
 impl ChannelRegistry {
-    pub fn new() -> Self {
-        let mut registry = Self {
+    fn empty() -> Self {
+        Self {
             factories: HashMap::new(),
-        };
+        }
+    }
 
-        // Register built-in channels
-        registry.register("telegram", || {
+    fn register_builtin_channels(&mut self) {
+        self.register("telegram", || {
             Box::new(platforms::telegram::TelegramChannel::new())
         });
-        registry.register("discord", || {
+        self.register("discord", || {
             Box::new(platforms::discord::DiscordChannel::new())
         });
+        self.register("websocket", || {
+            Box::new(platforms::websocket::WebSocketChannel::new())
+        });
+    }
+
+    /// Create a registry with built-in channel factories using process environment.
+    pub fn new() -> Self {
+        let mut registry = Self::empty();
+        registry.register_builtin_channels();
+        registry
+    }
+
+    /// Create a registry with built-in channel factories using the supplied config.
+    pub fn new_with_config(config: &kestrel_config::Config) -> Self {
+        let mut registry = Self::empty();
+
+        if let Some(telegram) = config.channels.telegram.clone() {
+            let notifications = config.notifications.clone();
+            registry.register("telegram", move || {
+                Box::new(
+                    platforms::telegram::TelegramChannel::new_with_notifications_config(
+                        &telegram,
+                        &notifications,
+                    ),
+                )
+            });
+        } else {
+            registry.register("telegram", || {
+                Box::new(platforms::telegram::TelegramChannel::new())
+            });
+        }
+
+        if let Some(discord) = config.channels.discord.clone() {
+            registry.register("discord", move || {
+                Box::new(platforms::discord::DiscordChannel::new_with_config(
+                    &discord,
+                ))
+            });
+        } else {
+            registry.register("discord", || {
+                Box::new(platforms::discord::DiscordChannel::new())
+            });
+        }
+
         registry.register("websocket", || {
             Box::new(platforms::websocket::WebSocketChannel::new())
         });

--- a/crates/kestrel-channels/tests/telegram_mock.rs
+++ b/crates/kestrel-channels/tests/telegram_mock.rs
@@ -3,6 +3,8 @@
 use kestrel_channels::base::BaseChannel;
 use kestrel_channels::platforms::telegram::TelegramChannel;
 use kestrel_core::Platform;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 /// Start a mock HTTP server that responds to a single request.
 async fn start_mock_telegram_server(
@@ -38,6 +40,63 @@ async fn start_mock_telegram_server(
             body
         );
         let _ = writer.write_all(resp.as_bytes()).await;
+    });
+
+    Some((port, handle))
+}
+
+async fn start_mock_telegram_server_with_responses(
+    responses: Vec<String>,
+    captured_requests: Arc<Mutex<Vec<String>>>,
+) -> Option<(u16, tokio::task::JoinHandle<()>)> {
+    let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(e) => panic!("failed to bind mock Telegram server: {e}"),
+    };
+    let port = listener.local_addr().unwrap().port();
+
+    let handle = tokio::spawn(async move {
+        use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+        for body in responses {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, mut writer) = stream.into_split();
+            let mut buf_reader = BufReader::new(reader);
+
+            let mut line = String::new();
+            let mut content_length = 0usize;
+            let mut request = String::new();
+            loop {
+                line.clear();
+                if buf_reader.read_line(&mut line).await.unwrap() == 0 {
+                    break;
+                }
+                request.push_str(&line);
+                let lower = line.to_ascii_lowercase();
+                if let Some((_, value)) = lower.split_once("content-length:") {
+                    content_length = value.trim().parse().unwrap_or(0);
+                }
+                if line == "\r\n" {
+                    break;
+                }
+            }
+
+            if content_length > 0 {
+                let mut body_buf = vec![0u8; content_length];
+                buf_reader.read_exact(&mut body_buf).await.unwrap();
+                request.push_str(std::str::from_utf8(&body_buf).unwrap());
+            }
+
+            captured_requests.lock().await.push(request);
+
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = writer.write_all(resp.as_bytes()).await;
+        }
     });
 
     Some((port, handle))
@@ -203,4 +262,52 @@ async fn test_telegram_send_typing_with_mock() {
 
     let result = channel.send_typing("123").await;
     assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_telegram_connect_sends_online_notification_once() {
+    let captured_requests = Arc::new(Mutex::new(Vec::new()));
+    let responses = vec![
+        r#"{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"Kestrel","username":"kestrel_bot"}}"#.to_string(),
+        r#"{"ok":true,"result":{"message_id":42,"chat":{"id":123,"type":"private"},"text":"online"}}"#.to_string(),
+    ];
+    let Some((port, _handle)) =
+        start_mock_telegram_server_with_responses(responses, captured_requests.clone()).await
+    else {
+        return;
+    };
+
+    let config = kestrel_config::schema::TelegramConfig {
+        token: "test-token".to_string(),
+        enabled: true,
+        allowed_users: vec![],
+        admin_users: vec![],
+        streaming: false,
+        proxy: None,
+    };
+    let notifications = kestrel_config::schema::NotificationsConfig {
+        online_notify: true,
+        notify_chat_id: Some("123".to_string()),
+        online_message: "Kestrel v{version} online - {channel} connected".to_string(),
+    };
+    let mut channel = TelegramChannel::with_config_and_url(
+        &config,
+        &notifications,
+        format!("http://127.0.0.1:{port}"),
+    );
+
+    let connected = channel.connect().await.unwrap();
+    assert!(connected);
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let requests = captured_requests.lock().await;
+    assert_eq!(requests.len(), 2);
+    assert!(requests[0].contains("GET /getMe HTTP/1.1"));
+    assert!(requests[1].contains("POST /sendMessage HTTP/1.1"));
+    assert!(requests[1].contains("\"chat_id\":123"));
+    assert!(requests[1].contains(&format!(
+        "\"text\":\"Kestrel v{} online - Telegram connected\"",
+        env!("CARGO_PKG_VERSION")
+    )));
 }

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -69,6 +69,10 @@ pub struct Config {
     /// Daemon mode configuration.
     #[serde(default)]
     pub daemon: DaemonConfig,
+
+    /// Startup notification settings.
+    #[serde(default)]
+    pub notifications: NotificationsConfig,
 }
 
 impl Default for Config {
@@ -89,6 +93,36 @@ impl Default for Config {
             mcp_servers: HashMap::new(),
             api: ApiConfig::default(),
             daemon: DaemonConfig::default(),
+            notifications: NotificationsConfig::default(),
+        }
+    }
+}
+
+/// Startup notification configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct NotificationsConfig {
+    /// Whether to send an online notification when a channel connects.
+    #[serde(default = "default_true")]
+    pub online_notify: bool,
+    /// Chat ID that receives the online notification.
+    #[serde(default)]
+    pub notify_chat_id: Option<String>,
+    /// Plain-text message template used for online notifications.
+    ///
+    /// Supported placeholders:
+    /// - `{version}` → the running Kestrel version
+    /// - `{channel}` → the connected channel name
+    #[serde(default = "default_online_message")]
+    pub online_message: String,
+}
+
+impl Default for NotificationsConfig {
+    fn default() -> Self {
+        Self {
+            online_notify: true,
+            notify_chat_id: None,
+            online_message: default_online_message(),
         }
     }
 }
@@ -827,6 +861,10 @@ fn default_cron_tick_secs() -> u64 {
     60
 }
 
+fn default_online_message() -> String {
+    "🟢 Kestrel v{version} online — {channel} connected".to_string()
+}
+
 fn default_mcp_transport() -> String {
     "stdio".to_string()
 }
@@ -844,6 +882,12 @@ mod tests {
         assert!(config.workspace.is_none());
         assert!(config.custom_providers.is_empty());
         assert!(config.mcp_servers.is_empty());
+        assert!(config.notifications.online_notify);
+        assert!(config.notifications.notify_chat_id.is_none());
+        assert_eq!(
+            config.notifications.online_message,
+            "🟢 Kestrel v{version} online — {channel} connected"
+        );
     }
 
     #[test]
@@ -967,6 +1011,10 @@ mcp_servers:
     args:
       - "--root"
       - "/data"
+notifications:
+  online_notify: false
+  notify_chat_id: "-1001234567890"
+  online_message: "Kestrel {version} online on {channel}"
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config._config_version, Some(4));
@@ -1012,6 +1060,26 @@ mcp_servers:
         assert_eq!(
             mcp.args,
             Some(vec!["--root".to_string(), "/data".to_string()])
+        );
+        assert!(!config.notifications.online_notify);
+        assert_eq!(
+            config.notifications.notify_chat_id.as_deref(),
+            Some("-1001234567890")
+        );
+        assert_eq!(
+            config.notifications.online_message,
+            "Kestrel {version} online on {channel}"
+        );
+    }
+
+    #[test]
+    fn test_notifications_config_parse_defaults_when_missing() {
+        let config: Config = serde_yaml::from_str("{}").unwrap();
+        assert!(config.notifications.online_notify);
+        assert!(config.notifications.notify_chat_id.is_none());
+        assert_eq!(
+            config.notifications.online_message,
+            "🟢 Kestrel v{version} online — {channel} connected"
         );
     }
 

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -301,7 +301,7 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     }
 
     // ── Channel manager (wrapped in Arc for shared access) ────
-    let channel_registry = ChannelRegistry::new();
+    let channel_registry = ChannelRegistry::new_with_config(&config);
     let channel_manager = Arc::new(ChannelManager::new(channel_registry, bus.clone()));
 
     // ── Skill registry ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #72

Adds a config-driven online notification that fires once when the Telegram channel first connects.

### Changes
- **kestrel-config/schema.rs**: Add `notifications` config block with `online_notify` (bool, default false) and `notify_chat_id` (Option<String>)
- **kestrel-channels/registry.rs**: Wire ChannelRegistry to receive root config, pass to channel constructors
- **kestrel-channels/platforms/telegram.rs**: On first successful `connect()`, send a fire-and-forget plain-text message to `notify_chat_id` using template placeholders
- **kestrel-channels/tests/telegram_mock.rs**: Integration tests for config-driven online notification
- **src/commands/gateway.rs**: Pass notifications config to ChannelRegistry

### Design Decisions
- Fire-and-forget on first connect only — reconnection polling does NOT resend
- Plain text message (no Markdown parse mode) for maximum delivery reliability
- Config-backed: defaults to disabled, user opts in via config.yaml

### Quality Gates
- cargo fmt --all --check ✅
- cargo check --workspace ✅
- cargo test --workspace ✅
- cargo clippy --workspace -- -D warnings ✅