### PR TITLE
fix: use CARGO_PKG_VERSION for VERSION constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.2] - 2026-04-23
+## [0.2.4] - 2026-04-23
+
+### Added
+
+- Structured log fields, message audit trail, and user-facing error replies (#139+)
+- JSONL audit log for key daemon events (message processing, tool invocation, agent lifecycle)
+- Skill invocation logging with duration tracking
+- Log retention configuration (`log_retain_days`) and log format selection (`log_format`)
+- Automatic log cleanup on daemon startup
+
+## [0.2.3] - 2026-04-23
 
 ### Fixed
 
@@ -105,7 +115,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed cargo fmt after PR merges
 - Removed legacy memory.rs, unified on kestrel-memory crate
 
-[Unreleased]: https://github.com/Bahtya/kestrel-agent/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/Bahtya/kestrel-agent/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/Bahtya/kestrel-agent/compare/v0.2.3...v0.2.4
+[0.2.3]: https://github.com/Bahtya/kestrel-agent/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Bahtya/kestrel-agent/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Bahtya/kestrel-agent/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Bahtya/kestrel-agent/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "serde",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2839,12 +2839,16 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
+ "chrono",
+ "filetime",
  "kestrel-config",
  "libc",
  "nix",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",
@@ -2854,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2877,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2897,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2921,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2936,12 +2940,13 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "kestrel-security"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -2954,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2972,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2991,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.1.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/kestrel-agent/src/lib.rs
+++ b/crates/kestrel-agent/src/lib.rs
@@ -25,7 +25,7 @@ pub use heartbeat::{
     SessionStoreHealthCheck,
 };
 pub use hook::{AgentHook, CompositeHook};
-pub use loop_mod::{AgentLoop, HeartbeatHandle};
+pub use loop_mod::{AgentLoop, AuditCallback, AuditLogEntry, HeartbeatHandle};
 pub use notes::{
     extract_compaction_notes, NoteCompactionConfig, NoteFormat, NotesManager, NotesStore,
 };

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -56,6 +56,25 @@ struct ReflectionTask {
     trace_id: Option<String>,
 }
 
+/// Callback for recording audit events during agent execution.
+pub type AuditCallback = Arc<dyn Fn(AuditLogEntry) + Send + Sync>;
+
+/// A single audit log entry passed to the audit callback.
+pub struct AuditLogEntry {
+    /// Event type (e.g. "message_received", "message_completed", "error").
+    pub event_type: String,
+    /// Human-readable message.
+    pub message: String,
+    /// Optional trace ID for correlation.
+    pub trace_id: Option<String>,
+    /// Optional session key.
+    pub session_key: Option<String>,
+    /// Optional channel name.
+    pub channel: Option<String>,
+    /// Optional duration in milliseconds.
+    pub duration_ms: Option<u64>,
+}
+
 /// The main agent loop that processes messages from the bus.
 pub struct AgentLoop {
     config: Arc<Config>,
@@ -82,6 +101,8 @@ pub struct AgentLoop {
     learning_bus: Option<LearningEventBus>,
     /// Optional prompt assembler for dynamic system prompt construction.
     prompt_assembler: Option<PromptAssembler>,
+    /// Optional audit callback for recording key events to the JSONL audit log.
+    audit_callback: Option<AuditCallback>,
 }
 
 impl AgentLoop {
@@ -110,6 +131,7 @@ impl AgentLoop {
             memory_config: None,
             learning_bus: None,
             prompt_assembler: None,
+            audit_callback: None,
         }
     }
 
@@ -194,6 +216,15 @@ impl AgentLoop {
                 channel = %msg.channel,
                 "Incoming message"
             );
+
+            self.record_audit(AuditLogEntry {
+                event_type: "message_received".to_string(),
+                message: content_preview.to_string(),
+                trace_id: msg.trace_id.clone(),
+                session_key: Some(session_key.clone()),
+                channel: Some(format!("{}", msg.channel)),
+                duration_ms: None,
+            });
 
             info!("Processing message");
 
@@ -357,6 +388,19 @@ impl AgentLoop {
                         iterations = result.iterations_used,
                         "Agent run completed"
                     );
+
+                    self.record_audit(AuditLogEntry {
+                        event_type: "message_completed".to_string(),
+                        message: format!(
+                            "tool_calls={}, iterations={}",
+                            result.tool_calls_made, result.iterations_used
+                        ),
+                        trace_id: msg.trace_id.clone(),
+                        session_key: Some(session_key.clone()),
+                        channel: Some(format!("{}", msg.channel)),
+                        duration_ms: Some(duration_ms),
+                    });
+
                     session.add_assistant_message(result.content.clone());
 
                     // Auto-extract structured notes from the response
@@ -462,7 +506,17 @@ impl AgentLoop {
                         .await;
                 }
                 Err(e) => {
-                    let error_msg = format!("处理消息时遇到问题: {e}，请稍后重试");
+                    let error_msg = format!("An error occurred while processing your message: {e}. Please try again later.");
+
+                    self.record_audit(AuditLogEntry {
+                        event_type: "error".to_string(),
+                        message: format!("{:#}", e),
+                        trace_id: msg.trace_id.clone(),
+                        session_key: Some(session_key.clone()),
+                        channel: Some(format!("{}", msg.channel)),
+                        duration_ms: None,
+                    });
+
                     error!(
                         error = %e,
                         "Agent run error for session {}, sending error reply",
@@ -661,6 +715,13 @@ impl AgentLoop {
 
         if let Err(e) = store.store(entry).await {
             warn!("Failed to store conversation memory: {}", e);
+        }
+    }
+
+    /// Record an audit event if an audit callback is attached.
+    fn record_audit(&self, entry: AuditLogEntry) {
+        if let Some(cb) = &self.audit_callback {
+            cb(entry);
         }
     }
 
@@ -886,6 +947,15 @@ impl AgentLoop {
     /// Get the prompt assembler, if one has been attached.
     pub fn prompt_assembler(&self) -> Option<&PromptAssembler> {
         self.prompt_assembler.as_ref()
+    }
+
+    /// Attach an audit callback for recording key events to the JSONL audit log.
+    ///
+    /// When set, the agent loop will record audit events at message processing
+    /// start, completion, and error points.
+    pub fn with_audit_callback(mut self, cb: AuditCallback) -> Self {
+        self.audit_callback = Some(cb);
+        self
     }
 
     /// Get the sub-agent manager, if one has been attached.

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -186,6 +186,15 @@ impl AgentLoop {
 
         async move {
             let session_key = msg.session_key();
+
+            // Audit log: message content at debug level for traceability
+            let content_preview = truncate_str(&msg.content, 100);
+            tracing::debug!(
+                content = %content_preview,
+                channel = %msg.channel,
+                "Incoming message"
+            );
+
             info!("Processing message");
 
             // Emit started event
@@ -283,6 +292,7 @@ impl AgentLoop {
 
             // Run agent with events wired through
             let messages = session.to_messages();
+            let run_start = std::time::Instant::now();
             let result = {
                 // Build a runner with event callback for this session
                 let event_bus = bus_for_stream.clone();
@@ -340,7 +350,13 @@ impl AgentLoop {
 
             match result {
                 Ok(result) => {
-                    // Add assistant response to session
+                    let duration_ms = run_start.elapsed().as_millis() as u64;
+                    info!(
+                        duration_ms = duration_ms,
+                        tool_calls = result.tool_calls_made,
+                        iterations = result.iterations_used,
+                        "Agent run completed"
+                    );
                     session.add_assistant_message(result.content.clone());
 
                     // Auto-extract structured notes from the response
@@ -446,7 +462,26 @@ impl AgentLoop {
                         .await;
                 }
                 Err(e) => {
-                    error!("Agent run error for session {}: {}", session_key, e);
+                    let error_msg = format!("处理消息时遇到问题: {e}，请稍后重试");
+                    error!(
+                        error = %e,
+                        "Agent run error for session {}, sending error reply",
+                        session_key
+                    );
+
+                    // Send error reply to the user instead of silently dropping
+                    let error_outbound = OutboundMessage {
+                        channel: msg.channel.clone(),
+                        chat_id: msg.chat_id.clone(),
+                        content: error_msg,
+                        reply_to: msg.message_id.clone(),
+                        trace_id: msg.trace_id.clone(),
+                        media: vec![],
+                        metadata: Default::default(),
+                    };
+                    if let Err(send_err) = self.bus.publish_outbound(error_outbound).await {
+                        error!("Failed to send error reply: {}", send_err);
+                    }
 
                     // Emit ToolFailed learning event
                     if let Some(ref bus) = self.learning_bus {

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -205,21 +205,19 @@ impl AgentRunner {
             conversation.push(assistant_msg);
 
             // Execute tool calls concurrently
-            let tool_start = std::time::Instant::now();
             let results = self.execute_tools(&tool_calls).await;
-            let tool_duration_ms = tool_start.elapsed().as_millis() as u64;
             tool_calls_made += tool_calls.len();
 
-            for tc in &tool_calls {
+            for (tc, (_, duration_ms)) in tool_calls.iter().zip(&results) {
                 debug!(
                     tool_name = %tc.function.name,
-                    duration_ms = tool_duration_ms,
+                    duration_ms = *duration_ms,
                     "Tool call completed"
                 );
             }
 
             // Add tool results to conversation
-            for (tool_call, result) in tool_calls.iter().zip(results) {
+            for (tool_call, (result, _)) in tool_calls.iter().zip(results) {
                 conversation.push(Message {
                     role: MessageRole::Tool,
                     content: result,
@@ -377,7 +375,7 @@ impl AgentRunner {
     /// Read-only tools run concurrently as before. Mutating tools each
     /// acquire a shared mutex before executing, guaranteeing they run
     /// one at a time even when the LLM issues several in a single turn.
-    async fn execute_tools(&self, tool_calls: &[ToolCall]) -> Vec<String> {
+    async fn execute_tools(&self, tool_calls: &[ToolCall]) -> Vec<(String, u64)> {
         let mut handles = Vec::new();
 
         for tc in tool_calls {
@@ -388,18 +386,22 @@ impl AgentRunner {
             let is_mutating = self.tools.is_mutating(&tool_name);
 
             let handle = tokio::spawn(async move {
+                let start = std::time::Instant::now();
                 let args: Value = match serde_json::from_str(&args_str) {
                     Ok(v) => v,
                     Err(e) => {
-                        return format!(
-                            "Tool argument error for '{}': failed to parse arguments: {}. \
+                        return (
+                            format!(
+                                "Tool argument error for '{}': failed to parse arguments: {}. \
                              Raw arguments: {:?}",
-                            tool_name, e, args_str
+                                tool_name, e, args_str
+                            ),
+                            start.elapsed().as_millis() as u64,
                         );
                     }
                 };
 
-                if is_mutating {
+                let result = if is_mutating {
                     let _lock = guard.lock().await;
                     match tools.execute(&tool_name, args).await {
                         Ok(result) => result,
@@ -410,7 +412,8 @@ impl AgentRunner {
                         Ok(result) => result,
                         Err(e) => format!("Tool error: {}", e),
                     }
-                }
+                };
+                (result, start.elapsed().as_millis() as u64)
             });
 
             handles.push(handle);
@@ -419,8 +422,8 @@ impl AgentRunner {
         let mut results = Vec::new();
         for handle in handles {
             match handle.await {
-                Ok(result) => results.push(result),
-                Err(e) => results.push(format!("Tool execution failed: {}", e)),
+                Ok((result, duration)) => results.push((result, duration)),
+                Err(e) => results.push((format!("Tool execution failed: {}", e), 0)),
             }
         }
 
@@ -527,7 +530,7 @@ mod tests {
         // Counter must be exactly 3
         assert_eq!(counter.load(Ordering::SeqCst), 3);
         // Each result should be distinct (serialized execution)
-        assert!(results.iter().all(|r| r.starts_with("write-")));
+        assert!(results.iter().all(|(r, _)| r.starts_with("write-")));
     }
 
     #[tokio::test]
@@ -606,7 +609,7 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert_eq!(counter.load(Ordering::SeqCst), 1);
-        assert_eq!(results[0], "exec-0");
+        assert_eq!(results[0].0, "exec-0");
     }
 
     #[tokio::test]
@@ -629,8 +632,28 @@ mod tests {
         let results = runner.execute_tools(&calls).await;
 
         assert_eq!(results.len(), 1);
-        assert!(results[0].contains("Tool error"));
-        assert!(results[0].contains("not found"));
+        assert!(results[0].0.contains("Tool error"));
+        assert!(results[0].0.contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_per_tool_duration_tracked() {
+        let registry = ToolRegistry::new();
+        registry.register(
+            CountingTool::new("slow", false, Arc::new(AtomicUsize::new(0)))
+                .with_work_duration(std::time::Duration::from_millis(50)),
+        );
+
+        let runner = make_runner(registry);
+        let calls = vec![tool_call("slow", 1)];
+        let results = runner.execute_tools(&calls).await;
+
+        assert_eq!(results.len(), 1);
+        let (_, duration_ms) = &results[0];
+        assert!(
+            *duration_ms >= 40,
+            "per-tool duration should reflect actual execution time, got {duration_ms}ms"
+        );
     }
 
     #[test]

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -106,6 +106,12 @@ impl AgentRunner {
             .get_provider(model)
             .with_context(|| format!("No provider available for model: {}", model))?;
 
+        info!(
+            llm_model = %model,
+            llm_provider = %provider.name(),
+            "Starting agent run"
+        );
+
         // Build initial messages with system prompt
         let mut conversation = vec![Message {
             role: MessageRole::System,
@@ -162,9 +168,11 @@ impl AgentRunner {
                 _ => {
                     let content = response.content.unwrap_or_default();
                     info!(
-                        "Agent completed in {} iterations, {} tool calls",
-                        iteration + 1,
-                        tool_calls_made
+                        llm_model = %model,
+                        iterations = iteration + 1,
+                        tool_calls = tool_calls_made,
+                        tokens_used = ?total_usage.total_tokens,
+                        "Agent run completed"
                     );
                     return Ok(RunResult {
                         content,
@@ -197,8 +205,18 @@ impl AgentRunner {
             conversation.push(assistant_msg);
 
             // Execute tool calls concurrently
+            let tool_start = std::time::Instant::now();
             let results = self.execute_tools(&tool_calls).await;
+            let tool_duration_ms = tool_start.elapsed().as_millis() as u64;
             tool_calls_made += tool_calls.len();
+
+            for tc in &tool_calls {
+                debug!(
+                    tool_name = %tc.function.name,
+                    duration_ms = tool_duration_ms,
+                    "Tool call completed"
+                );
+            }
 
             // Add tool results to conversation
             for (tool_call, result) in tool_calls.iter().zip(results) {

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -757,6 +757,14 @@ pub struct DaemonConfig {
     /// Log level for daemon file logging (trace, debug, info, warn, error).
     #[serde(default = "default_daemon_log_level")]
     pub log_level: String,
+
+    /// Number of days to retain log files before auto-cleanup.
+    #[serde(default = "default_daemon_log_retain_days")]
+    pub log_retain_days: u64,
+
+    /// Log output format: `"text"` (human-readable) or `"json"` (structured).
+    #[serde(default = "default_daemon_log_format")]
+    pub log_format: String,
 }
 
 fn default_daemon_pid_file() -> String {
@@ -789,6 +797,14 @@ fn default_daemon_log_level() -> String {
     "info".to_string()
 }
 
+const fn default_daemon_log_retain_days() -> u64 {
+    30
+}
+
+fn default_daemon_log_format() -> String {
+    "text".to_string()
+}
+
 impl Default for DaemonConfig {
     fn default() -> Self {
         Self {
@@ -797,6 +813,8 @@ impl Default for DaemonConfig {
             working_directory: default_daemon_working_directory(),
             grace_period_secs: default_daemon_grace_period(),
             log_level: default_daemon_log_level(),
+            log_retain_days: default_daemon_log_retain_days(),
+            log_format: default_daemon_log_format(),
         }
     }
 }
@@ -1195,6 +1213,8 @@ cron:
         assert!(dc.log_dir.contains("logs"));
         assert_eq!(dc.working_directory, "/");
         assert_eq!(dc.grace_period_secs, 30);
+        assert_eq!(dc.log_retain_days, 30);
+        assert_eq!(dc.log_format, "text");
     }
 
     #[test]
@@ -1205,12 +1225,16 @@ daemon:
   log_dir: /var/log/kestrel
   working_directory: /opt
   grace_period_secs: 60
+  log_retain_days: 7
+  log_format: json
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.daemon.pid_file, "/var/run/kestrel.pid");
         assert_eq!(config.daemon.log_dir, "/var/log/kestrel");
         assert_eq!(config.daemon.working_directory, "/opt");
         assert_eq!(config.daemon.grace_period_secs, 60);
+        assert_eq!(config.daemon.log_retain_days, 7);
+        assert_eq!(config.daemon.log_format, "json");
     }
 
     #[test]
@@ -1222,6 +1246,8 @@ daemon:
         assert_eq!(parsed.log_dir, dc.log_dir);
         assert_eq!(parsed.working_directory, dc.working_directory);
         assert_eq!(parsed.grace_period_secs, dc.grace_period_secs);
+        assert_eq!(parsed.log_retain_days, dc.log_retain_days);
+        assert_eq!(parsed.log_format, dc.log_format);
     }
 
     #[test]

--- a/crates/kestrel-core/src/constants.rs
+++ b/crates/kestrel-core/src/constants.rs
@@ -1,7 +1,7 @@
 //! Constants for the kestrel project.
 
 /// Current version of kestrel.
-pub const VERSION: &str = "0.1.1";
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Default maximum iterations for the agent loop.
 pub const DEFAULT_MAX_ITERATIONS: usize = 50;

--- a/crates/kestrel-daemon/Cargo.toml
+++ b/crates/kestrel-daemon/Cargo.toml
@@ -6,8 +6,11 @@ edition.workspace = true
 [dependencies]
 kestrel-config = { path = "../kestrel-config" }
 anyhow = { workspace = true }
+chrono = { workspace = true }
 libc = "0.2"
 nix = { version = "0.29", features = ["process", "signal", "fs"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/kestrel-daemon/Cargo.toml
+++ b/crates/kestrel-daemon/Cargo.toml
@@ -15,3 +15,4 @@ tracing-appender = "0.2"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+filetime = "0.2"

--- a/crates/kestrel-daemon/src/audit.rs
+++ b/crates/kestrel-daemon/src/audit.rs
@@ -104,8 +104,7 @@ mod tests {
 
         append_audit_event(log_dir, &event);
 
-        let content =
-            std::fs::read_to_string(tmp.path().join("kestrel.audit.jsonl")).unwrap();
+        let content = std::fs::read_to_string(tmp.path().join("kestrel.audit.jsonl")).unwrap();
         assert!(content.contains("message_received"));
         assert!(content.contains("trace-123"));
         assert!(content.contains("telegram"));
@@ -140,8 +139,7 @@ mod tests {
             ),
         );
 
-        let content =
-            std::fs::read_to_string(tmp.path().join("kestrel.audit.jsonl")).unwrap();
+        let content = std::fs::read_to_string(tmp.path().join("kestrel.audit.jsonl")).unwrap();
         let lines: Vec<&str> = content.trim().lines().collect();
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("first"));

--- a/crates/kestrel-daemon/src/audit.rs
+++ b/crates/kestrel-daemon/src/audit.rs
@@ -36,7 +36,10 @@ pub struct AuditEvent {
 /// Creates the file if it doesn't exist. Each call appends one line.
 /// Errors are logged via `tracing::warn` but not propagated — audit
 /// logging must not break the agent loop.
-pub fn append_audit_event(log_dir: &str, event: &AuditEvent) {
+///
+/// Uses `tokio::task::spawn_blocking` to avoid blocking the async runtime
+/// with file I/O.
+pub async fn append_audit_event(log_dir: &str, event: &AuditEvent) {
     let path = Path::new(log_dir).join("kestrel.audit.jsonl");
 
     let line = match serde_json::to_string(event) {
@@ -47,20 +50,25 @@ pub fn append_audit_event(log_dir: &str, event: &AuditEvent) {
         }
     };
 
-    match std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-    {
-        Ok(mut file) => {
-            if let Err(e) = writeln!(file, "{}", line) {
-                tracing::warn!("Failed to write audit event: {}", e);
+    let path = path.clone();
+    tokio::task::spawn_blocking(move || {
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+        {
+            Ok(mut file) => {
+                if let Err(e) = writeln!(file, "{}", line) {
+                    tracing::warn!("Failed to write audit event: {}", e);
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to open audit log {:?}: {}", path, e);
             }
         }
-        Err(e) => {
-            tracing::warn!("Failed to open audit log {:?}: {}", path, e);
-        }
-    }
+    })
+    .await
+    .unwrap_or(());
 }
 
 /// Create a timestamped audit event with the current UTC time.
@@ -88,8 +96,8 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    #[test]
-    fn test_append_audit_event_creates_file() {
+    #[tokio::test]
+    async fn test_append_audit_event_creates_file() {
         let tmp = TempDir::new().unwrap();
         let log_dir = tmp.path().to_str().unwrap();
 
@@ -102,7 +110,7 @@ mod tests {
             "User sent hello".to_string(),
         );
 
-        append_audit_event(log_dir, &event);
+        append_audit_event(log_dir, &event).await;
 
         let content = std::fs::read_to_string(tmp.path().join("kestrel.audit.jsonl")).unwrap();
         assert!(content.contains("message_received"));
@@ -111,8 +119,8 @@ mod tests {
         assert!(content.contains("User sent hello"));
     }
 
-    #[test]
-    fn test_append_multiple_events() {
+    #[tokio::test]
+    async fn test_append_multiple_events() {
         let tmp = TempDir::new().unwrap();
         let log_dir = tmp.path().to_str().unwrap();
 
@@ -126,7 +134,8 @@ mod tests {
                 None,
                 "first".to_string(),
             ),
-        );
+        )
+        .await;
         append_audit_event(
             log_dir,
             &audit_event(
@@ -137,7 +146,8 @@ mod tests {
                 Some(150),
                 "second".to_string(),
             ),
-        );
+        )
+        .await;
 
         let content = std::fs::read_to_string(tmp.path().join("kestrel.audit.jsonl")).unwrap();
         let lines: Vec<&str> = content.trim().lines().collect();
@@ -165,12 +175,13 @@ mod tests {
         assert!(json.contains("error"));
     }
 
-    #[test]
-    fn test_append_audit_event_nonexistent_dir() {
+    #[tokio::test]
+    async fn test_append_audit_event_nonexistent_dir() {
         // Should not panic — just log a warning
         append_audit_event(
             "/tmp/nonexistent_kestrel_audit_test",
             &audit_event("test", None, None, None, None, "ok".to_string()),
-        );
+        )
+        .await;
     }
 }

--- a/crates/kestrel-daemon/src/audit.rs
+++ b/crates/kestrel-daemon/src/audit.rs
@@ -1,0 +1,178 @@
+//! Lightweight JSONL audit log for key daemon events.
+//!
+//! Appends one JSON line per event to `kestrel.audit.jsonl` in the log directory.
+//! Records message processing, skill invocations, and errors — providing a
+//! structured audit trail alongside the rolling text/JSON log.
+
+use serde::Serialize;
+use std::io::Write;
+use std::path::Path;
+
+/// A single audit event written as one JSON line.
+#[derive(Debug, Serialize)]
+pub struct AuditEvent {
+    /// ISO 8601 timestamp.
+    pub timestamp: String,
+    /// Event type (e.g. "message_received", "message_completed", "skill_started", "error").
+    pub event_type: String,
+    /// Optional trace ID for correlation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// Optional session key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_key: Option<String>,
+    /// Optional channel name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// Optional duration in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    /// Human-readable message or description.
+    pub message: String,
+}
+
+/// Append an audit event to the JSONL file in `log_dir`.
+///
+/// Creates the file if it doesn't exist. Each call appends one line.
+/// Errors are logged via `tracing::warn` but not propagated — audit
+/// logging must not break the agent loop.
+pub fn append_audit_event(log_dir: &str, event: &AuditEvent) {
+    let path = Path::new(log_dir).join("kestrel.audit.jsonl");
+
+    let line = match serde_json::to_string(event) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!("Failed to serialize audit event: {}", e);
+            return;
+        }
+    };
+
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        Ok(mut file) => {
+            if let Err(e) = writeln!(file, "{}", line) {
+                tracing::warn!("Failed to write audit event: {}", e);
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Failed to open audit log {:?}: {}", path, e);
+        }
+    }
+}
+
+/// Create a timestamped audit event with the current UTC time.
+pub fn audit_event(
+    event_type: &str,
+    trace_id: Option<String>,
+    session_key: Option<String>,
+    channel: Option<String>,
+    duration_ms: Option<u64>,
+    message: String,
+) -> AuditEvent {
+    AuditEvent {
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        event_type: event_type.to_string(),
+        trace_id,
+        session_key,
+        channel,
+        duration_ms,
+        message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_append_audit_event_creates_file() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path().to_str().unwrap();
+
+        let event = audit_event(
+            "message_received",
+            Some("trace-123".to_string()),
+            Some("session-1".to_string()),
+            Some("telegram".to_string()),
+            None,
+            "User sent hello".to_string(),
+        );
+
+        append_audit_event(log_dir, &event);
+
+        let content =
+            std::fs::read_to_string(tmp.path().join("kestrel.audit.jsonl")).unwrap();
+        assert!(content.contains("message_received"));
+        assert!(content.contains("trace-123"));
+        assert!(content.contains("telegram"));
+        assert!(content.contains("User sent hello"));
+    }
+
+    #[test]
+    fn test_append_multiple_events() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path().to_str().unwrap();
+
+        append_audit_event(
+            log_dir,
+            &audit_event(
+                "message_received",
+                None,
+                None,
+                None,
+                None,
+                "first".to_string(),
+            ),
+        );
+        append_audit_event(
+            log_dir,
+            &audit_event(
+                "message_completed",
+                None,
+                None,
+                None,
+                Some(150),
+                "second".to_string(),
+            ),
+        );
+
+        let content =
+            std::fs::read_to_string(tmp.path().join("kestrel.audit.jsonl")).unwrap();
+        let lines: Vec<&str> = content.trim().lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("first"));
+        assert!(lines[1].contains("second"));
+        assert!(lines[1].contains("150"));
+    }
+
+    #[test]
+    fn test_audit_event_serializes_optional_fields() {
+        let event = audit_event(
+            "error",
+            None,
+            None,
+            None,
+            None,
+            "something broke".to_string(),
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("trace_id"));
+        assert!(!json.contains("session_key"));
+        assert!(!json.contains("channel"));
+        assert!(!json.contains("duration_ms"));
+        assert!(json.contains("error"));
+    }
+
+    #[test]
+    fn test_append_audit_event_nonexistent_dir() {
+        // Should not panic — just log a warning
+        append_audit_event(
+            "/tmp/nonexistent_kestrel_audit_test",
+            &audit_event("test", None, None, None, None, "ok".to_string()),
+        );
+    }
+}

--- a/crates/kestrel-daemon/src/lib.rs
+++ b/crates/kestrel-daemon/src/lib.rs
@@ -12,6 +12,8 @@
 //! All public APIs are gated on `cfg(target_family = "unix")`.
 
 #[cfg(target_family = "unix")]
+pub mod audit;
+#[cfg(target_family = "unix")]
 pub mod daemonize;
 #[cfg(target_family = "unix")]
 pub mod logging;

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -37,12 +37,23 @@ pub fn setup_file_logging(log_dir: &str, level: &str, log_format: &str) -> Resul
     let log_path = Path::new(log_dir);
     std::fs::create_dir_all(log_path).context("create log directory")?;
 
+    let effective_format = match log_format {
+        "text" | "json" => log_format,
+        _ => {
+            tracing::warn!(
+                "Invalid log_format '{}', falling back to 'text'. Supported: text, json",
+                log_format
+            );
+            "text"
+        }
+    };
+
     let file_appender = tracing_appender::rolling::daily(log_path, "kestrel.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
 
-    if log_format == "json" {
+    if effective_format == "json" {
         let file_layer = tracing_subscriber::fmt::layer()
             .with_writer(non_blocking)
             .with_ansi(false)
@@ -64,7 +75,7 @@ pub fn setup_file_logging(log_dir: &str, level: &str, log_format: &str) -> Resul
     tracing::info!(
         "File logging initialized: {}/kestrel.log (format: {})",
         log_dir,
-        log_format
+        effective_format
     );
 
     Ok(guard)
@@ -118,13 +129,19 @@ pub fn cleanup_old_logs(log_dir: &str, retain_days: u64) {
 /// the returned `JoinHandle` is dropped or cancelled.
 pub fn spawn_log_cleanup(log_dir: String, retain_days: u64) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        // Run once at startup
-        cleanup_old_logs(&log_dir, retain_days);
+        // Run once at startup (offloaded to blocking thread)
+        let dir = log_dir.clone();
+        tokio::task::spawn_blocking(move || cleanup_old_logs(&dir, retain_days))
+            .await
+            .unwrap_or(());
 
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
         loop {
             interval.tick().await;
-            cleanup_old_logs(&log_dir, retain_days);
+            let dir = log_dir.clone();
+            tokio::task::spawn_blocking(move || cleanup_old_logs(&dir, retain_days))
+                .await
+                .unwrap_or(());
         }
     })
 }
@@ -175,8 +192,8 @@ mod tests {
         std::fs::write(&old_file, "old log").unwrap();
         let old_time =
             std::time::SystemTime::now() - std::time::Duration::from_secs(60 * 24 * 60 * 60);
-        let ft =
-            filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time));
+        filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time))
+            .unwrap();
 
         // Create a recent file that should be kept
         let recent_file = log_dir.join("kestrel.log.2099-01-01");
@@ -211,5 +228,19 @@ mod tests {
         cleanup_old_logs(log_dir.to_str().unwrap(), 0);
 
         assert!(audit_file.exists(), "audit file should not be cleaned up");
+    }
+
+    #[test]
+    fn test_log_format_invalid_falls_back_to_text() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path().join("format_test");
+        let log_dir_str = log_dir.to_str().unwrap();
+
+        // "xml" is not a valid format — should fall back to "text"
+        let result = setup_file_logging(log_dir_str, "info", "xml");
+        assert!(log_dir.exists());
+        if let Ok(_guard) = result {
+            // Subscriber may conflict with other tests; that's OK
+        }
     }
 }

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -80,8 +80,8 @@ pub fn cleanup_old_logs(log_dir: &str, retain_days: u64) {
         return;
     };
 
-    let cutoff = std::time::SystemTime::now()
-        - std::time::Duration::from_secs(retain_days * 24 * 60 * 60);
+    let cutoff =
+        std::time::SystemTime::now() - std::time::Duration::from_secs(retain_days * 24 * 60 * 60);
 
     for entry in entries.flatten() {
         let path = entry.path();
@@ -173,9 +173,10 @@ mod tests {
         // Create an "old" file by setting mtime to 60 days ago
         let old_file = log_dir.join("kestrel.log.2025-01-01");
         std::fs::write(&old_file, "old log").unwrap();
-        let old_time = std::time::SystemTime::now()
-            - std::time::Duration::from_secs(60 * 24 * 60 * 60);
-        let ft = filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time));
+        let old_time =
+            std::time::SystemTime::now() - std::time::Duration::from_secs(60 * 24 * 60 * 60);
+        let ft =
+            filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time));
 
         // Create a recent file that should be kept
         let recent_file = log_dir.join("kestrel.log.2099-01-01");

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -2,7 +2,8 @@
 //!
 //! Sets up a non-blocking file writer for the `tracing` ecosystem so that
 //! daemon-mode processes can write structured logs to disk instead of
-//! (or in addition to) the terminal.
+//! (or in addition to) the terminal. Supports both human-readable text and
+//! structured JSON output formats.
 
 use anyhow::{Context, Result};
 use std::path::Path;
@@ -21,6 +22,7 @@ pub type LogGuard = tracing_appender::non_blocking::WorkerGuard;
 ///
 /// * `log_dir` - Directory for log files (created if it doesn't exist).
 /// * `level` - Log level filter (e.g. `"info"`, `"debug"`, `"trace"`).
+/// * `log_format` - Output format: `"text"` (human-readable) or `"json"`.
 ///
 /// # Returns
 ///
@@ -31,7 +33,7 @@ pub type LogGuard = tracing_appender::non_blocking::WorkerGuard;
 ///
 /// Returns an error if the log directory cannot be created or the subscriber
 /// cannot be installed.
-pub fn setup_file_logging(log_dir: &str, level: &str) -> Result<LogGuard> {
+pub fn setup_file_logging(log_dir: &str, level: &str, log_format: &str) -> Result<LogGuard> {
     let log_path = Path::new(log_dir);
     std::fs::create_dir_all(log_path).context("create log directory")?;
 
@@ -40,17 +42,91 @@ pub fn setup_file_logging(log_dir: &str, level: &str) -> Result<LogGuard> {
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
 
-    let file_layer = tracing_subscriber::fmt::layer()
-        .with_writer(non_blocking)
-        .with_ansi(false)
-        .with_filter(filter);
+    if log_format == "json" {
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_writer(non_blocking)
+            .with_ansi(false)
+            .json()
+            .with_filter(filter);
+        let subscriber = Registry::default().with(file_layer);
+        tracing::subscriber::set_global_default(subscriber)
+            .context("set global tracing subscriber")?;
+    } else {
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_writer(non_blocking)
+            .with_ansi(false)
+            .with_filter(filter);
+        let subscriber = Registry::default().with(file_layer);
+        tracing::subscriber::set_global_default(subscriber)
+            .context("set global tracing subscriber")?;
+    }
 
-    let subscriber = Registry::default().with(file_layer);
-    tracing::subscriber::set_global_default(subscriber).context("set global tracing subscriber")?;
-
-    tracing::info!("File logging initialized: {}/kestrel.log", log_dir);
+    tracing::info!(
+        "File logging initialized: {}/kestrel.log (format: {})",
+        log_dir,
+        log_format
+    );
 
     Ok(guard)
+}
+
+/// Delete log files older than `retain_days` from `log_dir`.
+///
+/// Scans the directory for files matching the `kestrel.log.*` pattern and
+/// removes any whose modification time is older than the retention period.
+/// Errors during individual file removal are logged but not propagated.
+pub fn cleanup_old_logs(log_dir: &str, retain_days: u64) {
+    let Ok(entries) = std::fs::read_dir(log_dir) else {
+        return;
+    };
+
+    let cutoff = std::time::SystemTime::now()
+        - std::time::Duration::from_secs(retain_days * 24 * 60 * 60);
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let filename = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        // Only clean up rolling log files (kestrel.log.YYYY-MM-DD)
+        if !filename.starts_with("kestrel.log.") {
+            continue;
+        }
+
+        if let Ok(metadata) = path.metadata() {
+            if let Ok(modified) = metadata.modified() {
+                if modified < cutoff {
+                    match std::fs::remove_file(&path) {
+                        Ok(()) => tracing::info!("Cleaned up old log file: {}", filename),
+                        Err(e) => tracing::warn!("Failed to remove {}: {}", filename, e),
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Spawn a background task that periodically cleans up old log files.
+///
+/// Runs cleanup immediately, then every 24 hours. The task exits when
+/// the returned `JoinHandle` is dropped or cancelled.
+pub fn spawn_log_cleanup(log_dir: String, retain_days: u64) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // Run once at startup
+        cleanup_old_logs(&log_dir, retain_days);
+
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
+        loop {
+            interval.tick().await;
+            cleanup_old_logs(&log_dir, retain_days);
+        }
+    })
 }
 
 #[cfg(test)]
@@ -66,7 +142,7 @@ mod tests {
 
         // Test directory creation — ignore the global subscriber conflict
         // (set_global_default can only be called once per process)
-        let result = setup_file_logging(log_dir_str, "info");
+        let result = setup_file_logging(log_dir_str, "info", "text");
         assert!(log_dir.exists(), "log directory should be created");
 
         // The guard may fail on re-install, but directory must exist regardless
@@ -82,10 +158,57 @@ mod tests {
         let log_dir_str = log_dir.to_str().unwrap();
 
         // The function creates the directory before attempting to set subscriber
-        let _ = setup_file_logging(log_dir_str, "info");
+        let _ = setup_file_logging(log_dir_str, "info", "text");
         assert!(
             log_dir.exists(),
             "directory must be created even if subscriber fails"
         );
+    }
+
+    #[test]
+    fn test_cleanup_old_logs_removes_expired() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path();
+
+        // Create an "old" file by setting mtime to 60 days ago
+        let old_file = log_dir.join("kestrel.log.2025-01-01");
+        std::fs::write(&old_file, "old log").unwrap();
+        let old_time = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(60 * 24 * 60 * 60);
+        let ft = filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time));
+
+        // Create a recent file that should be kept
+        let recent_file = log_dir.join("kestrel.log.2099-01-01");
+        std::fs::write(&recent_file, "recent log").unwrap();
+
+        // Create a non-log file that should be ignored
+        let other_file = log_dir.join("other.txt");
+        std::fs::write(&other_file, "not a log").unwrap();
+
+        cleanup_old_logs(log_dir.to_str().unwrap(), 30);
+
+        assert!(!old_file.exists(), "old log should be removed");
+        assert!(recent_file.exists(), "recent log should be kept");
+        assert!(other_file.exists(), "non-log file should be untouched");
+    }
+
+    #[test]
+    fn test_cleanup_old_logs_nonexistent_dir() {
+        // Should not panic on nonexistent directory
+        cleanup_old_logs("/tmp/nonexistent_kestrel_test_dir", 30);
+    }
+
+    #[test]
+    fn test_cleanup_old_logs_keeps_non_prefixed() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path();
+
+        // Create old files that DON'T match the kestrel.log.* pattern
+        let audit_file = log_dir.join("kestrel.audit.jsonl");
+        std::fs::write(&audit_file, "audit").unwrap();
+
+        cleanup_old_logs(log_dir.to_str().unwrap(), 0);
+
+        assert!(audit_file.exists(), "audit file should not be cleaned up");
     }
 }

--- a/crates/kestrel-skill/src/skill.rs
+++ b/crates/kestrel-skill/src/skill.rs
@@ -190,9 +190,21 @@ impl Skill for CompiledSkill {
     }
 
     async fn execute(&self, _args: serde_json::Value) -> SkillResult<SkillOutput> {
-        Ok(SkillOutput::PromptOnly {
+        let skill_name = &self.manifest.name;
+        let start = std::time::Instant::now();
+        tracing::info!(skill_name = %skill_name, "Skill started");
+
+        let result = Ok(SkillOutput::PromptOnly {
             segment: self.build_prompt(),
-        })
+        });
+
+        tracing::info!(
+            skill_name = %skill_name,
+            duration_ms = start.elapsed().as_millis() as u64,
+            "Skill completed"
+        );
+
+        result
     }
 
     fn update_confidence(&mut self, event: ConfidenceEvent) {

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -94,7 +94,11 @@ fn do_start(config: &Config) -> Result<DaemonHandles> {
     let pid_file = kestrel_daemon::pid_file::PidFile::create(pid_file_path)?;
 
     // Setup file logging in the daemon process
-    let log_guard = kestrel_daemon::logging::setup_file_logging(log_dir, &config.daemon.log_level)?;
+    let log_guard = kestrel_daemon::logging::setup_file_logging(
+        log_dir,
+        &config.daemon.log_level,
+        &config.daemon.log_format,
+    )?;
     tracing::info!("Daemon started (pid={})", std::process::id());
 
     Ok(DaemonHandles {

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -467,6 +467,27 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
             tool_registry.clone(),
         );
 
+        // Wire audit callback for JSONL audit logging
+        let audit_log_dir = config.daemon.log_dir.clone();
+        let audit_cb: kestrel_agent::AuditCallback =
+            Arc::new(move |entry: kestrel_agent::AuditLogEntry| {
+                let event = kestrel_daemon::audit::audit_event(
+                    &entry.event_type,
+                    entry.trace_id,
+                    entry.session_key,
+                    entry.channel,
+                    entry.duration_ms,
+                    entry.message,
+                );
+                // Use a blocking write via spawn_blocking — the callback must be
+                // sync (Fn, not async), so we fire-and-forget the spawned task.
+                let log_dir = audit_log_dir.clone();
+                tokio::spawn(async move {
+                    kestrel_daemon::audit::append_audit_event(&log_dir, &event).await;
+                });
+            });
+        al = al.with_audit_callback(audit_cb);
+
         // Wire memory store (TieredStore L1+L2)
         if let Some(ref ms) = memory_store {
             al = al.with_memory_store(ms.clone());
@@ -607,6 +628,13 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
             tracing::error!("API server error: {}", e);
         }
     });
+
+    // ── Log auto-cleanup ──────────────────────────────────────
+    {
+        let log_dir = config.daemon.log_dir.clone();
+        let retain_days = config.daemon.log_retain_days;
+        let _log_cleanup_handle = kestrel_daemon::logging::spawn_log_cleanup(log_dir, retain_days);
+    }
 
     // ── Learning event processor + persistent store ──────────
     let learning_config = LearningConfig::default();


### PR DESCRIPTION
## Summary
- Replace hardcoded `"0.1.1"` with `env!("CARGO_PKG_VERSION")` in `kestrel-core/src/constants.rs`
- Since `kestrel-core` uses `version.workspace = true`, this resolves to the workspace version (`0.2.4`) at compile time
- `--version` flag, `/status`, and API health endpoints will now always show the correct release version

Closes #149

## Test plan
- [ ] `cargo build --workspace && ./target/debug/kestrel --version` shows `kestrel 0.2.4`
- [ ] `cargo test --workspace` passes (existing `test_version_not_empty` validates VERSION is non-empty)
- [ ] `cargo clippy --workspace` — 0 warnings

Bahtya