### PR TITLE
fix: add DNS resolver fallback for Android/Termux compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ cron = "0.15"
 parking_lot = "0.12"
 dashmap = "6"
 
+# DNS
+hickory-resolver = { version = "0.25", features = ["tokio"] }
+
 # Misc
 uuid = { version = "1", features = ["v4"] }
 regex = "1"

--- a/crates/kestrel-channels/src/platforms/discord.rs
+++ b/crates/kestrel-channels/src/platforms/discord.rs
@@ -323,12 +323,15 @@ impl DiscordChannel {
                     .ok()
             });
 
+        let dns = kestrel_core::dns::build_dns_resolver();
+
         match proxy_url {
             Some(ref url) if url.starts_with("socks5") => {
                 info!("Discord HTTP client using SOCKS5 proxy: {}", url);
                 let proxy =
                     reqwest::Proxy::all(url).expect("Failed to create SOCKS5 proxy from config");
                 reqwest::Client::builder()
+                    .dns_resolver(dns)
                     .proxy(proxy)
                     .build()
                     .expect("Failed to build HTTP client with SOCKS5 proxy")
@@ -340,6 +343,7 @@ impl DiscordChannel {
                 let https_proxy =
                     reqwest::Proxy::https(url).expect("Failed to create HTTPS proxy from config");
                 reqwest::Client::builder()
+                    .dns_resolver(dns)
                     .proxy(http_proxy)
                     .proxy(https_proxy)
                     .build()
@@ -350,11 +354,17 @@ impl DiscordChannel {
                     "Discord HTTP client: unsupported proxy scheme in '{}', falling back to direct",
                     url
                 );
-                reqwest::Client::new()
+                reqwest::Client::builder()
+                    .dns_resolver(dns)
+                    .build()
+                    .expect("Failed to build HTTP client")
             }
             None => {
                 info!("Discord HTTP client: no proxy configured (direct connection)");
-                reqwest::Client::new()
+                reqwest::Client::builder()
+                    .dns_resolver(dns)
+                    .build()
+                    .expect("Failed to build HTTP client")
             }
         }
     }

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -597,12 +597,15 @@ impl TelegramChannel {
                     .ok()
             });
 
+        let dns = kestrel_core::dns::build_dns_resolver();
+
         match proxy_url {
             Some(ref url) if url.starts_with("socks5") => {
                 info!("Telegram HTTP client using SOCKS5 proxy: {}", url);
                 let proxy =
                     reqwest::Proxy::all(url).expect("Failed to create SOCKS5 proxy from config");
                 reqwest::Client::builder()
+                    .dns_resolver(dns)
                     .proxy(proxy)
                     .build()
                     .expect("Failed to build HTTP client with SOCKS5 proxy")
@@ -614,6 +617,7 @@ impl TelegramChannel {
                 let https_proxy =
                     reqwest::Proxy::https(url).expect("Failed to create HTTPS proxy from config");
                 reqwest::Client::builder()
+                    .dns_resolver(dns)
                     .proxy(http_proxy)
                     .proxy(https_proxy)
                     .build()
@@ -624,11 +628,17 @@ impl TelegramChannel {
                     "Telegram HTTP client: unsupported proxy scheme in '{}', falling back to direct",
                     url
                 );
-                reqwest::Client::new()
+                reqwest::Client::builder()
+                    .dns_resolver(dns)
+                    .build()
+                    .expect("Failed to build HTTP client")
             }
             None => {
                 info!("Telegram HTTP client: no proxy configured (direct connection)");
-                reqwest::Client::new()
+                reqwest::Client::builder()
+                    .dns_resolver(dns)
+                    .build()
+                    .expect("Failed to build HTTP client")
             }
         }
     }

--- a/crates/kestrel-core/Cargo.toml
+++ b/crates/kestrel-core/Cargo.toml
@@ -8,3 +8,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
+reqwest = { workspace = true }
+hickory-resolver = { workspace = true }

--- a/crates/kestrel-core/src/dns.rs
+++ b/crates/kestrel-core/src/dns.rs
@@ -17,6 +17,12 @@ pub struct DnsResolver {
     inner: Arc<TokioResolver>,
 }
 
