### PR TITLE
fix(channels): use underscores in Telegram bot command names

### DIFF
--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -126,30 +126,30 @@ fn is_reserved_command(command: &str) -> bool {
 
 fn normalize_skill_command_key(name: &str) -> String {
     let mut normalized = String::with_capacity(name.len());
-    let mut last_was_dash = false;
+    let mut last_was_sep = false;
 
     for ch in name.chars().flat_map(char::to_lowercase) {
         let mapped = match ch {
             'a'..='z' | '0'..='9' => Some(ch),
-            '-' | '_' | ' ' => Some('-'),
+            '-' | '_' | ' ' => Some('_'),
             _ => None,
         };
 
         match mapped {
-            Some('-') if !last_was_dash && !normalized.is_empty() => {
-                normalized.push('-');
-                last_was_dash = true;
+            Some('_') if !last_was_sep && !normalized.is_empty() => {
+                normalized.push('_');
+                last_was_sep = true;
             }
-            Some('-') => {}
+            Some('_') => {}
             Some(value) => {
                 normalized.push(value);
-                last_was_dash = false;
+                last_was_sep = false;
             }
             None => {}
         }
     }
 
-    normalized.trim_matches('-').to_string()
+    normalized.trim_matches('_').to_string()
 }
 
 async fn resolve_skill_command(
@@ -1987,7 +1987,7 @@ providers:
                 .unwrap(),
         );
 
-        assert!(rewritten.contains("The user explicitly invoked the /plan-release skill"));
+        assert!(rewritten.contains("The user explicitly invoked the /plan_release skill"));
         assert!(rewritten.contains("Skill name: plan-release"));
         assert!(rewritten.contains("Instructions for plan-release"));
         assert!(rewritten.contains("prepare the rollback checklist"));
@@ -2025,7 +2025,7 @@ providers:
         let commands = dynamic_skill_commands().await;
         assert!(commands
             .iter()
-            .any(|(command, _)| command == "release-plan"));
+            .any(|(command, _)| command == "release_plan"));
         assert!(!commands.iter().any(|(command, _)| command == "skill"));
     }
 

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -2302,7 +2302,7 @@ mod tests {
         let commands = TelegramChannel::bot_commands().await;
         assert!(commands
             .iter()
-            .any(|command| command.command == "plan-release"));
+            .any(|command| command.command == "plan_release"));
 
         crate::commands::set_skill_registry(None);
     }

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -630,11 +630,10 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     });
 
     // ── Log auto-cleanup ──────────────────────────────────────
-    {
-        let log_dir = config.daemon.log_dir.clone();
-        let retain_days = config.daemon.log_retain_days;
-        let _log_cleanup_handle = kestrel_daemon::logging::spawn_log_cleanup(log_dir, retain_days);
-    }
+    let _log_cleanup_handle = kestrel_daemon::logging::spawn_log_cleanup(
+        config.daemon.log_dir.clone(),
+        config.daemon.log_retain_days,
+    );
 
     // ── Learning event processor + persistent store ──────────
     let learning_config = LearningConfig::default();


### PR DESCRIPTION
## Summary
- Changed `normalize_skill_command_key` separator from `-` to `_` — Telegram Bot API requires `[a-z0-9_]{1,32}`, hyphens caused `BOT_COMMAND_INVALID`
- Fixed `_log_cleanup_handle` lifetime bug in `gateway.rs` — was created inside a block scope and immediately dropped, cancelling the log cleanup task

## Changes (31 lines, 3 files)
- `commands.rs`: separator `'-'` → `'_'`, updated 2 test assertions
- `telegram.rs`: updated 1 test assertion
- `gateway.rs`: removed block scope so `_log_cleanup_handle` lives until function exit

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace` — 0 warnings
- [ ] Verify skill commands register without BOT_COMMAND_INVALID in Telegram

Closes #145

Bahtya