### PR TITLE
fix(trace): daemon log_level from config + AgentEvent trace_id propagation

### DIFF
--- a/crates/kestrel-agent/src/hook.rs
+++ b/crates/kestrel-agent/src/hook.rs
@@ -103,6 +103,7 @@ mod tests {
         let hook = CompositeHook::new();
         let ctx = HookContext {
             event: AgentEvent::Started {
+                trace_id: None,
                 session_key: "test".to_string(),
             },
             data: std::collections::HashMap::new(),
@@ -119,6 +120,7 @@ mod tests {
 
         let ctx = HookContext {
             event: AgentEvent::Started {
+                trace_id: None,
                 session_key: "test".to_string(),
             },
             data: std::collections::HashMap::new(),

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -173,6 +173,7 @@ impl AgentLoop {
             // Emit started event
             let started_event = AgentEvent::Started {
                 session_key: session_key.clone(),
+                trace_id: msg.trace_id.clone(),
             };
             self.bus.emit_event(started_event.clone());
             self.hooks
@@ -283,6 +284,7 @@ impl AgentLoop {
                         AgentEvent::StreamingChunk {
                             session_key,
                             content,
+                            ..
                         } => {
                             event_bus.publish_stream_chunk(StreamChunk {
                                 session_key: session_key.clone(),
@@ -295,11 +297,13 @@ impl AgentLoop {
                             session_key,
                             tool_name,
                             iteration,
+                            ..
                         } => {
                             event_bus.emit_event(AgentEvent::ToolCall {
                                 session_key: session_key.clone(),
                                 tool_name: tool_name.clone(),
                                 iteration: *iteration,
+                                trace_id: trace_id_for_runner.clone(),
                             });
                         }
                         _ => {}
@@ -400,6 +404,7 @@ impl AgentLoop {
                         session_key: session_key.clone(),
                         iterations: result.iterations_used,
                         tool_calls: result.tool_calls_made,
+                        trace_id: msg.trace_id.clone(),
                     };
                     self.bus.emit_event(completed_event.clone());
                     self.hooks
@@ -429,6 +434,7 @@ impl AgentLoop {
                     let error_event = AgentEvent::Error {
                         session_key: session_key.clone(),
                         error: e.to_string(),
+                        trace_id: msg.trace_id.clone(),
                     };
                     self.bus.emit_event(error_event.clone());
                     self.hooks

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -181,6 +181,7 @@ impl AgentRunner {
                     session_key: self.session_key.clone().unwrap_or_default(),
                     tool_name: tc.function.name.clone(),
                     iteration: iteration + 1,
+                    trace_id: None,
                 });
             }
 

--- a/crates/kestrel-bus/src/events.rs
+++ b/crates/kestrel-bus/src/events.rs
@@ -120,12 +120,16 @@ pub struct StreamChunk {
 #[derive(Debug, Clone)]
 pub enum AgentEvent {
     /// Agent started processing a message.
-    Started { session_key: String },
+    Started {
+        session_key: String,
+        trace_id: Option<String>,
+    },
 
     /// Agent produced a streaming chunk.
     StreamingChunk {
         session_key: String,
         content: String,
+        trace_id: Option<String>,
     },
 
     /// Agent is executing a tool.
@@ -133,6 +137,7 @@ pub enum AgentEvent {
         session_key: String,
         tool_name: String,
         iteration: usize,
+        trace_id: Option<String>,
     },
 
     /// Agent completed processing.
@@ -140,10 +145,15 @@ pub enum AgentEvent {
         session_key: String,
         iterations: usize,
         tool_calls: usize,
+        trace_id: Option<String>,
     },
 
     /// Agent encountered an error.
-    Error { session_key: String, error: String },
+    Error {
+        session_key: String,
+        error: String,
+        trace_id: Option<String>,
+    },
 
     /// A cron job fired.
     CronFired {

--- a/crates/kestrel-bus/src/queue.rs
+++ b/crates/kestrel-bus/src/queue.rs
@@ -212,9 +212,11 @@ mod tests {
         let mut events_rx = bus.subscribe_events();
 
         bus.emit_event(AgentEvent::Started {
+            trace_id: None,
             session_key: "test".to_string(),
         });
         bus.emit_event(AgentEvent::Completed {
+            trace_id: None,
             session_key: "test".to_string(),
             iterations: 2,
             tool_calls: 1,

--- a/crates/kestrel-channels/src/base.rs
+++ b/crates/kestrel-channels/src/base.rs
@@ -73,7 +73,7 @@ pub trait BaseChannel: Send + Sync {
     }
 
     /// Send a typing indicator.
-    async fn send_typing(&self, chat_id: &str) -> Result<()>;
+    async fn send_typing(&self, chat_id: &str, trace_id: Option<&str>) -> Result<()>;
 
     /// Send a reaction emoji to a message.
     ///

--- a/crates/kestrel-channels/src/manager.rs
+++ b/crates/kestrel-channels/src/manager.rs
@@ -165,7 +165,7 @@ impl ChannelManager {
     ///
     /// Sends one typing action immediately, then repeats every 4 seconds.
     /// Call [`stop_typing`] to cancel.
-    pub fn start_typing(&self, session_key: &str) {
+    pub fn start_typing(&self, session_key: &str, trace_id: Option<&str>) {
         let (platform, chat_id) = match parse_session_key(session_key) {
             Some(p) => p,
             None => {
@@ -184,14 +184,16 @@ impl ChannelManager {
 
         let chat_id_owned = chat_id.to_string();
         let sk = session_key.to_string();
+        let trace_id_owned = trace_id.map(|t| t.to_string());
 
         // Fire one typing action immediately.
         {
             let ch = channel.clone();
             let cid = chat_id_owned.clone();
+            let tid = trace_id_owned.clone();
             tokio::spawn(async move {
                 let ch = ch.lock().await;
-                let _ = ch.send_typing(&cid).await;
+                let _ = ch.send_typing(&cid, tid.as_deref()).await;
             });
         }
 
@@ -200,7 +202,9 @@ impl ChannelManager {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 let ch = channel.lock().await;
-                let _ = ch.send_typing(&chat_id_owned).await;
+                let _ = ch
+                    .send_typing(&chat_id_owned, trace_id_owned.as_deref())
+                    .await;
             }
         });
 
@@ -230,9 +234,12 @@ impl ChannelManager {
         loop {
             match rx.recv().await {
                 Ok(event) => match &event {
-                    AgentEvent::Started { session_key } => {
+                    AgentEvent::Started {
+                        session_key,
+                        trace_id,
+                    } => {
                         debug!("Typing started for session: {session_key}");
-                        self.start_typing(session_key);
+                        self.start_typing(session_key, trace_id.as_deref());
                     }
                     AgentEvent::Completed { session_key, .. } => {
                         debug!("Typing stopped for session: {session_key}");
@@ -308,22 +315,27 @@ impl ChannelManager {
                     AgentEvent::StreamingChunk {
                         session_key,
                         content,
+                        trace_id,
                     } => {
                         debug!("Streaming chunk for session: {session_key}");
                         bus.publish_stream_chunk(StreamChunk {
                             session_key: session_key.clone(),
                             content: content.clone(),
                             done: false,
-                            trace_id: None,
+                            trace_id: trace_id.clone(),
                         });
                     }
-                    AgentEvent::Completed { session_key, .. } => {
+                    AgentEvent::Completed {
+                        session_key,
+                        trace_id,
+                        ..
+                    } => {
                         // Send final done chunk.
                         bus.publish_stream_chunk(StreamChunk {
                             session_key: session_key.clone(),
                             content: String::new(),
                             done: true,
-                            trace_id: None,
+                            trace_id: trace_id.clone(),
                         });
                     }
                     _ => {}
@@ -460,7 +472,7 @@ mod tests {
         let bus = MessageBus::new();
         let manager = ChannelManager::new(registry, bus);
         // Should silently do nothing — no panic.
-        manager.start_typing("telegram:123");
+        manager.start_typing("telegram:123", None);
         assert!(manager.typing_tasks.is_empty());
     }
 
@@ -478,7 +490,7 @@ mod tests {
         let registry = ChannelRegistry::new();
         let bus = MessageBus::new();
         let manager = ChannelManager::new(registry, bus);
-        manager.start_typing("invalid-no-colon");
+        manager.start_typing("invalid-no-colon", None);
         assert!(manager.typing_tasks.is_empty());
     }
 
@@ -504,6 +516,7 @@ mod tests {
         let manager = ChannelManager::new(registry, bus.clone());
 
         bus.emit_event(AgentEvent::Started {
+            trace_id: None,
             session_key: "telegram:123".to_string(),
         });
 
@@ -526,6 +539,7 @@ mod tests {
         let manager = ChannelManager::new(registry, bus.clone());
 
         bus.emit_event(AgentEvent::Completed {
+            trace_id: None,
             session_key: "telegram:123".to_string(),
             iterations: 1,
             tool_calls: 0,
@@ -549,6 +563,7 @@ mod tests {
         let manager = ChannelManager::new(registry, bus.clone());
 
         bus.emit_event(AgentEvent::Error {
+            trace_id: None,
             session_key: "discord:456".to_string(),
             error: "timeout".to_string(),
         });
@@ -569,13 +584,14 @@ mod tests {
         let registry = ChannelRegistry::new();
         let bus = MessageBus::new();
         let manager = ChannelManager::new(registry, bus);
+        let trace_id = Some("test-trace".to_string());
 
         let msg = OutboundMessage {
             channel: kestrel_core::Platform::Telegram,
             chat_id: "123".to_string(),
             content: "reply".to_string(),
             reply_to: None,
-            trace_id: None,
+            trace_id,
             media: vec![],
             metadata: Default::default(),
         };

--- a/crates/kestrel-channels/src/platforms/discord.rs
+++ b/crates/kestrel-channels/src/platforms/discord.rs
@@ -1159,7 +1159,7 @@ impl BaseChannel for DiscordChannel {
         })
     }
 
-    async fn send_typing(&self, chat_id: &str) -> Result<()> {
+    async fn send_typing(&self, chat_id: &str, _trace_id: Option<&str>) -> Result<()> {
         let path = format!("/channels/{chat_id}/typing");
 
         let resp = self

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1805,7 +1805,7 @@ impl BaseChannel for TelegramChannel {
         }
     }
 
-    async fn send_typing(&self, chat_id: &str) -> Result<()> {
+    async fn send_typing(&self, chat_id: &str, _trace_id: Option<&str>) -> Result<()> {
         debug!("Sending typing indicator to chat {}", chat_id);
 
         let chat_id_num: i64 = match chat_id.parse() {
@@ -2352,7 +2352,7 @@ mod tests {
     async fn test_telegram_send_typing_invalid_chat_id() {
         let channel = TelegramChannel::new();
         // Should not error — just logs a warning.
-        channel.send_typing("not_a_number").await.unwrap();
+        channel.send_typing("not_a_number", None).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -217,6 +217,8 @@ fn default_user_role() -> String {
 #[derive(Debug, serde::Serialize)]
 struct WsTypingIndicator {
     r#type: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trace_id: Option<String>,
 }
 
 /// Outbound image message.
@@ -850,9 +852,12 @@ impl BaseChannel for WebSocketChannel {
     }
 
     /// Send a typing indicator to a specific client.
-    async fn send_typing(&self, chat_id: &str) -> Result<()> {
+    async fn send_typing(&self, chat_id: &str, trace_id: Option<&str>) -> Result<()> {
         if let Some(client) = self.clients.get(chat_id) {
-            let msg = WsTypingIndicator { r#type: "typing" };
+            let msg = WsTypingIndicator {
+                r#type: "typing",
+                trace_id: trace_id.map(|t| t.to_string()),
+            };
             let json = serde_json::to_string(&msg)?;
             let _ = client.send(json);
         }
@@ -1134,7 +1139,10 @@ mod tests {
 
     #[test]
     fn test_typing_indicator_format() {
-        let msg = WsTypingIndicator { r#type: "typing" };
+        let msg = WsTypingIndicator {
+            r#type: "typing",
+            trace_id: None,
+        };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["type"], "typing");

--- a/crates/kestrel-channels/tests/discord_mock.rs
+++ b/crates/kestrel-channels/tests/discord_mock.rs
@@ -335,6 +335,6 @@ async fn test_discord_send_typing_with_mock() {
         format!("http://127.0.0.1:{}/", port),
     );
 
-    let result = channel.send_typing("12345").await;
+    let result = channel.send_typing("12345", None).await;
     assert!(result.is_ok());
 }

--- a/crates/kestrel-channels/tests/gateway_routing.rs
+++ b/crates/kestrel-channels/tests/gateway_routing.rs
@@ -86,7 +86,7 @@ impl BaseChannel for MockChannel {
         })
     }
 
-    async fn send_typing(&self, _chat_id: &str) -> anyhow::Result<()> {
+    async fn send_typing(&self, _chat_id: &str, _trace_id: Option<&str>) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/crates/kestrel-channels/tests/telegram_mock.rs
+++ b/crates/kestrel-channels/tests/telegram_mock.rs
@@ -260,7 +260,7 @@ async fn test_telegram_send_typing_with_mock() {
         format!("http://127.0.0.1:{}", port),
     );
 
-    let result = channel.send_typing("123").await;
+    let result = channel.send_typing("123", None).await;
     assert!(result.is_ok());
 }
 

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -738,6 +738,10 @@ pub struct DaemonConfig {
     /// Grace period in seconds for in-flight work during shutdown.
     #[serde(default = "default_daemon_grace_period")]
     pub grace_period_secs: u64,
+
+    /// Log level for daemon file logging (trace, debug, info, warn, error).
+    #[serde(default = "default_daemon_log_level")]
+    pub log_level: String,
 }
 
 fn default_daemon_pid_file() -> String {
@@ -766,6 +770,10 @@ const fn default_daemon_grace_period() -> u64 {
     30
 }
 
+fn default_daemon_log_level() -> String {
+    "info".to_string()
+}
+
 impl Default for DaemonConfig {
     fn default() -> Self {
         Self {
@@ -773,6 +781,7 @@ impl Default for DaemonConfig {
             log_dir: default_daemon_log_dir(),
             working_directory: default_daemon_working_directory(),
             grace_period_secs: default_daemon_grace_period(),
+            log_level: default_daemon_log_level(),
         }
     }
 }

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -94,7 +94,7 @@ fn do_start(config: &Config) -> Result<DaemonHandles> {
     let pid_file = kestrel_daemon::pid_file::PidFile::create(pid_file_path)?;
 
     // Setup file logging in the daemon process
-    let log_guard = kestrel_daemon::logging::setup_file_logging(log_dir, "info")?;
+    let log_guard = kestrel_daemon::logging::setup_file_logging(log_dir, &config.daemon.log_level)?;
     tracing::info!("Daemon started (pid={})", std::process::id());
 
     Ok(DaemonHandles {

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -446,8 +446,11 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     let _typing_handle = tokio::spawn(async move {
         loop {
             match typing_event_rx.recv().await {
-                Ok(AgentEvent::Started { session_key }) => {
-                    typing_cm.start_typing(&session_key);
+                Ok(AgentEvent::Started {
+                    session_key,
+                    trace_id,
+                }) => {
+                    typing_cm.start_typing(&session_key, trace_id.as_deref());
                 }
                 Ok(AgentEvent::Completed { session_key, .. })
                 | Ok(AgentEvent::Error { session_key, .. }) => {

--- a/tests/full_integration_test.rs
+++ b/tests/full_integration_test.rs
@@ -204,7 +204,7 @@ impl BaseChannel for MockChannel {
             retryable: false,
         })
     }
-    async fn send_typing(&self, _chat_id: &str) -> anyhow::Result<()> {
+    async fn send_typing(&self, _chat_id: &str, _trace_id: Option<&str>) -> anyhow::Result<()> {
         Ok(())
     }
     async fn send_image(
@@ -383,7 +383,7 @@ async fn test_full_message_pipeline() {
 
     // Verify events: Started → Completed
     let has_started = all_events.iter().any(
-        |e| matches!(e, AgentEvent::Started { session_key } if session_key.contains("chat_42")),
+        |e| matches!(e, AgentEvent::Started { session_key, .. } if session_key.contains("chat_42")),
     );
     assert!(has_started, "Expected a Started event for chat_42");
 


### PR DESCRIPTION
## Summary
- Add `log_level` field to `DaemonConfig` so daemon mode reads log level from config instead of hardcoding "info"
- Add `trace_id: Option<String>` to all 5 `AgentEvent` variants (Started, StreamingChunk, ToolCall, Completed, Error) and propagate through agent loop, runner, and channel manager
- Fix GAP-1: `WsTypingIndicator` now includes `trace_id` via updated `BaseChannel::send_typing` trait
- Fix GAP-2: `run_streaming_on_events` reads `trace_id` from `AgentEvent` instead of hardcoding `None`

Closes #101

## Test plan
- [x] `cargo check --workspace` — 0 errors
- [x] `cargo test --workspace` — 1937+ tests pass, 0 failures
- [x] `cargo clippy --workspace` — 0 warnings
- [x] `cargo fmt --all --check` — formatted

Bahtya