+impl Default for DnsResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DnsResolver {
     pub fn new() -> Self {
         let resolver = TokioResolver::builder_tokio()
@@ -50,6 +56,6 @@ impl Resolve for DnsResolver {
 }
 
 /// Build a shared DNS resolver suitable for injection into reqwest clients.
-pub fn build_dns_resolver() -> Arc<dyn Resolve> {
+pub fn build_dns_resolver() -> Arc<DnsResolver> {
     Arc::new(DnsResolver::new())
 }

--- a/crates/kestrel-core/src/dns.rs
+++ b/crates/kestrel-core/src/dns.rs
@@ -1,0 +1,55 @@
+//! DNS resolver with fallback for systems without `/etc/resolv.conf` (e.g. Android Termux).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use hickory_resolver::config::{LookupIpStrategy, ResolverConfig};
+use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::TokioResolver;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+/// DNS resolver that wraps hickory-resolver with a fallback to Google DNS.
+///
+/// On most systems hickory reads `/etc/resolv.conf` for nameserver config.
+/// On Android Termux that file doesn't exist, so we fall back to
+/// `ResolverConfig::default()` (Google public DNS: 8.8.8.8, 8.8.4.4).
+pub struct DnsResolver {
+    inner: Arc<TokioResolver>,
+}
+
+impl DnsResolver {
+    pub fn new() -> Self {
+        let resolver = TokioResolver::builder_tokio()
+            .map(|mut b| {
+                b.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+                b.build()
+            })
+            .unwrap_or_else(|_| {
+                let mut b = TokioResolver::builder_with_config(
+                    ResolverConfig::default(),
+                    TokioConnectionProvider::default(),
+                );
+                b.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+                b.build()
+            });
+        Self {
+            inner: Arc::new(resolver),
+        }
+    }
+}
+
+impl Resolve for DnsResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let inner = self.inner.clone();
+        Box::pin(async move {
+            let lookup = inner.lookup_ip(name.as_str()).await?;
+            let addrs: Addrs = Box::new(lookup.into_iter().map(|ip| SocketAddr::new(ip, 0)));
+            Ok(addrs)
+        })
+    }
+}
+
+/// Build a shared DNS resolver suitable for injection into reqwest clients.
+pub fn build_dns_resolver() -> Arc<dyn Resolve> {
+    Arc::new(DnsResolver::new())
+}

--- a/crates/kestrel-core/src/lib.rs
+++ b/crates/kestrel-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! Shared types, error definitions, and constants for the kestrel project.
 
 pub mod constants;
+pub mod dns;
 pub mod error;
 pub mod types;
 

--- a/crates/kestrel-providers/src/lib.rs
+++ b/crates/kestrel-providers/src/lib.rs
@@ -27,7 +27,9 @@ pub use retry::{CircuitBreaker, CircuitBreakerConfig, RetryConfig, RetryPolicy};
 /// By default, reqwest reads `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` from the environment.
 /// When `no_proxy` is true, all proxy env vars are ignored (for domestic APIs like ZAI).
 pub(crate) fn build_client(no_proxy: bool) -> anyhow::Result<reqwest::Client> {
-    let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(30));
+    let mut builder = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .dns_resolver(kestrel_core::dns::build_dns_resolver());
     if no_proxy {
         builder = builder.no_proxy();
     }


### PR DESCRIPTION
## Summary
- Add `DnsResolver` in `kestrel-core/src/dns.rs` that tries system DNS config first, falls back to Google public DNS (8.8.8.8, 8.8.4.4) when `/etc/resolv.conf` is missing (e.g. Android Termux)
- Inject `.dns_resolver(build_dns_resolver())` into all reqwest client builders across 3 locations: `kestrel-providers`, `kestrel-channels/telegram`, `kestrel-channels/discord`
- Replace bare `reqwest::Client::new()` calls (which use default resolver) with explicitly built clients using the fallback-capable resolver

## Test plan
- [ ] CI compiles successfully on all targets
- [ ] Existing integration tests pass (no behavior change on systems with `/etc/resolv.conf`)
- [ ] Manual verification on Android Termux that DNS resolution works

Bahtya