### PR TITLE
feat(trace): unified trace_id across all channels (Closes #62)

### DIFF
--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -266,13 +266,16 @@ impl AgentLoop {
             let result = {
                 // Build a runner with event callback for this session
                 let event_bus = bus_for_stream.clone();
-                let trace_id_for_stream = msg.trace_id.clone();
+                let session_key_for_runner = session_key.clone();
+                let trace_id_for_runner = msg.trace_id.clone();
 
                 let runner_with_events = AgentRunner::new(
                     self.config.clone(),
                     self.provider_registry.clone(),
                     self.tool_registry.clone(),
                 )
+                .with_session_key(&session_key_for_runner)
+                .with_trace_id(trace_id_for_runner.clone().unwrap_or_default())
                 .with_stream_tx(event_bus.subscribe_stream_tx())
                 .with_event_callback(Box::new(move |event: AgentEvent| {
                     // Re-emit through bus
@@ -285,7 +288,7 @@ impl AgentLoop {
                                 session_key: session_key.clone(),
                                 content: content.clone(),
                                 done: false,
-                                trace_id: trace_id_for_stream.clone(),
+                                trace_id: trace_id_for_runner.clone(),
                             });
                         }
                         AgentEvent::ToolCall {

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -28,6 +28,10 @@ pub struct AgentRunner {
     /// Guard that serializes execution of mutating tools. Read-only tools
     /// bypass this lock and run concurrently.
     mutating_guard: Arc<Mutex<()>>,
+    /// Session key for correlating tool-call events and stream chunks.
+    session_key: Option<String>,
+    /// Full-chain trace ID propagated from the originating inbound message.
+    trace_id: Option<String>,
 }
 
 impl AgentRunner {
@@ -43,6 +47,8 @@ impl AgentRunner {
             stream_tx: None,
             event_callback: None,
             mutating_guard: Arc::new(Mutex::new(())),
+            session_key: None,
+            trace_id: None,
         }
     }
 
@@ -58,19 +64,31 @@ impl AgentRunner {
         self
     }
 
+    /// Set the session key for correlating events and stream chunks.
+    pub fn with_session_key(mut self, key: impl Into<String>) -> Self {
+        self.session_key = Some(key.into());
+        self
+    }
+
+    /// Set the trace ID for full-chain correlation.
+    pub fn with_trace_id(mut self, id: impl Into<String>) -> Self {
+        self.trace_id = Some(id.into());
+        self
+    }
+
     fn emit_event(&self, event: AgentEvent) {
         if let Some(cb) = &self.event_callback {
             cb(event);
         }
     }
 
-    fn emit_stream_chunk(&self, session_key: &str, content: String, done: bool) {
+    fn emit_stream_chunk(&self, content: String, done: bool) {
         if let Some(tx) = &self.stream_tx {
             let _ = tx.send(StreamChunk {
-                session_key: session_key.to_string(),
+                session_key: self.session_key.clone().unwrap_or_default(),
                 content,
                 done,
-                trace_id: None,
+                trace_id: self.trace_id.clone(),
             });
         }
     }
@@ -160,7 +178,7 @@ impl AgentRunner {
             // Emit tool call events
             for tc in &tool_calls {
                 self.emit_event(AgentEvent::ToolCall {
-                    session_key: String::new(), // filled by caller
+                    session_key: self.session_key.clone().unwrap_or_default(),
                     tool_name: tc.function.name.clone(),
                     iteration: iteration + 1,
                 });
@@ -224,7 +242,7 @@ impl AgentRunner {
             if let Some(delta) = &chunk.delta {
                 full_content.push_str(delta);
                 // Emit streaming chunk
-                self.emit_stream_chunk("", delta.clone(), false);
+                self.emit_stream_chunk(delta.clone(), false);
             }
 
             // Accumulate tool call deltas
@@ -256,7 +274,7 @@ impl AgentRunner {
         }
 
         // Emit final stream chunk
-        self.emit_stream_chunk("", String::new(), true);
+        self.emit_stream_chunk(String::new(), true);
 
         // Build tool calls from accumulated deltas
         let mut tool_calls_list: Vec<(usize, CoreToolCall)> = tool_calls_map

--- a/crates/kestrel-api/src/server.rs
+++ b/crates/kestrel-api/src/server.rs
@@ -2297,7 +2297,14 @@ mod tests {
             tool_calls: None,
         }];
 
-        let resp = stream_completion(state, req, "test".to_string(), messages, "test-req-id".to_string()).await;
+        let resp = stream_completion(
+            state,
+            req,
+            "test".to_string(),
+            messages,
+            "test-req-id".to_string(),
+        )
+        .await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         let ct = resp
@@ -2349,7 +2356,14 @@ mod tests {
             tool_calls: None,
         }];
 
-        let resp = stream_completion(state, req, "test".to_string(), messages, "test-req-id".to_string()).await;
+        let resp = stream_completion(
+            state,
+            req,
+            "test".to_string(),
+            messages,
+            "test-req-id".to_string(),
+        )
+        .await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();

--- a/crates/kestrel-api/src/server.rs
+++ b/crates/kestrel-api/src/server.rs
@@ -19,7 +19,7 @@
 use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
 use axum::{
     body::Body,
-    extract::{DefaultBodyLimit, State},
+    extract::{DefaultBodyLimit, Extension, State},
     http::{HeaderValue, Method, Request, StatusCode},
     middleware::{self, Next},
     response::sse::{Event, KeepAlive, Sse},
@@ -326,7 +326,7 @@ struct ErrorDetail {
 /// If the client sends an `x-request-id` header it is preserved; otherwise a
 /// new UUID v4 is generated. The ID is set on the response header and injected
 /// into the current tracing span for structured log correlation.
-async fn request_id_middleware(req: Request<Body>, next: Next) -> impl IntoResponse {
+async fn request_id_middleware(mut req: Request<Body>, next: Next) -> impl IntoResponse {
     let request_id = req
         .headers()
         .get("x-request-id")
@@ -336,6 +336,7 @@ async fn request_id_middleware(req: Request<Body>, next: Next) -> impl IntoRespo
 
     // Inject into tracing span so downstream log lines carry the request ID.
     let span = tracing::info_span!("request", request_id = %request_id);
+    req.extensions_mut().insert(request_id.clone());
     let response: axum::response::Response = next.run(req).instrument(span).await;
 
     // Attach the request ID to the response.
@@ -490,6 +491,7 @@ fn validate_request(req: &ChatCompletionRequest) -> Result<(), axum::response::R
 
 async fn chat_completions(
     State(state): State<AppState>,
+    Extension(request_id): Extension<String>,
     Json(req): Json<ChatCompletionRequest>,
 ) -> impl IntoResponse {
     debug!(
@@ -544,11 +546,11 @@ async fn chat_completions(
         .collect();
 
     if req.stream {
-        return stream_completion(state, req, system_prompt, messages).await;
+        return stream_completion(state, req, system_prompt, messages, request_id).await;
     }
 
     // Non-streaming path
-    non_stream_completion(state, req, system_prompt, messages).await
+    non_stream_completion(state, req, system_prompt, messages, request_id).await
 }
 
 /// Handle non-streaming completion.
@@ -557,12 +559,14 @@ async fn non_stream_completion(
     req: ChatCompletionRequest,
     system_prompt: String,
     messages: Vec<Message>,
+    request_id: String,
 ) -> axum::response::Response {
     let runner = AgentRunner::new(
         state.config.clone(),
         state.provider_registry.clone(),
         state.tool_registry.clone(),
-    );
+    )
+    .with_trace_id(&request_id);
 
     match runner.run(system_prompt, messages).await {
         Ok(result) => {
@@ -624,6 +628,7 @@ async fn stream_completion(
     req: ChatCompletionRequest,
     system_prompt: String,
     messages: Vec<Message>,
+    request_id: String,
 ) -> axum::response::Response {
     let completion_id = format!("chatcmpl-{}", uuid::Uuid::new_v4());
     let model = req.model.clone();
@@ -633,7 +638,8 @@ async fn stream_completion(
         state.config.clone(),
         state.provider_registry.clone(),
         state.tool_registry.clone(),
-    );
+    )
+    .with_trace_id(&request_id);
 
     let stream_result = runner.run(system_prompt, messages).await;
     let cancel = state.cancel.clone();
@@ -1016,6 +1022,7 @@ mod tests {
             .route("/v1/models", get(list_models))
             .route("/health", get(health))
             .route("/ready", get(ready))
+            .layer(middleware::from_fn(request_id_middleware))
             .with_state(test_state())
     }
 
@@ -1025,6 +1032,7 @@ mod tests {
             .route("/v1/models", get(list_models))
             .route("/health", get(health))
             .route("/ready", get(ready))
+            .layer(middleware::from_fn(request_id_middleware))
             .with_state(test_state_with_provider())
     }
 
@@ -1045,6 +1053,7 @@ mod tests {
         Router::new()
             .merge(public_routes)
             .merge(protected_routes)
+            .layer(middleware::from_fn(request_id_middleware))
             .with_state(state)
     }
 
@@ -1457,6 +1466,7 @@ mod tests {
             .route("/v1/chat/completions", post(chat_completions))
             .route("/v1/models", get(list_models))
             .route("/health", get(health))
+            .layer(middleware::from_fn(request_id_middleware))
             .with_state(state);
 
         let req_body = serde_json::json!({
@@ -2169,6 +2179,7 @@ mod tests {
             .route("/v1/chat/completions", post(chat_completions))
             .layer(DefaultBodyLimit::max(body_limit))
             .layer(middleware::from_fn(request_log_middleware))
+            .layer(middleware::from_fn(request_id_middleware))
             .layer(cors)
             .with_state(state);
 
@@ -2220,6 +2231,7 @@ mod tests {
         let app = Router::new()
             .route("/v1/chat/completions", post(chat_completions))
             .layer(DefaultBodyLimit::max(body_limit))
+            .layer(middleware::from_fn(request_id_middleware))
             .layer(cors)
             .with_state(state);
 
@@ -2285,7 +2297,7 @@ mod tests {
             tool_calls: None,
         }];
 
-        let resp = stream_completion(state, req, "test".to_string(), messages).await;
+        let resp = stream_completion(state, req, "test".to_string(), messages, "test-req-id".to_string()).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         let ct = resp
@@ -2337,7 +2349,7 @@ mod tests {
             tool_calls: None,
         }];
 
-        let resp = stream_completion(state, req, "test".to_string(), messages).await;
+        let resp = stream_completion(state, req, "test".to_string(), messages, "test-req-id".to_string()).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();

--- a/crates/kestrel-channels/src/platforms/discord.rs
+++ b/crates/kestrel-channels/src/platforms/discord.rs
@@ -1021,7 +1021,7 @@ impl DiscordChannel {
             source: Some(source),
             message_type,
             message_id: Some(msg.id.clone()),
-            trace_id: Some(format!("kst_dc_{}", &uuid::Uuid::new_v4().to_string()[..8])),
+            trace_id: Some(format!("dc_{}", msg.id)),
             reply_to: None,
             timestamp: chrono::Local::now(),
         };

--- a/crates/kestrel-channels/src/platforms/discord.rs
+++ b/crates/kestrel-channels/src/platforms/discord.rs
@@ -1497,6 +1497,7 @@ mod tests {
         assert_eq!(inbound.content, "Hello bot!");
         assert_eq!(inbound.message_type, MessageType::Text);
         assert_eq!(inbound.message_id.as_deref(), Some("111"));
+        assert_eq!(inbound.trace_id.as_deref(), Some("dc_111"));
         let src = inbound.source.unwrap();
         assert_eq!(src.platform, Platform::Discord);
         assert_eq!(src.chat_type, "guild");
@@ -1522,6 +1523,7 @@ mod tests {
 
         let inbound = rx.try_recv().unwrap();
         assert_eq!(inbound.message_type, MessageType::Command);
+        assert_eq!(inbound.trace_id.as_deref(), Some("dc_555"));
         let src = inbound.source.unwrap();
         assert_eq!(src.chat_type, "dm");
     }

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1081,7 +1081,13 @@ impl TelegramChannel {
                                 .await;
                             }
                             crate::commands::CommandDispatch::Rewrite(rewritten) => {
-                                match Self::dispatch_message(&handler, &msg, Some(rewritten)).await
+                                match Self::dispatch_message(
+                                    &handler,
+                                    &msg,
+                                    Some(rewritten),
+                                    update.update_id,
+                                )
+                                .await
                                 {
                                     Ok(true) => {
                                         Self::send_read_receipt(
@@ -1102,7 +1108,7 @@ impl TelegramChannel {
                             }
                         }
                     } else {
-                        match Self::dispatch_message(&handler, &msg, None).await {
+                        match Self::dispatch_message(&handler, &msg, None, update.update_id).await {
                             Ok(true) => {
                                 // Message dispatched — send 👀 read receipt.
                                 Self::send_read_receipt(
@@ -1120,9 +1126,15 @@ impl TelegramChannel {
                         }
                     }
                 } else if let Some(cq) = update.callback_query {
-                    if let Err(e) =
-                        Self::dispatch_callback_query(&client, &base_url, &handler, &cq, &router)
-                            .await
+                    if let Err(e) = Self::dispatch_callback_query(
+                        &client,
+                        &base_url,
+                        &handler,
+                        &cq,
+                        &router,
+                        update.update_id,
+                    )
+                    .await
                     {
                         error!("Failed to dispatch Telegram callback query: {e}");
                     }
@@ -1142,6 +1154,7 @@ impl TelegramChannel {
         handler: &tokio::sync::mpsc::Sender<InboundMessage>,
         msg: &TgMessage,
         text_override: Option<String>,
+        update_id: i64,
     ) -> Result<bool> {
         let sender_id = msg
             .from
@@ -1240,7 +1253,7 @@ impl TelegramChannel {
             source: Some(source),
             message_type,
             message_id: Some(msg.message_id.to_string()),
-            trace_id: Some(format!("kst_tg_{}", &uuid::Uuid::new_v4().to_string()[..8])),
+            trace_id: Some(format!("tg_{}_{}", update_id, msg.message_id)),
             reply_to: msg
                 .reply_to_message
                 .as_ref()
@@ -1267,6 +1280,7 @@ impl TelegramChannel {
         handler: &tokio::sync::mpsc::Sender<InboundMessage>,
         cq: &TgCallbackQuery,
         router: &Arc<tokio::sync::Mutex<CallbackRouter>>,
+        update_id: i64,
     ) -> Result<()> {
         let sender_id = cq
             .from
@@ -1382,7 +1396,7 @@ impl TelegramChannel {
             source: Some(source),
             message_type: MessageType::Command,
             message_id: Some(msg.message_id.to_string()),
-            trace_id: Some(format!("kst_tg_{}", &uuid::Uuid::new_v4().to_string()[..8])),
+            trace_id: Some(format!("tg_{}_{}", update_id, msg.message_id)),
             reply_to: None,
             timestamp: Local::now(),
         };
@@ -2494,7 +2508,7 @@ mod tests {
             reply_to_message: None,
         };
 
-        TelegramChannel::dispatch_message(&tx, &msg, None)
+        TelegramChannel::dispatch_message(&tx, &msg, None, 0)
             .await
             .unwrap();
 
@@ -2536,7 +2550,7 @@ mod tests {
             reply_to_message: None,
         };
 
-        TelegramChannel::dispatch_message(&tx, &msg, None)
+        TelegramChannel::dispatch_message(&tx, &msg, None, 0)
             .await
             .unwrap();
 
@@ -2585,7 +2599,7 @@ mod tests {
             reply_to_message: None,
         };
 
-        TelegramChannel::dispatch_message(&tx, &msg, None)
+        TelegramChannel::dispatch_message(&tx, &msg, None, 0)
             .await
             .unwrap();
 
@@ -2633,7 +2647,7 @@ mod tests {
             })),
         };
 
-        TelegramChannel::dispatch_message(&tx, &msg, None)
+        TelegramChannel::dispatch_message(&tx, &msg, None, 0)
             .await
             .unwrap();
 
@@ -2666,7 +2680,7 @@ mod tests {
         };
 
         // Should succeed but not send anything — no text, no photo.
-        let dispatched = TelegramChannel::dispatch_message(&tx, &msg, None)
+        let dispatched = TelegramChannel::dispatch_message(&tx, &msg, None, 0)
             .await
             .unwrap();
         assert!(!dispatched);
@@ -2689,7 +2703,7 @@ mod tests {
             caption: None,
             reply_to_message: None,
         };
-        let dispatched = TelegramChannel::dispatch_message(&tx, &msg, None)
+        let dispatched = TelegramChannel::dispatch_message(&tx, &msg, None, 0)
             .await
             .unwrap();
         assert!(dispatched);
@@ -2716,7 +2730,7 @@ mod tests {
             caption: None,
             reply_to_message: None,
         };
-        let dispatched = TelegramChannel::dispatch_message(&tx, &msg, None)
+        let dispatched = TelegramChannel::dispatch_message(&tx, &msg, None, 0)
             .await
             .unwrap();
         assert!(dispatched);
@@ -2806,7 +2820,7 @@ mod tests {
         // The answerCallbackQuery call will fail (no server) but dispatch
         // should still succeed since we only warn on failure.
         let result =
-            TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router).await;
+            TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router, 0).await;
         // The handler should still receive the message even if answer fails.
         if result.is_ok() {
             let inbound = rx.try_recv().unwrap();
@@ -2848,7 +2862,7 @@ mod tests {
         };
 
         // Should return Ok(()) — no message attached means nothing to dispatch.
-        TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router)
+        TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router, 0)
             .await
             .unwrap();
     }
@@ -3579,7 +3593,7 @@ mod tests {
         // Router matches → handler runs, returns Acknowledged.
         // No message sent to bus.
         let result =
-            TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router).await;
+            TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router, 0).await;
         // Should succeed (HTTP calls to localhost:0 fail but are only warned).
         assert!(result.is_ok() || result.is_err());
     }
@@ -3614,7 +3628,7 @@ mod tests {
         };
 
         let result =
-            TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router).await;
+            TelegramChannel::dispatch_callback_query(&client, base_url, &tx, &cq, &router, 0).await;
         if result.is_ok() {
             // Falls through to bus → InboundMessage produced.
             let inbound = rx.try_recv().unwrap();

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -2519,11 +2519,44 @@ mod tests {
         assert_eq!(inbound.content, "hello world");
         assert_eq!(inbound.message_type, MessageType::Text);
         assert_eq!(inbound.message_id.as_deref(), Some("42"));
+        assert_eq!(inbound.trace_id.as_deref(), Some("tg_0_42"));
         assert!(inbound.media.is_empty());
         assert!(inbound.source.is_some());
         let src = inbound.source.unwrap();
         assert_eq!(src.chat_type, "dm");
         assert_eq!(src.user_name.as_deref(), Some("Alice"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_message_trace_id_uses_platform_native_ids() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<InboundMessage>(10);
+
+        let msg = TgMessage {
+            message_id: 44521,
+            from: Some(TgUser {
+                id: 123,
+                first_name: Some("Alice".to_string()),
+                last_name: None,
+                username: None,
+            }),
+            chat: TgChat {
+                id: 123,
+                chat_type: Some("private".to_string()),
+                title: None,
+                thread_id: None,
+            },
+            text: Some("hello".to_string()),
+            photo: None,
+            caption: None,
+            reply_to_message: None,
+        };
+
+        TelegramChannel::dispatch_message(&tx, &msg, None, 9823)
+            .await
+            .unwrap();
+
+        let inbound = rx.try_recv().unwrap();
+        assert_eq!(inbound.trace_id.as_deref(), Some("tg_9823_44521"));
     }
 
     #[tokio::test]
@@ -2830,6 +2863,7 @@ mod tests {
             assert_eq!(inbound.content, "callback:action:confirm");
             assert_eq!(inbound.message_type, MessageType::Command);
             assert_eq!(inbound.message_id.as_deref(), Some("50"));
+            assert_eq!(inbound.trace_id.as_deref(), Some("tg_0_50"));
             assert_eq!(
                 inbound.metadata.get("tg_callback_data").unwrap(),
                 &serde_json::json!("action:confirm")


### PR DESCRIPTION
## Summary

Implements Issue #62: unified TraceID across all channels (Telegram, Discord, WebSocket, API Server).

### Changes

**TraceID injection per channel:**
- **Telegram**: `kst_tg_{uuid}` → `tg_{update_id}_{message_id}` (platform-native IDs)
- **Discord**: `kst_dc_{uuid}` → `dc_{snowflake_message_id}` (platform-native IDs)
- **WebSocket**: Already done in #61, no changes needed
- **API Server**: `x-request-id` middleware now injects into `InboundMessage.trace_id` via Axum Extension

**AgentRunner fixes:**
- Fixed `session_key: String::new()` bug — tool call events now carry correct session_key
- `trace_id` bound to AgentRunner via builder pattern

**OutboundMessage:**
- All channels now propagate `trace_id` on outbound replies

Closes #62