### PR TITLE
fix(memory): word-boundary text search precision

### DIFF
--- a/crates/kestrel-memory/src/hot_store.rs
+++ b/crates/kestrel-memory/src/hot_store.rs
@@ -24,6 +24,7 @@ use crate::config::MemoryConfig;
 use crate::error::{MemoryError, Result};
 use crate::security_scan::{scan_memory_entry, SecurityScanResult};
 use crate::store::MemoryStore;
+use crate::text_search::matches_filters;
 use crate::types::{EntryId, MemoryCategory, MemoryEntry, MemoryQuery, ScoredEntry};
 
 #[derive(Clone)]
@@ -404,30 +405,10 @@ fn compute_score(entry: &MemoryEntry, query: &MemoryQuery) -> f64 {
     1.0
 }
 
-/// Check if an entry matches the filter criteria in a query.
-fn matches_filters(entry: &MemoryEntry, query: &MemoryQuery) -> bool {
-    if let Some(ref cat) = query.category {
-        if entry.category != *cat {
-            return false;
-        }
-    }
-    if let Some(min_conf) = query.min_confidence {
-        if entry.confidence < min_conf {
-            return false;
-        }
-    }
-    if let Some(ref text) = query.text {
-        if !entry.content.to_lowercase().contains(&text.to_lowercase()) {
-            return false;
-        }
-    }
-    true
-}
-
 /// Compute cosine similarity between two vectors.
 ///
 /// Returns 0.0 if vectors have different lengths or are empty.
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
+pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
     if a.len() != b.len() || a.is_empty() {
         return 0.0;
     }

--- a/crates/kestrel-memory/src/lib.rs
+++ b/crates/kestrel-memory/src/lib.rs
@@ -17,6 +17,7 @@ pub mod error;
 pub mod hot_store;
 pub mod security_scan;
 pub mod store;
+pub mod text_search;
 pub mod tiered;
 pub mod types;
 pub mod warm_store;

--- a/crates/kestrel-memory/src/text_search.rs
+++ b/crates/kestrel-memory/src/text_search.rs
@@ -61,6 +61,7 @@ pub fn matches_filters(entry: &MemoryEntry, query: &MemoryQuery) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MemoryCategory;
 
     // -- text_matches precision tests --
 

