### PR TITLE
fix(memory): generate embeddings for learning insights and align embedding dimensions

### DIFF
--- a/crates/kestrel-memory/src/embedding.rs
+++ b/crates/kestrel-memory/src/embedding.rs
@@ -46,9 +46,9 @@ impl HashEmbedding {
         Self { dimension }
     }
 
-    /// Create with the default dimension of 256.
+    /// Create with the default dimension matching [`MemoryConfig::embedding_dim`](crate::config::MemoryConfig::embedding_dim).
     pub fn default_dim() -> Self {
-        Self::new(256)
+        Self::new(1536)
     }
 
     /// Tokenize text into lowercase words.
@@ -201,6 +201,6 @@ mod tests {
     #[test]
     fn test_default_impl() {
         let default: HashEmbedding = HashEmbedding::default();
-        assert_eq!(default.dimension(), 256);
+        assert_eq!(default.dimension(), 1536);
     }
 }

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -183,6 +183,7 @@ async fn execute_learning_action(
     action: &LearningAction,
     memory_store: Option<&Arc<dyn MemoryStore>>,
     skill_registry: &SkillRegistry,
+    embedding: &Arc<dyn kestrel_memory::EmbeddingGenerator>,
 ) -> Result<()> {
     let span = tracing::info_span!("learning_action", action_type = action_type_name(action),);
     async move {
@@ -213,7 +214,7 @@ async fn execute_learning_action(
                 .with_context(|| format!("failed to deprecate skill '{skill}'")),
             LearningAction::RecordInsight { insight, category } => {
                 let store = memory_store.context("memory store not configured")?;
-                let entry = build_memory_entry(insight, category);
+                let entry = build_memory_entry(insight, category, embedding).await?;
                 store
                     .store(entry)
                     .await
@@ -242,9 +243,10 @@ async fn execute_learning_actions(
     actions: &[LearningAction],
     memory_store: Option<&Arc<dyn MemoryStore>>,
     skill_registry: &SkillRegistry,
+    embedding: &Arc<dyn kestrel_memory::EmbeddingGenerator>,
 ) {
     for action in actions {
-        if let Err(e) = execute_learning_action(action, memory_store, skill_registry).await {
+        if let Err(e) = execute_learning_action(action, memory_store, skill_registry, embedding).await {
             tracing::error!("Failed to execute learning action {:?}: {}", action, e);
         }
     }
@@ -266,8 +268,18 @@ fn event_type_name(event: &LearningEvent) -> &'static str {
 }
 
 /// Convert an insight action into a memory entry for persistence.
-fn build_memory_entry(insight: &str, category: &str) -> MemoryEntry {
-    MemoryEntry::new(insight, map_memory_category(category)).with_confidence(0.8)
+async fn build_memory_entry(
+    insight: &str,
+    category: &str,
+    embedding: &Arc<dyn kestrel_memory::EmbeddingGenerator>,
+) -> Result<MemoryEntry> {
+    let vec = embedding
+        .generate(insight)
+        .await
+        .context("embedding generation failed")?;
+    Ok(MemoryEntry::new(insight, map_memory_category(category))
+        .with_confidence(0.8)
+        .with_embedding(vec))
 }
 
 /// Map a learning insight category to the closest memory category.
@@ -293,6 +305,7 @@ async fn run_learning_consumer<P>(
     processor: &mut P,
     memory_store: Option<Arc<dyn MemoryStore>>,
     skill_registry: Arc<SkillRegistry>,
+    embedding: Arc<dyn kestrel_memory::EmbeddingGenerator>,
 ) where
     P: GatewayLearningProcessor,
 {
@@ -336,6 +349,7 @@ async fn run_learning_consumer<P>(
                             &actions,
                             memory_store.as_ref(),
                             skill_registry.as_ref(),
+                            &embedding,
                         )
                         .await;
 
@@ -407,6 +421,10 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     // ── Agent loop ────────────────────────────────────────────
     let learning_bus = LearningEventBus::new();
 
+    // Shared embedding generator for memory tools and learning insights.
+    let embedding: Arc<dyn kestrel_memory::EmbeddingGenerator> =
+        Arc::new(kestrel_memory::HashEmbedding::default_dim());
+
     // Initialize memory store early so it can be shared with the learning consumer.
     let memory_config = MemoryConfig {
         hot_store_path: home.join("memory").join("hot.jsonl"),
@@ -450,12 +468,11 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
     };
     let heartbeat_memory_store = memory_store.clone();
     let learning_memory_store = memory_store.clone();
+    let learning_embedding = embedding.clone();
 
     // Register memory tools if the memory store is available.
     if let Some(ref ms) = memory_store {
-        let embedding: Arc<dyn kestrel_memory::EmbeddingGenerator> =
-            Arc::new(kestrel_memory::HashEmbedding::default_dim());
-        builtins::register_memory_tools(&tool_registry, ms.clone(), embedding);
+        builtins::register_memory_tools(&tool_registry, ms.clone(), embedding.clone());
         info!("Memory tools registered (store_memory, recall_memory)");
     }
 
@@ -670,6 +687,7 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
                 &mut processor,
                 memory_store,
                 skill_registry,
+                learning_embedding,
             )
             .await;
         })
@@ -759,7 +777,11 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use kestrel_learning::event::SkillOutcome;
-    use kestrel_memory::{MemoryQuery, ScoredEntry};
+    use kestrel_memory::{HashEmbedding, MemoryQuery, ScoredEntry};
+
+    fn test_embedding() -> Arc<dyn kestrel_memory::EmbeddingGenerator> {
+        Arc::new(HashEmbedding::default_dim())
+    }
     use kestrel_skill::manifest::SkillManifestBuilder;
     use kestrel_skill::skill::CompiledSkill;
     use kestrel_skill::Skill;
@@ -1066,6 +1088,7 @@ mod tests {
             },
             None,
             &registry,
+            &test_embedding(),
         )
         .await
         .unwrap();
@@ -1099,6 +1122,7 @@ mod tests {
             },
             None,
             &registry,
+            &test_embedding(),
         )
         .await
         .unwrap();
@@ -1109,6 +1133,7 @@ mod tests {
             },
             None,
             &registry,
+            &test_embedding(),
         )
         .await
         .unwrap();
@@ -1140,6 +1165,7 @@ mod tests {
             },
             Some(&memory_store),
             &skill_registry,
+            &test_embedding(),
         )
         .await
         .unwrap();
