### PR TITLE
fix(release): use -march=haswell to disable AVX512 on macOS x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           # `lance-linalg` compiles AVX512 C kernels through the `cc` crate on x86_64.
           # Rust target-feature flags do not reach that C build, so disable AVX512 here
           # for the macOS Intel target to avoid missing AVX512 symbols at link time.
-          CFLAGS_x86_64_apple_darwin: ${{ matrix.target == 'x86_64-apple-darwin' && '-mno-avx512f -mno-avx512vl -mno-avx512bw -mno-avx512dq' || '' }}
+          CFLAGS_x86_64_apple_darwin: ${{ matrix.target == 'x86_64-apple-darwin' && '-march=haswell' || '' }}
 
       - name: Package binary
         run: |


### PR DESCRIPTION
## Summary
- change the macOS x86_64 release workflow CFLAGS override to use -march=haswell
- prevent lance-linalg AVX512 C compilation on Intel macOS so it falls back to AVX2
- leave Rust sources untouched
