### PR TITLE
fix(heartbeat): prevent test data leaking into production state

### DIFF
--- a/tests/full_integration_test.rs
+++ b/tests/full_integration_test.rs
@@ -668,11 +668,13 @@ async fn test_cron_fires_event() {
 /// unhealthy snapshot and event emission.
 #[tokio::test]
 async fn test_heartbeat_health_check() {
+    let tmp_dir = tempfile::tempdir().unwrap();
     let config = make_test_config();
     let bus = MessageBus::new();
     let mut event_rx = bus.subscribe_events();
 
-    let mut heartbeat = kestrel_heartbeat::HeartbeatService::new(config);
+    let mut heartbeat =
+        kestrel_heartbeat::HeartbeatService::with_data_dir(config, tmp_dir.path().to_path_buf());
     heartbeat.set_bus(bus);
 
     // Register a failing health check
@@ -731,11 +733,13 @@ async fn test_heartbeat_health_check() {
 /// Test 5b: Heartbeat with healthy and unhealthy checks.
 #[tokio::test]
 async fn test_heartbeat_mixed_checks() {
+    let tmp_dir = tempfile::tempdir().unwrap();
     let config = make_test_config();
     let bus = MessageBus::new();
     let mut event_rx = bus.subscribe_events();
 
-    let mut heartbeat = kestrel_heartbeat::HeartbeatService::new(config);
+    let mut heartbeat =
+        kestrel_heartbeat::HeartbeatService::with_data_dir(config, tmp_dir.path().to_path_buf());
     heartbeat.set_bus(bus);
 
     struct HealthyCheck;


### PR DESCRIPTION
## Summary
- Two heartbeat integration tests (`test_heartbeat_health_check`, `test_heartbeat_mixed_checks`) used `HeartbeatService::new()` which writes state to `~/.kestrel/data/heartbeat_state.json` — the production path
- This caused `broken_svc` and `test_component` failure records to pollute the real state file
- Switched both to `HeartbeatService::with_data_dir()` backed by `tempfile::tempdir()` so state is isolated

## Test plan
- [ ] `cargo test --workspace` passes (no production state file touched)
- [ ] Verify `~/.kestrel/data/heartbeat_state.json` no longer contains `broken_svc` after test runs

Closes #147

Bahtya