### PR TITLE
fix(skill): auto-create skills dir and bundle default skills

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 parking_lot = { workspace = true }
 async-trait = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/kestrel-config/src/paths.rs
+++ b/crates/kestrel-config/src/paths.rs
@@ -3,7 +3,7 @@
 //! Mirrors the Python config/paths.py module for data, media, cron, and workspace paths.
 
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Get the kestrel home directory.
 ///
@@ -71,6 +71,13 @@ pub fn get_memory_dir() -> Result<PathBuf> {
 /// Get the skills directory.
 pub fn get_skills_dir() -> Result<PathBuf> {
     let home = get_kestrel_home()?;
+    get_skills_dir_with_home(&home)
+}
+
+/// Get the skills directory using an explicit home path.
+///
+/// Creates the directory if it does not exist.
+pub fn get_skills_dir_with_home(home: &Path) -> Result<PathBuf> {
     let skills_dir = home.join("skills");
     ensure_dir(&skills_dir)?;
     Ok(skills_dir)
@@ -94,7 +101,7 @@ pub fn get_templates_dir() -> Result<PathBuf> {
 }
 
 /// Ensure a directory exists, creating it if necessary.
-fn ensure_dir(path: &PathBuf) -> Result<()> {
+fn ensure_dir(path: &Path) -> Result<()> {
     if !path.exists() {
         std::fs::create_dir_all(path)
             .with_context(|| format!("Failed to create directory: {}", path.display()))?;

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -36,19 +36,19 @@ use tracing::info;
 
 /// Initialize the skill registry by loading TOML manifests from the skills directory.
 ///
-/// Looks for `skills/` under the given kestrel home directory. If the directory
-/// does not exist, returns an empty registry. Invalid manifests are logged and skipped.
+/// Calls [`kestrel_config::paths::get_skills_dir`] which auto-creates the directory.
+/// If directory creation fails, returns an empty registry. Invalid manifests are
+/// logged and skipped.
 async fn init_skill_registry(home: &Path) -> Arc<SkillRegistry> {
-    let skills_dir = home.join("skills");
-    let registry = Arc::new(SkillRegistry::new().with_skills_dir(&skills_dir));
+    let skills_dir = match kestrel_config::paths::get_skills_dir_with_home(home) {
+        Ok(dir) => dir,
+        Err(e) => {
+            tracing::warn!("Failed to create skills directory: {}", e);
+            return Arc::new(SkillRegistry::new());
+        }
+    };
 
-    if !skills_dir.exists() {
-        info!(
-            "Skills directory not found at {}, skipping skill loading",
-            skills_dir.display()
-        );
-        return registry;
-    }
+    let registry = Arc::new(SkillRegistry::new().with_skills_dir(&skills_dir));
 
     let config = SkillConfig::default().with_skills_dir(&skills_dir);
     let loader = SkillLoader::new(config);
@@ -56,7 +56,11 @@ async fn init_skill_registry(home: &Path) -> Arc<SkillRegistry> {
     match loader.load_all(&registry).await {
         Ok(loaded) => {
             if loaded.is_empty() {
-                info!("No skill manifests found in {}", skills_dir.display());
+                info!(
+                    "No skill manifests found in {}, seeding defaults",
+                    skills_dir.display()
+                );
+                seed_default_skills(&registry).await;
             } else {
                 info!("Loaded {} skills: {:?}", loaded.len(), loaded);
             }
@@ -67,6 +71,47 @@ async fn init_skill_registry(home: &Path) -> Arc<SkillRegistry> {
     }
 
     registry
+}
+
+/// Seed the registry with bundled default skills when no skills exist.
+///
+/// Writes embedded TOML manifests and Markdown instructions to the skills
+/// directory and registers them. Errors are logged but not propagated so the
+/// gateway can still start.
+async fn seed_default_skills(registry: &SkillRegistry) {
+    let defaults = [
+        (
+            "greeting",
+            include_str!("../skills/default/greeting.toml"),
+            include_str!("../skills/default/greeting.md"),
+        ),
+        (
+            "system-info",
+            include_str!("../skills/default/system-info.toml"),
+            include_str!("../skills/default/system-info.md"),
+        ),
+    ];
+
+    for (name, toml_content, md_content) in &defaults {
+        if registry.get(name).await.is_some() {
+            continue;
+        }
+        let manifest: kestrel_skill::SkillManifest = match toml::from_str(toml_content) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!("Skipping bundled skill '{}': invalid manifest: {}", name, e);
+                continue;
+            }
+        };
+        if let Err(e) = registry
+            .create_skill(&manifest.name, &manifest.description, md_content)
+            .await
+        {
+            tracing::warn!("Failed to seed default skill '{}': {}", name, e);
+        } else {
+            info!("Seeded default skill: {}", name);
+        }
+    }
 }
 
 /// Register the gateway heartbeat checks and publish an initial snapshot.
@@ -739,13 +784,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_init_skill_registry_missing_dir_returns_empty() {
+    async fn test_init_skill_registry_missing_dir_creates_and_seeds() {
         let home = tempfile::tempdir().unwrap();
-        // No skills/ directory created
+        // No skills/ directory created — should auto-create and seed defaults
 
         let registry = init_skill_registry(home.path()).await;
 
-        assert!(registry.is_empty().await);
+        // Directory should now exist
+        assert!(home.path().join("skills").is_dir());
+        // Default skills should be loaded
+        assert!(!registry.is_empty().await);
+        assert!(registry.get("greeting").await.is_some());
+        assert!(registry.get("system-info").await.is_some());
     }
 
     #[tokio::test]
@@ -766,15 +816,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_init_skill_registry_empty_dir_returns_empty() {
+    async fn test_init_skill_registry_empty_dir_seeds_defaults() {
         let home = tempfile::tempdir().unwrap();
         let skills_dir = home.path().join("skills");
         std::fs::create_dir_all(&skills_dir).unwrap();
-        // Empty directory, no TOML files
+        // Empty directory — should seed default skills
 
         let registry = init_skill_registry(home.path()).await;
 
-        assert!(registry.is_empty().await);
+        assert!(!registry.is_empty().await);
+        assert!(registry.get("greeting").await.is_some());
     }
 
     #[tokio::test]

--- a/src/skills/default/greeting.md
+++ b/src/skills/default/greeting.md
@@ -1,0 +1,7 @@
+# Greeting
+
+When the user sends a greeting:
+
+1. Respond warmly and concisely
+2. Ask how you can help
+3. If context from previous sessions is available, reference it naturally

--- a/src/skills/default/greeting.toml
+++ b/src/skills/default/greeting.toml
@@ -1,0 +1,5 @@
+name = "greeting"
+version = "1.0.0"
+description = "Greet the user and offer assistance"
+category = "social"
+triggers = ["hello", "hi", "hey", "greet", "good morning", "good afternoon", "good evening"]

--- a/src/skills/default/system-info.md
+++ b/src/skills/default/system-info.md
@@ -1,0 +1,8 @@
+# System Info
+
+When the user asks about system status:
+
+1. Report kestrel version
+2. List active channels and their status
+3. Summarize configured providers
+4. Note memory store status if available

--- a/src/skills/default/system-info.toml
+++ b/src/skills/default/system-info.toml
@@ -1,0 +1,5 @@
+name = "system-info"
+version = "1.0.0"
+description = "Report current system status and configuration"
+category = "utility"
+triggers = ["system info", "status", "health", "config", "uptime", "version"]


### PR DESCRIPTION
## Summary

- **Fix 1 (P0):** `init_skill_registry()` now calls `get_skills_dir_with_home()` instead of manually joining `"skills"` to the home path. This auto-creates `~/.kestrel/skills/` via `ensure_dir()` on startup.
- **Fix 2 (P0):** Bundles 2 default skills (`greeting`, `system-info`) embedded in the binary via `include_str!`. These are seeded to the skills directory when it's empty.
- **Fix 3 (P1):** Cold-start path — when the registry is empty after loading, `seed_default_skills()` writes the bundled defaults, breaking the chicken-and-egg deadlock.

### Files changed
- `Cargo.toml` — added `toml` to runtime deps
- `crates/kestrel-config/src/paths.rs` — added `get_skills_dir_with_home()` + widened `ensure_dir` to `&Path`
- `src/commands/gateway.rs` — rewrote `init_skill_registry()`, added `seed_default_skills()`
- `src/skills/default/` — 4 new embedded skill files (2 TOML manifests + 2 Markdown instructions)
- 2 tests updated to reflect new auto-create behavior

## Test plan
- [x] `cargo test --workspace` — all 1,800+ tests pass (0 failures)
- [x] `cargo check` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p kestrel-config -p kestrel-skill` — 0 warnings
- [ ] Manual: restart kestrel gateway, verify `~/.kestrel/skills/` auto-created with default skills
- [ ] Manual: verify skills are matchable via `/skill list`

Closes #100

Bahtya