--- a/crates/kestrel-memory/src/text_search.rs
+++ b/crates/kestrel-memory/src/text_search.rs
@@ -1,0 +1,185 @@
+//! Shared text search utilities for memory stores.
+//!
+//! Provides word-boundary-aware text matching that avoids false positives
+//! from naive substring matching (e.g., "rust" matching "trust").
+
+use crate::types::{MemoryEntry, MemoryQuery};
+
+/// Check if a content string matches a query term with word-boundary awareness.
+///
+/// Both the content and query are tokenized by splitting on non-alphanumeric
+/// characters. The query matches if every query token is a case-insensitive
+/// prefix of at least one content token.
+///
+/// This avoids false positives like "rust" matching "trust" or "thruster"
+/// while still allowing useful matches like "rust" matching "Rust" or
+/// "rust-lang".
+pub fn text_matches(content: &str, query: &str) -> bool {
+    let content_lower = content.to_lowercase();
+    let query_lower = query.to_lowercase();
+
+    let content_tokens = tokenize(&content_lower);
+    let query_tokens = tokenize(&query_lower);
+
+    if query_tokens.is_empty() {
+        return true;
+    }
+
+    query_tokens
+        .iter()
+        .all(|q| content_tokens.iter().any(|c| c.starts_with(q.as_str())))
+}
+
+/// Split a string into tokens on non-alphanumeric boundaries.
+fn tokenize(s: &str) -> Vec<String> {
+    s.split(|c: char| !c.is_alphanumeric())
+        .filter(|part| !part.is_empty())
+        .map(|part| part.to_string())
+        .collect()
+}
+
+/// Check if an entry matches the filter criteria in a query.
+pub fn matches_filters(entry: &MemoryEntry, query: &MemoryQuery) -> bool {
+    if let Some(ref cat) = query.category {
+        if entry.category != *cat {
+            return false;
+        }
+    }
+    if let Some(min_conf) = query.min_confidence {
+        if entry.confidence < min_conf {
+            return false;
+        }
+    }
+    if let Some(ref text) = query.text {
+        if !text_matches(&entry.content, text) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- text_matches precision tests --
+
+    #[test]
+    fn test_exact_word_match() {
+        assert!(text_matches("I love Rust programming", "rust"));
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        assert!(text_matches("Rust programming", "RUST"));
+        assert!(text_matches("rust programming", "Rust"));
+    }
+
+    #[test]
+    fn test_word_prefix_match() {
+        assert!(text_matches("Rust programming", "prog"));
+    }
+
+    #[test]
+    fn test_false_positive_trust() {
+        assert!(!text_matches("trust in the system", "rust"));
+    }
+
+    #[test]
+    fn test_false_positive_thruster() {
+        assert!(!text_matches("thruster module", "rust"));
+    }
+
+    #[test]
+    fn test_false_positive_busting() {
+        assert!(!text_matches("cache busting technique", "rust"));
+    }
+
+    #[test]
+    fn test_hyphenated_word() {
+        assert!(text_matches("rust-lang is great", "rust"));
+    }
+
+    #[test]
+    fn test_underscore_boundary() {
+        assert!(text_matches("rust_compiler config", "rust"));
+    }
+
+    #[test]
+    fn test_punctuation_boundary() {
+        assert!(text_matches("I use Rust.", "rust"));
+        assert!(text_matches("Rust, Python, Go", "rust"));
+        assert!(text_matches("(Rust)", "rust"));
+    }
+
+    #[test]
+    fn test_multi_word_query_all_must_match() {
+        assert!(text_matches("Rust programming language", "rust prog"));
+        assert!(!text_matches("Rust programming language", "rust python"));
+    }
+
+    #[test]
+    fn test_empty_query_matches_everything() {
+        assert!(text_matches("anything", ""));
+    }
+
+    #[test]
+    fn test_no_content_no_match() {
+        assert!(!text_matches("", "rust"));
+    }
+
+    #[test]
+    fn test_query_longer_than_content_token() {
+        assert!(!text_matches("rust", "rusting"));
+    }
+
+    #[test]
+    fn test_numeric_tokens() {
+        assert!(text_matches("version 2.0 release", "2"));
+        assert!(text_matches("version 2.0 release", "2.0"));
+    }
+
+    // -- matches_filters tests --
+
+    #[test]
+    fn test_filters_category_match() {
+        let entry = MemoryEntry::new("test", MemoryCategory::Fact);
+        let query = MemoryQuery::new().with_category(MemoryCategory::Fact);
+        assert!(matches_filters(&entry, &query));
+    }
+
+    #[test]
+    fn test_filters_category_mismatch() {
+        let entry = MemoryEntry::new("test", MemoryCategory::Fact);
+        let query = MemoryQuery::new().with_category(MemoryCategory::AgentNote);
+        assert!(!matches_filters(&entry, &query));
+    }
+
+    #[test]
+    fn test_filters_confidence() {
+        let entry = MemoryEntry::new("test", MemoryCategory::Fact).with_confidence(0.3);
+        let query = MemoryQuery::new().with_min_confidence(0.5);
+        assert!(!matches_filters(&entry, &query));
+    }
+
+    #[test]
+    fn test_filters_text_precision() {
+        let entry = MemoryEntry::new("trust in the system", MemoryCategory::Fact);
+        let query = MemoryQuery::new().with_text("rust");
+        assert!(!matches_filters(&entry, &query));
+    }
+
+    #[test]
+    fn test_filters_text_match() {
+        let entry = MemoryEntry::new("Rust programming", MemoryCategory::Fact);
+        let query = MemoryQuery::new().with_text("rust");
+        assert!(matches_filters(&entry, &query));
+    }
+
+    #[test]
+    fn test_filters_no_constraints() {
+        let entry = MemoryEntry::new("anything", MemoryCategory::Fact);
+        let query = MemoryQuery::new();
+        assert!(matches_filters(&entry, &query));
+    }
+}

--- a/crates/kestrel-memory/src/types.rs
+++ b/crates/kestrel-memory/src/types.rs
@@ -123,7 +123,7 @@ pub struct ScoredEntry {
 /// Query parameters for searching memories.
 #[derive(Debug, Clone, Default)]
 pub struct MemoryQuery {
-    /// Full-text search pattern (case-insensitive substring match).
+    /// Full-text search pattern (case-insensitive word-boundary match).
     pub text: Option<String>,
     /// Filter by category.
     pub category: Option<MemoryCategory>,

--- a/crates/kestrel-memory/src/warm_store.rs
+++ b/crates/kestrel-memory/src/warm_store.rs
@@ -19,6 +19,7 @@ use crate::error::{MemoryError, Result};
 use crate::hot_store::cosine_similarity;
 use crate::security_scan::{scan_memory_entry, SecurityScanResult};
 use crate::store::MemoryStore;
+use crate::text_search::matches_filters;
 use crate::types::{MemoryCategory, MemoryEntry, MemoryQuery, ScoredEntry};
 
 const TABLE_NAME: &str = "warm_memory";
@@ -437,26 +438,6 @@ fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>> {
     chrono::DateTime::parse_from_rfc3339(s)
         .map(|dt| dt.to_utc())
         .map_err(|e| MemoryError::LanceDb(format!("invalid datetime '{s}': {e}")))
-}
-
-/// Check if an entry matches the filter criteria in a query.
-fn matches_filters(entry: &MemoryEntry, query: &MemoryQuery) -> bool {
-    if let Some(ref cat) = query.category {
-        if entry.category != *cat {
-            return false;
-        }
-    }
-    if let Some(min_conf) = query.min_confidence {
-        if entry.confidence < min_conf {
-            return false;
-        }
-    }
-    if let Some(ref text) = query.text {
-        if !entry.content.to_lowercase().contains(&text.to_lowercase()) {
-            return false;
-        }
-    }
-    true
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Replace naive `to_lowercase().contains()` text matching with word-boundary-aware tokenization that splits on non-alphanumeric chars and matches query tokens as word prefixes
- Extract shared `text_search.rs` module to deduplicate `matches_filters()` from both HotStore and WarmStore
- Add comprehensive tests for false-positive cases ("rust" no longer matches "trust"/"thruster")

## Test plan
- [x] `cargo check -p kestrel-memory` passes clean (0 warnings)
- [ ] `cargo test -p kestrel-memory` (CI)
- [ ] `cargo clippy --workspace` (CI)
- [ ] Verify existing hot_store/warm_store search tests still pass (backward compatible)

Closes #88

Bahtya