### PR TITLE
fix(memory,tools): address PR #117 review comments

### DIFF
--- a/crates/kestrel-memory/src/embedding.rs
+++ b/crates/kestrel-memory/src/embedding.rs
@@ -34,6 +34,12 @@ pub struct HashEmbedding {
     dimension: usize,
 }
 
+impl Default for HashEmbedding {
+    fn default() -> Self {
+        Self::default_dim()
+    }
+}
+
 impl HashEmbedding {
     /// Create a new hash embedding generator with the given vector dimension.
     pub fn new(dimension: usize) -> Self {
@@ -190,5 +196,11 @@ mod tests {
     fn test_tokenize_empty() {
         let tokens = HashEmbedding::tokenize("   !!! ... ");
         assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_default_impl() {
+        let default: HashEmbedding = HashEmbedding::default();
+        assert_eq!(default.dimension(), 256);
     }
 }

--- a/crates/kestrel-tools/src/builtins/memory.rs
+++ b/crates/kestrel-tools/src/builtins/memory.rs
@@ -76,8 +76,13 @@ impl Tool for StoreMemoryTool {
     async fn execute(&self, args: Value) -> Result<String, ToolError> {
         let content = args["content"]
             .as_str()
-            .ok_or_else(|| ToolError::Validation("missing or invalid 'content' field".into()))?
-            .to_string();
+            .ok_or_else(|| ToolError::Validation("missing or invalid 'content' field".into()))?;
+
+        if content.trim().is_empty() {
+            return Err(ToolError::Validation("content must not be empty".into()));
+        }
+
+        let content = content.to_string();
 
         let category_str = args["category"]
             .as_str()
@@ -85,7 +90,12 @@ impl Tool for StoreMemoryTool {
 
         let category = parse_category(category_str)?;
 
-        let confidence = args["confidence"].as_f64().unwrap_or(1.0);
+        let confidence = match args.get("confidence") {
+            Some(v) if !v.is_null() => v.as_f64().ok_or_else(|| {
+                ToolError::Validation("confidence must be a number between 0.0 and 1.0".into())
+            })?,
+            _ => 1.0,
+        };
 
         let embedding_vec = self
             .embedding
@@ -507,5 +517,41 @@ mod tests {
         assert!(recall_tool.description().len() > 20);
         assert!(!recall_tool.is_mutating());
         assert!(recall_tool.is_available());
+    }
+
+    #[tokio::test]
+    async fn test_store_memory_invalid_confidence() {
+        let (_store, store_tool, _recall_tool, _dir) = make_tools().await;
+
+        let result = store_tool
+            .execute(json!({
+                "content": "test",
+                "category": "fact",
+                "confidence": "high"
+            }))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("confidence"),
+            "error should mention confidence: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_store_memory_empty_content() {
+        let (_store, store_tool, _recall_tool, _dir) = make_tools().await;
+
+        let result = store_tool
+            .execute(json!({
+                "content": "   ",
+                "category": "fact"
+            }))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("empty"), "error should mention empty: {err}");
     }
 }

--- a/crates/kestrel-tools/src/builtins/mod.rs
+++ b/crates/kestrel-tools/src/builtins/mod.rs
@@ -10,6 +10,8 @@ pub mod spawn;
 pub mod web;
 
 use crate::registry::ToolRegistry;
+use kestrel_memory::{EmbeddingGenerator, MemoryStore};
+use std::sync::Arc;
 
 /// Configuration applied when registering built-in tools.
 #[derive(Debug, Clone, Copy, Default)]
@@ -37,6 +39,19 @@ pub fn register_all_with_config(registry: &ToolRegistry, config: BuiltinsConfig)
     registry.register(message::MessageTool::new());
     registry.register(cron::CronTool::new());
     registry.register(spawn::SpawnTool::new());
+}
+
+/// Register memory tools that require a memory store and embedding generator.
+pub fn register_memory_tools(
+    registry: &ToolRegistry,
+    store: Arc<dyn MemoryStore>,
+    embedding: Arc<dyn EmbeddingGenerator>,
+) {
+    registry.register(memory::StoreMemoryTool::new(
+        store.clone(),
+        embedding.clone(),
+    ));
+    registry.register(memory::RecallMemoryTool::new(store, embedding));
 }
 
 #[cfg(test)]
@@ -84,5 +99,47 @@ mod tests {
         );
         assert!(!registry.is_mutating("grep"), "grep should NOT be mutating");
         assert!(!registry.is_mutating("glob"), "glob should NOT be mutating");
+
+        // Memory tools are NOT in register_all — they need deps
+        assert!(
+            registry.get("store_memory").is_none(),
+            "store_memory should not be in register_all"
+        );
+        assert!(
+            registry.get("recall_memory").is_none(),
+            "recall_memory should not be in register_all"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_register_memory_tools() {
+        use kestrel_memory::{HashEmbedding, HotStore, MemoryConfig};
+
+        let registry = ToolRegistry::new();
+        register_all(&registry);
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = MemoryConfig::for_test(dir.path());
+        let store: Arc<dyn MemoryStore> = Arc::new(HotStore::new(&config).await.unwrap());
+        let embedding: Arc<dyn EmbeddingGenerator> = Arc::new(HashEmbedding::default_dim());
+
+        register_memory_tools(&registry, store, embedding);
+
+        assert!(
+            registry.get("store_memory").is_some(),
+            "store_memory should be registered"
+        );
+        assert!(
+            registry.get("recall_memory").is_some(),
+            "recall_memory should be registered"
+        );
+        assert!(
+            registry.is_mutating("store_memory"),
+            "store_memory should be mutating"
+        );
+        assert!(
+            !registry.is_mutating("recall_memory"),
+            "recall_memory should NOT be mutating"
+        );
     }
 }

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -393,6 +393,14 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     let heartbeat_memory_store = memory_store.clone();
     let learning_memory_store = memory_store.clone();
 
+    // Register memory tools if the memory store is available.
+    if let Some(ref ms) = memory_store {
+        let embedding: Arc<dyn kestrel_memory::EmbeddingGenerator> =
+            Arc::new(kestrel_memory::HashEmbedding::default_dim());
+        builtins::register_memory_tools(&tool_registry, ms.clone(), embedding);
+        info!("Memory tools registered (store_memory, recall_memory)");
+    }
+
     let agent_loop = {
         let mut al = AgentLoop::new(
             config.clone(),


### PR DESCRIPTION
## Summary
Fixes 4 minor issues found during review of #117:

1. **Tool registration wiring**: Added `register_memory_tools()` function in `builtins/mod.rs` and wired it in the gateway command after memory store initialization
2. **Confidence validation**: Non-numeric confidence values now return `ToolError::Validation` instead of silently defaulting to 1.0
3. **Empty content guard**: `StoreMemoryTool` rejects empty/whitespace-only content with `ToolError::Validation`
4. **HashEmbedding Default**: Added `impl Default for HashEmbedding` using `Self::default_dim()`

## Test plan
- [ ] `cargo clippy --workspace` passes (verified locally)
- [ ] `cargo check -p kestrel-memory -p kestrel-tools` passes (verified locally)
- [ ] New tests: `test_store_memory_invalid_confidence`, `test_store_memory_empty_content`, `test_register_memory_tools`, `test_default_impl`
- [ ] `cargo test --workspace` passes in CI (disk constraints prevented local full build)

Bahtya