### PR TITLE
feat(memory,tools): add embedding pipeline and LLM memory tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ dependencies = [
  "kestrel-bus",
  "kestrel-config",
  "kestrel-core",
+ "kestrel-memory",
  "kestrel-security",
  "kestrel-skill",
  "notify",

--- a/crates/kestrel-memory/src/embedding.rs
+++ b/crates/kestrel-memory/src/embedding.rs
@@ -1,0 +1,194 @@
+//! Embedding generation trait and hash-based placeholder implementation.
+//!
+//! The [`EmbeddingGenerator`] trait abstracts over embedding backends so the
+//! memory tools can generate vectors without knowing the concrete algorithm.
+//! [`HashEmbedding`] provides a deterministic, zero-dependency placeholder
+//! using random-projection hashing — good enough for development and testing,
+//! and designed to be swapped out for a real model (e.g. OpenAI embeddings)
+//! without changing downstream code.
+
+use async_trait::async_trait;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use crate::error::Result;
+
+/// Trait for generating embedding vectors from text.
+#[async_trait]
+pub trait EmbeddingGenerator: Send + Sync {
+    /// Generate an embedding vector for the given text.
+    async fn generate(&self, text: &str) -> Result<Vec<f32>>;
+
+    /// Return the dimension of generated embedding vectors.
+    fn dimension(&self) -> usize;
+}
+
+/// Simple hash-based embedding generator using random-projection hashing.
+///
+/// Each word in the input is hashed to determine both the dimension index
+/// and a sign (+1 / -1). The resulting sparse vector is L2-normalized. This
+/// produces deterministic, fixed-dimension embeddings where texts sharing
+/// words have higher cosine similarity — sufficient for development and as
+/// a placeholder until a real embedding model is wired in.
+pub struct HashEmbedding {
+    dimension: usize,
+}
+
+impl HashEmbedding {
+    /// Create a new hash embedding generator with the given vector dimension.
+    pub fn new(dimension: usize) -> Self {
+        Self { dimension }
+    }
+
+    /// Create with the default dimension of 256.
+    pub fn default_dim() -> Self {
+        Self::new(256)
+    }
+
+    /// Tokenize text into lowercase words.
+    fn tokenize(text: &str) -> Vec<&str> {
+        text.split(|c: char| !c.is_alphanumeric())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
+    /// Hash a string to a u64.
+    fn hash_str(s: &str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        s.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+#[async_trait]
+impl EmbeddingGenerator for HashEmbedding {
+    async fn generate(&self, text: &str) -> Result<Vec<f32>> {
+        let tokens = Self::tokenize(text);
+        if tokens.is_empty() {
+            return Ok(vec![0.0; self.dimension]);
+        }
+
+        let mut vec = vec![0.0_f32; self.dimension];
+
+        for token in &tokens {
+            let lower = token.to_lowercase();
+            let h = Self::hash_str(&lower);
+            let idx = (h as usize) % self.dimension;
+            // Use a second hash for the sign to reduce collision bias.
+            let sign_h = h.wrapping_mul(0x9E3779B97F4A7C15);
+            let sign: f32 = if sign_h % 2 == 0 { 1.0 } else { -1.0 };
+            vec[idx] += sign;
+        }
+
+        // L2 normalize.
+        let norm: f64 = vec.iter().map(|v| (*v as f64).powi(2)).sum::<f64>().sqrt();
+        if norm > 0.0 {
+            for v in &mut vec {
+                *v = (*v as f64 / norm) as f32;
+            }
+        }
+
+        Ok(vec)
+    }
+
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_generate_basic() {
+        let gen = HashEmbedding::new(64);
+        let vec = gen.generate("hello world").await.unwrap();
+        assert_eq!(vec.len(), 64);
+        // Should be L2-normalized.
+        let norm: f64 = vec.iter().map(|v| (*v as f64).powi(2)).sum::<f64>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4, "norm = {norm}");
+    }
+
+    #[tokio::test]
+    async fn test_generate_empty() {
+        let gen = HashEmbedding::new(64);
+        let vec = gen.generate("").await.unwrap();
+        assert_eq!(vec.len(), 64);
+        assert!(vec.iter().all(|v| *v == 0.0));
+    }
+
+    #[tokio::test]
+    async fn test_deterministic() {
+        let gen = HashEmbedding::new(64);
+        let a = gen.generate("rust programming").await.unwrap();
+        let b = gen.generate("rust programming").await.unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    async fn test_similar_texts_higher_similarity() {
+        let gen = HashEmbedding::new(256);
+        let a = gen.generate("the cat sat on the mat").await.unwrap();
+        let b = gen
+            .generate("the cat sat on the mat and slept")
+            .await
+            .unwrap();
+        let c = gen
+            .generate("quantum physics and differential equations")
+            .await
+            .unwrap();
+
+        let sim_ab = cosine_similarity(&a, &b);
+        let sim_ac = cosine_similarity(&a, &c);
+
+        assert!(
+            sim_ab > sim_ac,
+            "similar texts should have higher cosine similarity: ab={sim_ab}, ac={sim_ac}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dimension() {
+        let gen = HashEmbedding::new(128);
+        assert_eq!(gen.dimension(), 128);
+        assert_eq!(gen.generate("test").await.unwrap().len(), 128);
+    }
+
+    #[tokio::test]
+    async fn test_case_insensitive() {
+        let gen = HashEmbedding::new(64);
+        let a = gen.generate("Hello World").await.unwrap();
+        let b = gen.generate("hello world").await.unwrap();
+        assert_eq!(a, b);
+    }
+
+    fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
+        if a.len() != b.len() || a.is_empty() {
+            return 0.0;
+        }
+        let dot: f64 = a
+            .iter()
+            .zip(b.iter())
+            .map(|(x, y)| (*x as f64) * (*y as f64))
+            .sum();
+        let na: f64 = a.iter().map(|x| (*x as f64).powi(2)).sum::<f64>().sqrt();
+        let nb: f64 = b.iter().map(|x| (*x as f64).powi(2)).sum::<f64>().sqrt();
+        if na == 0.0 || nb == 0.0 {
+            return 0.0;
+        }
+        dot / (na * nb)
+    }
+
+    #[test]
+    fn test_tokenize() {
+        let tokens = HashEmbedding::tokenize("Hello, world! Foo-bar baz123");
+        assert_eq!(tokens, vec!["Hello", "world", "Foo", "bar", "baz123"]);
+    }
+
+    #[test]
+    fn test_tokenize_empty() {
+        let tokens = HashEmbedding::tokenize("   !!! ... ");
+        assert!(tokens.is_empty());
+    }
+}

--- a/crates/kestrel-memory/src/lib.rs
+++ b/crates/kestrel-memory/src/lib.rs
@@ -7,9 +7,12 @@
 //! - [`HotStore`] (L1) — in-memory LRU cache with JSON lines file persistence
 //! - [`WarmStore`] (L2) — persistent semantic vector search via LanceDB
 //! - [`MemoryEntry`] — typed memory entries with metadata and embeddings
+//! - [`EmbeddingGenerator`] — trait for producing embedding vectors
+//! - [`HashEmbedding`] — zero-dependency placeholder via random-projection hashing
 //! - [`MemoryConfig`] — TOML-based configuration
 
 pub mod config;
+pub mod embedding;
 pub mod error;
 pub mod hot_store;
 pub mod store;
@@ -18,6 +21,7 @@ pub mod types;
 pub mod warm_store;
 
 pub use config::MemoryConfig;
+pub use embedding::{EmbeddingGenerator, HashEmbedding};
 pub use error::MemoryError;
 pub use hot_store::HotStore;
 pub use store::MemoryStore;

--- a/crates/kestrel-tools/Cargo.toml
+++ b/crates/kestrel-tools/Cargo.toml
@@ -9,6 +9,7 @@ kestrel-config = { path = "../kestrel-config" }
 kestrel-bus = { path = "../kestrel-bus" }
 kestrel-security = { path = "../kestrel-security" }
 kestrel-skill = { path = "../kestrel-skill" }
+kestrel-memory = { path = "../kestrel-memory" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/crates/kestrel-tools/src/builtins/memory.rs
+++ b/crates/kestrel-tools/src/builtins/memory.rs
@@ -1,0 +1,511 @@
+//! Memory tools: `store_memory` and `recall_memory`.
+//!
+//! These tools let the LLM actively store and retrieve memories via the
+//! [`MemoryStore`] trait. An [`EmbeddingGenerator`] is used to produce
+//! vectors automatically, so the LLM only deals with plain text.
+
+use async_trait::async_trait;
+use kestrel_memory::{EmbeddingGenerator, MemoryCategory, MemoryEntry, MemoryQuery, MemoryStore};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use crate::trait_def::{Tool, ToolError};
+
+// ─── store_memory ────────────────────────────────────────────────
+
+/// Tool for storing a memory entry that the LLM can later recall.
+///
+/// The LLM supplies the content, category, and optional confidence.
+/// An embedding vector is generated automatically from the content text.
+pub struct StoreMemoryTool {
+    store: Arc<dyn MemoryStore>,
+    embedding: Arc<dyn EmbeddingGenerator>,
+}
+
+impl StoreMemoryTool {
+    /// Create a new store_memory tool backed by the given store and embedding generator.
+    pub fn new(store: Arc<dyn MemoryStore>, embedding: Arc<dyn EmbeddingGenerator>) -> Self {
+        Self { store, embedding }
+    }
+}
+
+#[async_trait]
+impl Tool for StoreMemoryTool {
+    fn name(&self) -> &str {
+        "store_memory"
+    }
+
+    fn description(&self) -> &str {
+        "Store a piece of information in long-term memory for later recall. \
+         Use this to remember facts about the user, project conventions, \
+         lessons learned, or any knowledge worth persisting across conversations."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The information to store."
+                },
+                "category": {
+                    "type": "string",
+                    "enum": [
+                        "user_profile", "agent_note", "fact", "preference",
+                        "environment", "project_convention", "tool_discovery",
+                        "error_lesson", "workflow_pattern", "critical"
+                    ],
+                    "description": "Category for the memory entry."
+                },
+                "confidence": {
+                    "type": "number",
+                    "description": "Confidence score from 0.0 to 1.0 (default 1.0).",
+                    "minimum": 0.0,
+                    "maximum": 1.0
+                }
+            },
+            "required": ["content", "category"]
+        })
+    }
+
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value) -> Result<String, ToolError> {
+        let content = args["content"]
+            .as_str()
+            .ok_or_else(|| ToolError::Validation("missing or invalid 'content' field".into()))?
+            .to_string();
+
+        let category_str = args["category"]
+            .as_str()
+            .ok_or_else(|| ToolError::Validation("missing or invalid 'category' field".into()))?;
+
+        let category = parse_category(category_str)?;
+
+        let confidence = args["confidence"].as_f64().unwrap_or(1.0);
+
+        let embedding_vec = self
+            .embedding
+            .generate(&content)
+            .await
+            .map_err(|e| ToolError::Execution(format!("embedding generation failed: {e}")))?;
+
+        let entry = MemoryEntry::new(content, category)
+            .with_confidence(confidence)
+            .with_embedding(embedding_vec);
+
+        let id = entry.id.clone();
+        self.store
+            .store(entry)
+            .await
+            .map_err(|e| ToolError::Execution(format!("store failed: {e}")))?;
+
+        Ok(json!({
+            "id": id,
+            "status": "stored"
+        })
+        .to_string())
+    }
+}
+
+// ─── recall_memory ───────────────────────────────────────────────
+
+/// Tool for searching and recalling stored memories.
+///
+/// The LLM supplies a text query. An embedding is generated and used
+/// for semantic search, falling back to text substring matching.
+pub struct RecallMemoryTool {
+    store: Arc<dyn MemoryStore>,
+    embedding: Arc<dyn EmbeddingGenerator>,
+}
+
+impl RecallMemoryTool {
+    /// Create a new recall_memory tool backed by the given store and embedding generator.
+    pub fn new(store: Arc<dyn MemoryStore>, embedding: Arc<dyn EmbeddingGenerator>) -> Self {
+        Self { store, embedding }
+    }
+}
+
+#[async_trait]
+impl Tool for RecallMemoryTool {
+    fn name(&self) -> &str {
+        "recall_memory"
+    }
+
+    fn description(&self) -> &str {
+        "Search long-term memory for information previously stored. \
+         Returns matching entries sorted by relevance. Use this to recall \
+         user preferences, project facts, or past lessons."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Text to search for in memory."
+                },
+                "category": {
+                    "type": "string",
+                    "enum": [
+                        "user_profile", "agent_note", "fact", "preference",
+                        "environment", "project_convention", "tool_discovery",
+                        "error_lesson", "workflow_pattern", "critical"
+                    ],
+                    "description": "Optional category filter."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default 5).",
+                    "minimum": 1,
+                    "maximum": 50
+                }
+            },
+            "required": ["query"]
+        })
+    }
+
+    fn is_mutating(&self) -> bool {
+        false
+    }
+
+    async fn execute(&self, args: Value) -> Result<String, ToolError> {
+        let query_text = args["query"]
+            .as_str()
+            .ok_or_else(|| ToolError::Validation("missing or invalid 'query' field".into()))?
+            .to_string();
+
+        let limit = args["limit"].as_u64().unwrap_or(5).min(50) as usize;
+
+        let category = match args["category"].as_str() {
+            Some(s) => Some(parse_category(s)?),
+            None => None,
+        };
+
+        let embedding_vec = self
+            .embedding
+            .generate(&query_text)
+            .await
+            .map_err(|e| ToolError::Execution(format!("embedding generation failed: {e}")))?;
+
+        let mut query = MemoryQuery::new()
+            .with_embedding(embedding_vec)
+            .with_limit(limit);
+
+        if let Some(cat) = category {
+            query = query.with_category(cat);
+        }
+
+        let results = self
+            .store
+            .search(&query)
+            .await
+            .map_err(|e| ToolError::Execution(format!("search failed: {e}")))?;
+
+        let output: Vec<Value> = results
+            .into_iter()
+            .map(|scored| {
+                json!({
+                    "id": scored.entry.id,
+                    "content": scored.entry.content,
+                    "category": scored.entry.category.to_string(),
+                    "confidence": scored.entry.confidence,
+                    "score": (scored.score * 100.0).round() / 100.0,
+                })
+            })
+            .collect();
+
+        if output.is_empty() {
+            Ok(json!({"results": [], "count": 0}).to_string())
+        } else {
+            Ok(json!({"results": output, "count": output.len()}).to_string())
+        }
+    }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────
+
+fn parse_category(s: &str) -> Result<MemoryCategory, ToolError> {
+    match s {
+        "user_profile" => Ok(MemoryCategory::UserProfile),
+        "agent_note" => Ok(MemoryCategory::AgentNote),
+        "fact" => Ok(MemoryCategory::Fact),
+        "preference" => Ok(MemoryCategory::Preference),
+        "environment" => Ok(MemoryCategory::Environment),
+        "project_convention" => Ok(MemoryCategory::ProjectConvention),
+        "tool_discovery" => Ok(MemoryCategory::ToolDiscovery),
+        "error_lesson" => Ok(MemoryCategory::ErrorLesson),
+        "workflow_pattern" => Ok(MemoryCategory::WorkflowPattern),
+        "critical" => Ok(MemoryCategory::Critical),
+        other => Err(ToolError::Validation(format!("unknown category '{other}'"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kestrel_memory::{HashEmbedding, HotStore, MemoryConfig};
+
+    async fn make_tools() -> (
+        Arc<dyn MemoryStore>,
+        StoreMemoryTool,
+        RecallMemoryTool,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = MemoryConfig::for_test(dir.path());
+        let store: Arc<dyn MemoryStore> = Arc::new(HotStore::new(&config).await.unwrap());
+        let embedding: Arc<dyn EmbeddingGenerator> = Arc::new(HashEmbedding::default_dim());
+        let store_tool = StoreMemoryTool::new(store.clone(), embedding.clone());
+        let recall_tool = RecallMemoryTool::new(store.clone(), embedding.clone());
+        (store, store_tool, recall_tool, dir)
+    }
+
+    #[test]
+    fn test_parse_category_all() {
+        let cats = [
+            ("user_profile", MemoryCategory::UserProfile),
+            ("agent_note", MemoryCategory::AgentNote),
+            ("fact", MemoryCategory::Fact),
+            ("preference", MemoryCategory::Preference),
+            ("environment", MemoryCategory::Environment),
+            ("project_convention", MemoryCategory::ProjectConvention),
+            ("tool_discovery", MemoryCategory::ToolDiscovery),
+            ("error_lesson", MemoryCategory::ErrorLesson),
+            ("workflow_pattern", MemoryCategory::WorkflowPattern),
+            ("critical", MemoryCategory::Critical),
+        ];
+        for (s, expected) in cats {
+            assert_eq!(parse_category(s).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn test_parse_category_invalid() {
+        assert!(parse_category("nonexistent").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_store_memory_tool() {
+        let (_store, store_tool, _recall_tool, _dir) = make_tools().await;
+
+        let result = store_tool
+            .execute(json!({
+                "content": "User prefers dark mode",
+                "category": "preference",
+                "confidence": 0.9
+            }))
+            .await
+            .unwrap();
+
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "stored");
+        assert!(parsed["id"].as_str().unwrap().len() > 10);
+    }
+
+    #[tokio::test]
+    async fn test_store_memory_tool_missing_content() {
+        let (_store, store_tool, _recall_tool, _dir) = make_tools().await;
+
+        let result = store_tool
+            .execute(json!({
+                "category": "fact"
+            }))
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("content"));
+    }
+
+    #[tokio::test]
+    async fn test_store_memory_tool_missing_category() {
+        let (_store, store_tool, _recall_tool, _dir) = make_tools().await;
+
+        let result = store_tool
+            .execute(json!({
+                "content": "some fact"
+            }))
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("category"));
+    }
+
+    #[tokio::test]
+    async fn test_store_memory_tool_invalid_category() {
+        let (_store, store_tool, _recall_tool, _dir) = make_tools().await;
+
+        let result = store_tool
+            .execute(json!({
+                "content": "test",
+                "category": "invalid_cat"
+            }))
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("invalid_cat"));
+    }
+
+    #[tokio::test]
+    async fn test_recall_memory_tool() {
+        let (_store, store_tool, recall_tool, _dir) = make_tools().await;
+
+        store_tool
+            .execute(json!({
+                "content": "User prefers dark mode for IDE",
+                "category": "preference"
+            }))
+            .await
+            .unwrap();
+
+        store_tool
+            .execute(json!({
+                "content": "Project uses Rust edition 2024",
+                "category": "project_convention"
+            }))
+            .await
+            .unwrap();
+
+        let result = recall_tool
+            .execute(json!({
+                "query": "dark mode",
+                "limit": 5
+            }))
+            .await
+            .unwrap();
+
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let results = parsed["results"].as_array().unwrap();
+        assert!(!results.is_empty());
+        assert_eq!(parsed["count"].as_u64().unwrap(), results.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn test_recall_memory_tool_with_category_filter() {
+        let (_store, store_tool, recall_tool, _dir) = make_tools().await;
+
+        store_tool
+            .execute(json!({
+                "content": "fact about the project",
+                "category": "fact"
+            }))
+            .await
+            .unwrap();
+
+        store_tool
+            .execute(json!({
+                "content": "user preference for light theme",
+                "category": "preference"
+            }))
+            .await
+            .unwrap();
+
+        let result = recall_tool
+            .execute(json!({
+                "query": "project",
+                "category": "fact"
+            }))
+            .await
+            .unwrap();
+
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let results = parsed["results"].as_array().unwrap();
+        assert!(results.iter().all(|r| r["category"] == "fact"));
+    }
+
+    #[tokio::test]
+    async fn test_recall_memory_tool_no_results() {
+        let (_store, _store_tool, recall_tool, _dir) = make_tools().await;
+
+        let result = recall_tool
+            .execute(json!({
+                "query": "nonexistent thing"
+            }))
+            .await
+            .unwrap();
+
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["count"].as_u64().unwrap(), 0);
+        assert!(parsed["results"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_recall_memory_tool_missing_query() {
+        let (_store, _store_tool, recall_tool, _dir) = make_tools().await;
+
+        let result = recall_tool.execute(json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("query"));
+    }
+
+    #[tokio::test]
+    async fn test_store_and_recall_roundtrip() {
+        let (_store, store_tool, recall_tool, _dir) = make_tools().await;
+
+        store_tool
+            .execute(json!({
+                "content": "The database runs on port 5432",
+                "category": "environment",
+                "confidence": 0.95
+            }))
+            .await
+            .unwrap();
+
+        let result = recall_tool
+            .execute(json!({
+                "query": "database port"
+            }))
+            .await
+            .unwrap();
+
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let results = parsed["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0]["content"].as_str().unwrap().contains("5432"));
+        assert_eq!(results[0]["category"], "environment");
+    }
+
+    #[test]
+    fn test_store_tool_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (store, store_tool, _, _) = rt.block_on(async {
+            let config = MemoryConfig::for_test(dir.path());
+            let store: Arc<dyn MemoryStore> = Arc::new(HotStore::new(&config).await.unwrap());
+            let embedding: Arc<dyn EmbeddingGenerator> = Arc::new(HashEmbedding::default_dim());
+            let store_tool = StoreMemoryTool::new(store.clone(), embedding.clone());
+            let recall_tool = RecallMemoryTool::new(store.clone(), embedding);
+            (store, store_tool, recall_tool, dir)
+        });
+
+        assert_eq!(store_tool.name(), "store_memory");
+        assert!(store_tool.description().len() > 20);
+        assert!(store_tool.is_mutating());
+        assert!(store_tool.is_available());
+
+        let _ = &store;
+    }
+
+    #[test]
+    fn test_recall_tool_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (_, _, recall_tool, _) = rt.block_on(async {
+            let config = MemoryConfig::for_test(dir.path());
+            let store: Arc<dyn MemoryStore> = Arc::new(HotStore::new(&config).await.unwrap());
+            let embedding: Arc<dyn EmbeddingGenerator> = Arc::new(HashEmbedding::default_dim());
+            let store_tool = StoreMemoryTool::new(store.clone(), embedding.clone());
+            let recall_tool = RecallMemoryTool::new(store.clone(), embedding);
+            (store, store_tool, recall_tool, dir)
+        });
+
+        assert_eq!(recall_tool.name(), "recall_memory");
+        assert!(recall_tool.description().len() > 20);
+        assert!(!recall_tool.is_mutating());
+        assert!(recall_tool.is_available());
+    }
+}

--- a/crates/kestrel-tools/src/builtins/mod.rs
+++ b/crates/kestrel-tools/src/builtins/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod cron;
 pub mod filesystem;
+pub mod memory;
 pub mod message;
 pub mod search;
 pub mod shell;


### PR DESCRIPTION
## Summary
- Add `EmbeddingGenerator` trait and `HashEmbedding` (random-projection hashing) in kestrel-memory as placeholder for semantic vector generation (Closes #81)
- Add `store_memory` and `recall_memory` tools in kestrel-tools that let the LLM actively persist and retrieve memories via `MemoryStore` (Closes #79)
- `store_memory` auto-generates embeddings from content text
- `recall_memory` uses embedding-based semantic search for retrieval

## Implementation Details

### Issue #81: Embedding Pipeline
- `EmbeddingGenerator` trait: async `generate(text) -> Vec<f32>` with `dimension() -> usize`
- `HashEmbedding`: deterministic, zero-dependency embedding using word hashing → fixed-dimension vector → L2 normalization
- Designed as drop-in placeholder; can be swapped for OpenAI/Anthropic embeddings without changing downstream code

### Issue #79: LLM-Callable Memory Tools
- `StoreMemoryTool`: accepts content, category, optional confidence → auto-embeds → stores via `MemoryStore`
- `RecallMemoryTool`: accepts query text, optional category/limit → auto-embeds → semantic search via `MemoryStore`
- Both tools take `Arc<dyn MemoryStore>` + `Arc<dyn EmbeddingGenerator>` at construction for dependency injection

## Test plan
- [x] `cargo test -p kestrel-memory -p kestrel-tools` — 329 tests pass (74 + 255)
- [x] `cargo test --workspace` — 0 failures
- [x] `cargo clippy --workspace` — 0 warnings
- [x] `cargo fmt` — clean
- [x] Embedding tests: determinism, normalization, similarity ordering, case insensitivity
- [x] Tool tests: store/recall roundtrip, validation errors, category filter, metadata checks

Fixes #79, Fixes #81

Bahtya