### PR TITLE
fix(release): disable AVX512 for macOS x86_64 build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "target-feature=-avx512f,-avx512vl,-avx512bw,-avx512dq"]

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 *~
 .env
 .DS_Store
-.cargo/config.toml


### PR DESCRIPTION
## Summary
- Disable AVX512 target features for `x86_64-apple-darwin` via `.cargo/config.toml` to fix linker error in release workflow
- Remove `.cargo/config.toml` from `.gitignore` so the build config is tracked

## Context
The GitHub Actions macOS x86_64 runner fails with:
```
error: linking with `cc` failed: exit status: 1
  "_sum_4bit_dist_table_32bytes_batch_avx512", referenced from:
    lance_index::vector::flat::index::FlatIndex::search
  clang: error: linker command failed with exit code 1
```

Root cause: `lance-index` compiles AVX512 SIMD code for x86_64, but the macOS deployment target on CI runners is incompatible with AVX512 symbols.

## Test plan
- [ ] CI release workflow passes on `Build x86_64-apple-darwin`
- [ ] Other platform builds (Linux, aarch64-macos) are unaffected

Bahtya