@@ -1148,6 +1174,10 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].content, "remember this");
         assert_eq!(entries[0].category, MemoryCategory::Environment);
+        assert!(
+            entries[0].embedding.is_some(),
+            "learning insight should have an embedding"
+        );
     }
 
     #[tokio::test]
@@ -1171,7 +1201,13 @@ mod tests {
             },
         ];
 
-        execute_learning_actions(&actions, Some(&memory_store), &skill_registry).await;
+        execute_learning_actions(
+            &actions,
+            Some(&memory_store),
+            &skill_registry,
+            &test_embedding(),
+        )
+        .await;
 
         let skill = skill_registry.get("deploy").await.unwrap();
         assert!(skill.read().confidence() > 0.5);


### PR DESCRIPTION
## Summary

Fixes #155 — all 19 warm store (LanceDB) entries had zero-filled 1536-dim vectors, making semantic search completely non-functional.

### Root cause

**Bug 1:** `build_memory_entry()` (gateway.rs:269) created memory entries without calling the `EmbeddingGenerator`, so learning insights from `RecordInsight` actions were stored with `embedding: None`. `WarmStore.entry_to_batch` replaced `None` with `vec![0.0; 1536]`.

**Bug 2:** `HashEmbedding::default_dim()` produced 256-dim vectors while `MemoryConfig` expected 1536-dim. `WarmStore::validate_embedding` rejected entries from `StoreMemoryTool`, silently caught by `TieredMemoryStore`.

### Changes

- **`embedding.rs`**: `HashEmbedding::default_dim()` now returns 1536 dimensions to match `MemoryConfig::embedding_dim`
- **`gateway.rs`**: Created a shared `EmbeddingGenerator` instance used by both memory tools and the learning consumer. `build_memory_entry()` now generates embeddings asynchronously.

### Test plan

- [ ] CI passes (all existing tests updated for new function signatures)
- [ ] `test_record_insight_action_stores_memory` now asserts `embedding.is_some()`
- [ ] New learning insights stored in warm store have non-zero vectors
- [ ] `recall_memory` returns semantically relevant results
- [ ] Existing 19 zero-vector entries can be re-indexed with a migration (follow-up)

Bahtya