### PR TITLE
fix(channels): Telegram MarkdownV2 parse_mode for message rendering

### DIFF
--- a/crates/kestrel-channels/src/platforms/mod.rs
+++ b/crates/kestrel-channels/src/platforms/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod discord;
 pub mod telegram;
+pub mod telegram_format;
 pub mod websocket;

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -21,6 +21,9 @@ use kestrel_bus::events::InboundMessage;
 use kestrel_core::{MediaAttachment, MessageType, Platform, SessionSource};
 
 use crate::base::{BaseChannel, SendResult};
+use crate::platforms::telegram_format::markdown_to_telegram;
+
+const TELEGRAM_PARSE_MODE: &str = "MarkdownV2";
 
 // ---------------------------------------------------------------------------
 // Telegram Bot API response types
@@ -141,6 +144,8 @@ struct SendMessageBody {
     chat_id: i64,
     text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    parse_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_markup: Option<serde_json::Value>,
@@ -152,6 +157,8 @@ struct SendPhotoBody {
     photo: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     caption: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    caption_parse_mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<i64>,
 }
@@ -167,6 +174,8 @@ struct EditMessageTextBody {
     chat_id: i64,
     message_id: i64,
     text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parse_mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_markup: Option<serde_json::Value>,
 }
@@ -533,6 +542,25 @@ pub struct TelegramChannel {
 }
 
 impl TelegramChannel {
+    /// Prepare outbound text for Telegram delivery with a safe MarkdownV2 fallback.
+    fn prepare_outbound_text(text: &str) -> (String, Option<String>) {
+        match markdown_to_telegram(text) {
+            Some(converted) => (converted, Some(TELEGRAM_PARSE_MODE.to_string())),
+            None => (text.to_string(), None),
+        }
+    }
+
+    /// Prepare an optional Telegram photo caption for MarkdownV2 delivery.
+    fn prepare_outbound_caption(caption: Option<&str>) -> (Option<String>, Option<String>) {
+        match caption {
+            Some(text) => {
+                let (formatted, parse_mode) = Self::prepare_outbound_text(text);
+                (Some(formatted), parse_mode)
+            }
+            None => (None, None),
+        }
+    }
+
     /// Build a reqwest client with config-driven proxy support.
     ///
     /// Priority: `proxy_config` > env vars (`HTTPS_PROXY`, `ALL_PROXY`, etc.) > direct.
@@ -732,9 +760,11 @@ impl TelegramChannel {
         keyboard: Option<&InlineKeyboardMarkup>,
     ) {
         let reply_markup = keyboard.map(|kb| serde_json::to_value(kb).unwrap_or_default());
+        let (text, parse_mode) = Self::prepare_outbound_text(text);
         let body = SendMessageBody {
             chat_id,
-            text: text.to_string(),
+            text,
+            parse_mode,
             reply_to_message_id: None,
             reply_markup,
         };
@@ -1208,10 +1238,12 @@ impl TelegramChannel {
         if let (Ok(chat_id_num), Ok(msg_id_num)) =
             (chat_id.parse::<i64>(), message_id.parse::<i64>())
         {
+            let (text, parse_mode) = Self::prepare_outbound_text(text);
             let body = EditMessageTextBody {
                 chat_id: chat_id_num,
                 message_id: msg_id_num,
-                text: text.to_string(),
+                text,
+                parse_mode,
                 reply_markup,
             };
             let url = format!("{}/editMessageText", base_url);
@@ -1232,9 +1264,11 @@ impl TelegramChannel {
         match response {
             CallbackResponse::Reply(text) => {
                 if let Ok(chat_id_num) = chat_id.parse::<i64>() {
+                    let (text, parse_mode) = Self::prepare_outbound_text(&text);
                     let body = SendMessageBody {
                         chat_id: chat_id_num,
                         text,
+                        parse_mode,
                         reply_to_message_id: None,
                         reply_markup: None,
                     };
@@ -1250,10 +1284,12 @@ impl TelegramChannel {
                 {
                     let reply_markup =
                         keyboard.map(|kb| serde_json::to_value(&kb).unwrap_or_default());
+                    let (text, parse_mode) = Self::prepare_outbound_text(&text);
                     let body = EditMessageTextBody {
                         chat_id: chat_id_num,
                         message_id: msg_id_num,
                         text,
+                        parse_mode,
                         reply_markup,
                     };
                     let url = format!("{}/editMessageText", base_url);
@@ -1472,10 +1508,12 @@ impl BaseChannel for TelegramChannel {
         };
 
         let reply_to_id = reply_to.and_then(|r| r.parse::<i64>().ok());
+        let (text, parse_mode) = Self::prepare_outbound_text(content);
 
         let body = SendMessageBody {
             chat_id: chat_id_num,
-            text: content.to_string(),
+            text,
+            parse_mode,
             reply_to_message_id: reply_to_id,
             reply_markup: None,
         };
@@ -1607,10 +1645,12 @@ impl BaseChannel for TelegramChannel {
             }
         };
 
+        let (caption, caption_parse_mode) = Self::prepare_outbound_caption(caption);
         let body = SendPhotoBody {
             chat_id: chat_id_num,
             photo: image_url.to_string(),
-            caption: caption.map(|s| s.to_string()),
+            caption,
+            caption_parse_mode,
             reply_to_message_id: None,
         };
 
@@ -1703,10 +1743,12 @@ impl TelegramChannel {
             }
         };
 
+        let (text, parse_mode) = Self::prepare_outbound_text(text);
         let body = EditMessageTextBody {
             chat_id: chat_id_num,
             message_id: message_id_num,
-            text: text.to_string(),
+            text,
+            parse_mode,
             reply_markup,
         };
 
@@ -1867,13 +1909,17 @@ impl TelegramChannel {
             chat_id: i64,
             text: String,
             #[serde(skip_serializing_if = "Option::is_none")]
+            parse_mode: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
             reply_to_message_id: Option<i64>,
             reply_markup: InlineKeyboardMarkup,
         }
 
+        let (text, parse_mode) = Self::prepare_outbound_text(text);
         let body = SendMessageWithKeyboardBody {
             chat_id: chat_id_num,
-            text: text.to_string(),
+            text,
+            parse_mode,
             reply_to_message_id: reply_to_id,
             reply_markup: keyboard.clone(),
         };
@@ -2543,6 +2589,7 @@ mod tests {
             chat_id: 123,
             message_id: 456,
             text: "updated text".to_string(),
+            parse_mode: Some(TELEGRAM_PARSE_MODE.to_string()),
             reply_markup: Some(serde_json::json!({
                 "inline_keyboard": [[{"text": "Click", "callback_data": "yes"}]]
             })),
@@ -2551,7 +2598,37 @@ mod tests {
         assert_eq!(json["chat_id"], 123);
         assert_eq!(json["message_id"], 456);
         assert_eq!(json["text"], "updated text");
+        assert_eq!(json["parse_mode"], TELEGRAM_PARSE_MODE);
         assert!(json["reply_markup"]["inline_keyboard"].is_array());
+    }
+
+    #[test]
+    fn test_prepare_outbound_text_enables_markdown_v2() {
+        let (text, parse_mode) = TelegramChannel::prepare_outbound_text("**bold**");
+        assert_eq!(text, "*bold*");
+        assert_eq!(parse_mode.as_deref(), Some(TELEGRAM_PARSE_MODE));
+    }
+
+    #[test]
+    fn test_prepare_outbound_text_falls_back_to_plain_text() {
+        let input = "[broken](https://example.com";
+        let (text, parse_mode) = TelegramChannel::prepare_outbound_text(input);
+        assert_eq!(text, input);
+        assert!(parse_mode.is_none());
+    }
+
+    #[test]
+    fn test_prepare_outbound_caption_applies_markdown_v2() {
+        let (caption, parse_mode) = TelegramChannel::prepare_outbound_caption(Some("## Title"));
+        assert_eq!(caption.as_deref(), Some("*Title*"));
+        assert_eq!(parse_mode.as_deref(), Some(TELEGRAM_PARSE_MODE));
+    }
+
+    #[test]
+    fn test_prepare_outbound_caption_none_stays_empty() {
+        let (caption, parse_mode) = TelegramChannel::prepare_outbound_caption(None);
+        assert!(caption.is_none());
+        assert!(parse_mode.is_none());
     }
 
     #[test]

--- a/crates/kestrel-channels/src/platforms/telegram_format.rs
+++ b/crates/kestrel-channels/src/platforms/telegram_format.rs
@@ -1,0 +1,352 @@
+//! Telegram MarkdownV2 formatting helpers.
+
+const SPECIAL_CHARS: [char; 18] = [
+    '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!',
+];
+
+/// Convert standard Markdown to Telegram MarkdownV2 format.
+/// Falls back to plain text (`None`) if conversion fails.
+pub fn markdown_to_telegram(input: &str) -> Option<String> {
+    let segments = split_code_segments(input)?;
+    let mut output = String::new();
+
+    for segment in segments {
+        match segment {
+            Segment::Text(text) => output.push_str(&convert_text_segment(&text)?),
+            Segment::CodeInline(code) => {
+                output.push('`');
+                output.push_str(&code);
+                output.push('`');
+            }
+            Segment::CodeBlock(code) => {
+                if code.contains("```") {
+                    return None;
+                }
+
+                if code.contains('\n') {
+                    let (language, body) = split_code_block_language(&code);
+                    output.push_str("```");
+                    if let Some(language) = language {
+                        output.push_str(language);
+                    }
+                    output.push('\n');
+                    output.push_str(body);
+                    if !body.ends_with('\n') {
+                        output.push('\n');
+                    }
+                    output.push_str("```");
+                } else {
+                    output.push('`');
+                    output.push_str(&code);
+                    output.push('`');
+                }
+            }
+        }
+    }
+
+    Some(output)
+}
+
+fn split_code_block_language(code: &str) -> (Option<&str>, &str) {
+    if let Some(first_newline) = code.find('\n') {
+        let prefix = &code[..first_newline];
+        if !prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return (Some(prefix), &code[first_newline + 1..]);
+        }
+    }
+
+    (None, code)
+}
+
+#[derive(Debug)]
+enum Segment {
+    Text(String),
+    CodeInline(String),
+    CodeBlock(String),
+}
+
+fn split_code_segments(input: &str) -> Option<Vec<Segment>> {
+    let mut chars = input.char_indices().peekable();
+    let mut text_start = 0usize;
+    let mut segments = Vec::new();
+
+    while let Some((idx, ch)) = chars.next() {
+        if ch != '`' {
+            continue;
+        }
+
+        let mut tick_count = 1usize;
+        while let Some((_, '`')) = chars.peek() {
+            chars.next();
+            tick_count += 1;
+        }
+
+        match tick_count {
+            1 => {
+                if text_start < idx {
+                    segments.push(Segment::Text(input[text_start..idx].to_string()));
+                }
+                let code_start = idx + 1;
+                let rest = &input[code_start..];
+                let Some(end) = rest.find('`') else {
+                    continue;
+                };
+                let code_end = code_start + end;
+                let code = &input[code_start..code_end];
+                if code.contains('\n') || code.contains('`') {
+                    return None;
+                }
+                segments.push(Segment::CodeInline(code.to_string()));
+                let next_index = code_end + 1;
+                while let Some((next_idx, _)) = chars.peek() {
+                    if *next_idx < next_index {
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                text_start = next_index;
+            }
+            3 => {
+                if text_start < idx {
+                    segments.push(Segment::Text(input[text_start..idx].to_string()));
+                }
+                let code_start = idx + 3;
+                let rest = &input[code_start..];
+                let end = rest.find("```")?;
+                let code_end = code_start + end;
+                let code = &input[code_start..code_end];
+                if let Some(first_newline) = code.find('\n') {
+                    let prefix = &code[..first_newline];
+                    if !prefix.is_empty() && !prefix.chars().all(|c| c.is_ascii_alphanumeric()) {
+                        return None;
+                    }
+                }
+                segments.push(Segment::CodeBlock(code.to_string()));
+                let next_index = code_end + 3;
+                while let Some((next_idx, _)) = chars.peek() {
+                    if *next_idx < next_index {
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                text_start = next_index;
+            }
+            _ => continue,
+        }
+    }
+
+    if text_start < input.len() {
+        segments.push(Segment::Text(input[text_start..].to_string()));
+    }
+
+    Some(segments)
+}
+
+fn convert_text_segment(input: &str) -> Option<String> {
+    let mut lines = Vec::new();
+
+    for line in input.split('\n') {
+        lines.push(convert_line(line)?);
+    }
+
+    Some(lines.join("\n"))
+}
+
+fn convert_line(line: &str) -> Option<String> {
+    if let Some(rest) = line.strip_prefix("## ") {
+        return Some(format!("*{}*", convert_inline(rest)?));
+    }
+
+    if let Some(rest) = line.strip_prefix("- ") {
+        return Some(format!("• {}", convert_inline(rest)?));
+    }
+
+    convert_inline(line)
+}
+
+fn convert_inline(input: &str) -> Option<String> {
+    let mut output = String::new();
+    let mut idx = 0usize;
+
+    while idx < input.len() {
+        let rest = &input[idx..];
+
+        if let Some(after) = rest.strip_prefix("**") {
+            if let Some(close) = after.find("**") {
+                let inner = &after[..close];
+                output.push('*');
+                output.push_str(&convert_inline(inner)?);
+                output.push('*');
+                idx += 2 + close + 2;
+                continue;
+            }
+        }
+
+        if let Some(after) = rest.strip_prefix('*') {
+            if let Some(close) = find_single_italic_close(after) {
+                let inner = &after[..close];
+                output.push('_');
+                output.push_str(&convert_inline(inner)?);
+                output.push('_');
+                idx += 1 + close + 1;
+                continue;
+            }
+        }
+
+        if rest.starts_with('[') && rest.find("](").is_some_and(|close_text| close_text > 1) {
+            let (rendered, consumed) = convert_link(rest)?;
+            output.push_str(&rendered);
+            idx += consumed;
+            continue;
+        }
+
+        let ch = rest.chars().next()?;
+        push_escaped(&mut output, ch);
+        idx += ch.len_utf8();
+    }
+
+    Some(output)
+}
+
+fn find_single_italic_close(input: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut idx = 0usize;
+
+    while idx < bytes.len() {
+        if bytes[idx] == b'*' {
+            let prev_is_star = idx > 0 && bytes[idx - 1] == b'*';
+            let next_is_star = idx + 1 < bytes.len() && bytes[idx + 1] == b'*';
+            if !prev_is_star && !next_is_star {
+                return Some(idx);
+            }
+        }
+        idx += 1;
+    }
+
+    None
+}
+
+fn convert_link(input: &str) -> Option<(String, usize)> {
+    let close_text = input.find("](")?;
+    let link_text = &input[1..close_text];
+    let url_start = close_text + 2;
+    let url_end = find_link_url_end(&input[url_start..])?;
+    let url = &input[url_start..url_start + url_end];
+    if link_text.is_empty() || url.is_empty() {
+        return None;
+    }
+    let consumed = url_start + url_end + 1;
+
+    let mut rendered = String::new();
+    rendered.push('[');
+    rendered.push_str(&escape_non_code(link_text));
+    rendered.push_str("](");
+    rendered.push_str(&escape_link_url(url));
+    rendered.push(')');
+
+    Some((rendered, consumed))
+}
+
+fn find_link_url_end(input: &str) -> Option<usize> {
+    let mut depth = 0usize;
+
+    for (idx, ch) in input.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' if depth == 0 => return Some(idx),
+            ')' => depth -= 1,
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn escape_non_code(input: &str) -> String {
+    let mut output = String::new();
+    for ch in input.chars() {
+        push_escaped(&mut output, ch);
+    }
+    output
+}
+
+fn escape_link_url(input: &str) -> String {
+    let mut output = String::new();
+    for ch in input.chars() {
+        if matches!(ch, ')' | '\\') {
+            output.push('\\');
+        }
+        output.push(ch);
+    }
+    output
+}
+
+fn push_escaped(output: &mut String, ch: char) {
+    if SPECIAL_CHARS.contains(&ch) {
+        output.push('\\');
+    }
+    output.push(ch);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::markdown_to_telegram;
+
+    #[test]
+    fn test_bold_and_italic_conversion() {
+        let formatted = markdown_to_telegram("**bold** and *italic*").unwrap();
+        assert_eq!(formatted, "*bold* and _italic_");
+    }
+
+    #[test]
+    fn test_code_block_preserved_without_escaping() {
+        let formatted = markdown_to_telegram("Before\n```let x = a_b;```\nAfter").unwrap();
+        assert_eq!(formatted, "Before\n`let x = a_b;`\nAfter");
+    }
+
+    #[test]
+    fn test_special_character_escaping() {
+        let formatted = markdown_to_telegram("_*[]()~>#+-=|{}.!").unwrap();
+        assert_eq!(
+            formatted,
+            "\\_\\*\\[\\]\\(\\)\\~\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!"
+        );
+    }
+
+    #[test]
+    fn test_invalid_input_falls_back() {
+        assert!(markdown_to_telegram("[broken](https://example.com").is_none());
+        assert!(markdown_to_telegram("```unterminated").is_none());
+    }
+
+    #[test]
+    fn test_header_conversion() {
+        let formatted = markdown_to_telegram("## Heading").unwrap();
+        assert_eq!(formatted, "*Heading*");
+    }
+
+    #[test]
+    fn test_list_marker_conversion() {
+        let formatted = markdown_to_telegram("- item").unwrap();
+        assert_eq!(formatted, "• item");
+    }
+
+    #[test]
+    fn test_mixed_content_conversion() {
+        let formatted =
+            markdown_to_telegram("**Title** uses `code` and [link](https://example.com/a)")
+                .unwrap();
+        assert_eq!(
+            formatted,
+            "*Title* uses `code` and [link](https://example.com/a)"
+        );
+    }
+
+    #[test]
+    fn test_multiline_fenced_code_block_stays_fenced() {
+        let formatted = markdown_to_telegram("```rust\nlet x = 1;\nlet y = x + 1;\n```").unwrap();
+        assert_eq!(formatted, "```rust\nlet x = 1;\nlet y = x + 1;\n```");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #70

Adds Telegram MarkdownV2 formatting for outbound messages with safe fallback to plain text.

### Changes
- **New `telegram_format.rs`** — Markdown → Telegram MarkdownV2 converter
  - Escapes all 18 special characters (`_ * [ ] ( ) ~ \` > # + - = | { } . !`)
  - Handles bold (`**` → `*`), italic (`*` → `_`), inline code, fenced code blocks
  - Converts `## Heading` → `*Heading*`, `- item` → `• item`
  - Supports `[text](url)` links with proper escaping
  - Returns `None` on malformed input → triggers plain-text fallback

- **Modified `telegram.rs`** — Wire MarkdownV2 into all send/edit paths
  - `prepare_outbound_text()` — attempts conversion, falls back to plain text
  - `prepare_outbound_caption()` — same for photo captions
  - Applied to: `send_message`, `send_photo`, `edit_message_text`, `callback_response`, `send_message_with_keyboard`
  - `parse_mode` / `caption_parse_mode` set only when conversion succeeds (safe fallback)

- **Tests** — 8 new unit tests covering conversion, fallback, and caption paths

### Quality Gates
- [x] `cargo fmt --all --check` — passed
- [x] `cargo check --workspace` — passed
- [x] `cargo clippy --workspace -- -D warnings` — passed
- [x] `cargo test -p kestrel-channels telegram` — passed
- [ ] `cargo test --workspace` — known sandbox WebSocket permission issue (unrelated to this PR)