### PR TITLE
feat: Telegram streaming, tool display, and /stop interrupt

### DIFF
--- a/crates/kestrel-agent/Cargo.toml
+++ b/crates/kestrel-agent/Cargo.toml
@@ -10,12 +10,14 @@ kestrel-bus = { path = "../kestrel-bus" }
 kestrel-session = { path = "../kestrel-session" }
 kestrel-providers = { path = "../kestrel-providers" }
 kestrel-tools = { path = "../kestrel-tools" }
+kestrel-channels = { path = "../kestrel-channels" }
 kestrel-memory = { path = "../kestrel-memory" }
 kestrel-cron = { path = "../kestrel-cron" }
 kestrel-heartbeat = { path = "../kestrel-heartbeat" }
 kestrel-skill = { path = "../kestrel-skill" }
 kestrel-learning = { path = "../kestrel-learning" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -517,13 +517,13 @@ impl AgentLoop {
 
                                 // Send tool progress message to Telegram
                                 if let Some(ref channel) = channel_for_tool_display {
+                                    let ch = channel.clone();
+                                    let cid = chat_id_for_tool.clone();
                                     let progress =
                                         format!("Using `{}` tool...", tool_name);
-                                    let _ = channel.send_message(
-                                        &chat_id_for_tool,
-                                        &progress,
-                                        None,
-                                    ).await;
+                                    tokio::spawn(async move {
+                                        let _ = ch.send_message(&cid, &progress, None).await;
+                                    });
                                 }
                             }
                             _ => {}

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -17,8 +17,12 @@ use crate::notes::NotesManager;
 use crate::runner::AgentRunner;
 use crate::subagent::SubAgentManager;
 use anyhow::Result;
+use dashmap::DashMap;
 use kestrel_bus::events::{AgentEvent, InboundMessage, OutboundMessage, StreamChunk};
 use kestrel_bus::MessageBus;
+use kestrel_channels::stream_consumer::StreamConsumer;
+use kestrel_channels::BaseChannel;
+use kestrel_config::schema::StreamingConfig;
 use kestrel_config::Config;
 use kestrel_core::{Message, MessageRole};
 use kestrel_heartbeat::HeartbeatService;
@@ -111,6 +115,14 @@ pub struct AgentLoop {
     audit_callback: Option<AuditCallback>,
     /// Consecutive reflection failure count for escalating log level.
     consecutive_reflection_failures: Arc<std::sync::atomic::AtomicU32>,
+    /// Channel registry for accessing platform adapters during streaming.
+    channel_registry: Option<Arc<kestrel_channels::ChannelRegistry>>,
+    /// Live Telegram channel for streaming support.
+    telegram_channel: Option<Arc<dyn BaseChannel>>,
+    /// Active cancellation tokens per session_key (for /stop support).
+    active_sessions: Arc<DashMap<String, tokio_util::sync::CancellationToken>>,
+    /// Pending messages queued while session is busy.
+    pending_messages: Arc<DashMap<String, InboundMessage>>,
 }
 
 impl AgentLoop {
@@ -141,6 +153,10 @@ impl AgentLoop {
             prompt_assembler: None,
             audit_callback: None,
             consecutive_reflection_failures: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            channel_registry: None,
+            telegram_channel: None,
+            active_sessions: Arc::new(DashMap::new()),
+            pending_messages: Arc::new(DashMap::new()),
         }
     }
 
@@ -244,6 +260,55 @@ impl AgentLoop {
 
         async move {
             let session_key = msg.session_key();
+
+            // Handle /stop command: cancel active agent run
+            let content_trimmed = msg.content.trim().to_lowercase();
+            if content_trimmed == "/stop" {
+                if self.cancel_session(&session_key) {
+                    let reply = OutboundMessage {
+                        channel: msg.channel.clone(),
+                        chat_id: msg.chat_id.clone(),
+                        content: "Stopped.".to_string(),
+                        reply_to: msg.message_id.clone(),
+                        trace_id: msg.trace_id.clone(),
+                        media: vec![],
+                        metadata: Default::default(),
+                    };
+                    if let Err(e) = self.bus.publish_outbound(reply).await {
+                        error!("Failed to send /stop reply: {e}");
+                    }
+
+                    // Drain any pending message
+                    if let Some((_, pending)) = self.pending_messages.remove(&session_key) {
+                        let _ = self.process_message(pending).await;
+                    }
+                    return Ok(());
+                } else {
+                    let reply = OutboundMessage {
+                        channel: msg.channel.clone(),
+                        chat_id: msg.chat_id.clone(),
+                        content: "Nothing to stop.".to_string(),
+                        reply_to: msg.message_id.clone(),
+                        trace_id: msg.trace_id.clone(),
+                        media: vec![],
+                        metadata: Default::default(),
+                    };
+                    if let Err(e) = self.bus.publish_outbound(reply).await {
+                        error!("Failed to send /stop reply: {e}");
+                    }
+                    return Ok(());
+                }
+            }
+
+            // If session is busy, queue the message
+            if self.is_session_active(&session_key) {
+                self.pending_messages.insert(session_key.clone(), msg.clone());
+                info!(
+                    "Session {} is busy, queued message",
+                    session_key
+                );
+                return Ok(());
+            }
 
             // Audit log: message content at debug level for traceability
             let content_preview = truncate_str(&msg.content, 100);
@@ -357,6 +422,30 @@ impl AgentLoop {
             // Set up event callback for this session
             let bus_for_stream = self.bus.clone();
 
+            // Create cancellation token for this session
+            let cancel_token = tokio_util::sync::CancellationToken::new();
+            self.active_sessions
+                .insert(session_key.clone(), cancel_token.clone());
+
+            // Determine streaming mode: agent-level streaming + channel support
+            let is_telegram = msg.channel == kestrel_core::Platform::Telegram;
+            let channel_streaming = is_telegram
+                && self
+                    .config
+                    .channels
+                    .telegram
+                    .as_ref()
+                    .map(|c| c.streaming)
+                    .unwrap_or(false);
+            let use_streaming = self.config.agent.streaming;
+
+            // Optionally spawn a StreamConsumer for Telegram streaming display
+            let stream_consumer_handle = if channel_streaming && use_streaming {
+                self.spawn_stream_consumer(&msg.chat_id)
+            } else {
+                None
+            };
+
             // Run agent with events wired through
             let messages = session.to_messages();
             let run_start = std::time::Instant::now();
@@ -365,6 +454,8 @@ impl AgentLoop {
                 let event_bus = bus_for_stream.clone();
                 let session_key_for_runner = session_key.clone();
                 let trace_id_for_runner = msg.trace_id.clone();
+                let channel_for_tool_display = self.telegram_channel.clone();
+                let chat_id_for_tool = msg.chat_id.clone();
 
                 let mut runner_with_events = AgentRunner::new(
                     self.config.clone(),
@@ -372,9 +463,10 @@ impl AgentLoop {
                     self.tool_registry.clone(),
                 )
                 .with_session_key(&session_key_for_runner)
-                .with_trace_id(trace_id_for_runner.clone().unwrap_or_default());
+                .with_trace_id(trace_id_for_runner.clone().unwrap_or_default())
+                .with_cancel_token(cancel_token.clone());
 
-                if self.config.agent.streaming {
+                if use_streaming {
                     runner_with_events =
                         runner_with_events.with_stream_tx(event_bus.subscribe_stream_tx());
                 }
@@ -407,12 +499,39 @@ impl AgentLoop {
                                     iteration: *iteration,
                                     trace_id: trace_id_for_runner.clone(),
                                 });
+
+                                // Send tool progress message to Telegram
+                                if let Some(ref channel) = channel_for_tool_display {
+                                    let progress =
+                                        format!("Using `{}` tool...", tool_name);
+                                    let _ = channel.send_message(
+                                        &chat_id_for_tool,
+                                        &progress,
+                                        None,
+                                    ).await;
+                                }
                             }
                             _ => {}
                         }
                     }));
 
                 runner_with_events.run(system_prompt, messages).await
+            };
+
+            // Clean up active session
+            self.active_sessions.remove(&session_key);
+
+            // Wait for stream consumer to finish and get the delivered message id
+            let stream_delivered_msg_id = if let Some(handle) = stream_consumer_handle {
+                match handle.await {
+                    Ok((_text, msg_id)) => msg_id,
+                    Err(e) => {
+                        warn!("Stream consumer task error: {e}");
+                        None
+                    }
+                }
+            } else {
+                None
             };
 
             match result {
@@ -491,15 +610,18 @@ impl AgentLoop {
                     let outbound = OutboundMessage {
                         channel: msg.channel.clone(),
                         chat_id: msg.chat_id.clone(),
-                        content: result.content,
+                        content: result.content.clone(),
                         reply_to: msg.message_id.clone(),
                         trace_id: msg.trace_id.clone(),
                         media: vec![],
                         metadata: Default::default(),
                     };
 
-                    if let Err(e) = self.bus.publish_outbound(outbound).await {
-                        error!("Failed to publish outbound message: {}", e);
+                    // Skip outbound if stream consumer already delivered the response
+                    if stream_delivered_msg_id.is_none() {
+                        if let Err(e) = self.bus.publish_outbound(outbound).await {
+                            error!("Failed to publish outbound message: {}", e);
+                        }
                     }
 
                     // Post-task LLM reflection runs in the background after the
@@ -628,6 +750,11 @@ impl AgentLoop {
                         })
                         .await;
                 }
+            }
+
+            // Drain pending messages for this session
+            if let Some((_, pending)) = self.pending_messages.remove(&session_key) {
+                let _ = self.process_message(pending).await;
             }
 
             Ok(())
@@ -763,6 +890,23 @@ impl AgentLoop {
         if let Some(cb) = &self.audit_callback {
             cb(entry);
         }
+    }
+
+    /// Spawn a StreamConsumer task for progressive Telegram message editing.
+    ///
+    /// Returns a JoinHandle that resolves to (final_text, message_id) when done.
+    fn spawn_stream_consumer(
+        &self,
+        chat_id: &str,
+    ) -> Option<tokio::task::JoinHandle<(String, Option<String>)>> {
+        let channel = self.telegram_channel.clone()?;
+        let stream_rx = self.bus.subscribe_stream();
+        let cfg = StreamingConfig::default();
+
+        let consumer = StreamConsumer::new(channel, chat_id.to_string(), cfg, stream_rx);
+        let handle = tokio::spawn(async move { consumer.run().await });
+
+        Some(handle)
     }
 
     /// Stop the agent loop.
@@ -1001,6 +1145,43 @@ impl AgentLoop {
     /// Get the sub-agent manager, if one has been attached.
     pub fn subagent_manager(&self) -> Option<&Arc<SubAgentManager>> {
         self.subagent_manager.as_ref()
+    }
+
+    /// Attach a channel registry for streaming support.
+    ///
+    /// When set, the agent loop can access platform adapters to perform
+    /// progressive message editing during streaming.
+    pub fn with_channel_registry(
+        mut self,
+        registry: Arc<kestrel_channels::ChannelRegistry>,
+    ) -> Self {
+        self.channel_registry = Some(registry);
+        self
+    }
+
+    /// Attach a live Telegram channel for streaming display.
+    pub fn with_telegram_channel(mut self, channel: Arc<dyn BaseChannel>) -> Self {
+        self.telegram_channel = Some(channel);
+        self
+    }
+
+    /// Cancel a running agent for the given session key.
+    ///
+    /// Used by /stop command to interrupt an in-progress agent run.
+    /// Returns true if a session was found and cancelled.
+    pub fn cancel_session(&self, session_key: &str) -> bool {
+        if let Some((_, token)) = self.active_sessions.remove(session_key) {
+            token.cancel();
+            info!("Cancelled agent run for session {}", session_key);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Check if a session currently has an active agent run.
+    pub fn is_session_active(&self, session_key: &str) -> bool {
+        self.active_sessions.contains_key(session_key)
     }
 }
 

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -771,7 +771,7 @@ impl AgentLoop {
             let pending = self.pending_messages.remove(&session_key);
             self.active_sessions.remove(&session_key);
             if let Some((_, pending_msg)) = pending {
-                let _ = self.process_message(pending_msg).await;
+                let _ = Box::pin(self.process_message(pending_msg)).await;
             }
 
             Ok(())

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -179,6 +179,34 @@ impl AgentLoop {
             None
         };
 
+        // Spawn background interrupt listener that cancels sessions via
+        // InterruptRequested bus events. This bypasses the sequential mpsc
+        // bottleneck so /stop works even while an agent run is in progress.
+        let interrupt_active = self.active_sessions.clone();
+        let interrupt_bus = self.bus.clone();
+        let interrupt_running = self.running.clone();
+        let interrupt_pending = self.pending_messages.clone();
+        tokio::spawn(async move {
+            let mut event_rx = interrupt_bus.subscribe_events();
+            while *interrupt_running.read().await {
+                match event_rx.recv().await {
+                    Ok(AgentEvent::InterruptRequested { session_key }) => {
+                        if let Some((_, token)) = interrupt_active.remove(&session_key) {
+                            info!("Interrupt requested for session {}", session_key);
+                            token.cancel();
+                            // Clear any queued pending message for this session
+                            interrupt_pending.remove(&session_key);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("Interrupt listener lagged by {n} events");
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+
         let inbound_rx = self.bus.consume_inbound().await;
         let mut inbound_rx = match inbound_rx {
             Some(rx) => rx,
@@ -261,43 +289,30 @@ impl AgentLoop {
         async move {
             let session_key = msg.session_key();
 
-            // Handle /stop command: cancel active agent run
+            // Handle /stop command: cancel active agent run.
+            // The Telegram poll loop already emitted InterruptRequested on the
+            // bus event channel (bypassing the mpsc bottleneck), but we also
+            // try to cancel here for non-Telegram channels or edge cases.
             let content_trimmed = msg.content.trim().to_lowercase();
             if content_trimmed == "/stop" {
-                if self.cancel_session(&session_key) {
-                    let reply = OutboundMessage {
-                        channel: msg.channel.clone(),
-                        chat_id: msg.chat_id.clone(),
-                        content: "Stopped.".to_string(),
-                        reply_to: msg.message_id.clone(),
-                        trace_id: msg.trace_id.clone(),
-                        media: vec![],
-                        metadata: Default::default(),
-                    };
-                    if let Err(e) = self.bus.publish_outbound(reply).await {
-                        error!("Failed to send /stop reply: {e}");
-                    }
+                self.cancel_session(&session_key);
 
-                    // Drain any pending message
-                    if let Some((_, pending)) = self.pending_messages.remove(&session_key) {
-                        let _ = self.process_message(pending).await;
-                    }
-                    return Ok(());
-                } else {
-                    let reply = OutboundMessage {
-                        channel: msg.channel.clone(),
-                        chat_id: msg.chat_id.clone(),
-                        content: "Nothing to stop.".to_string(),
-                        reply_to: msg.message_id.clone(),
-                        trace_id: msg.trace_id.clone(),
-                        media: vec![],
-                        metadata: Default::default(),
-                    };
-                    if let Err(e) = self.bus.publish_outbound(reply).await {
-                        error!("Failed to send /stop reply: {e}");
-                    }
-                    return Ok(());
+                let reply = OutboundMessage {
+                    channel: msg.channel.clone(),
+                    chat_id: msg.chat_id.clone(),
+                    content: "Stopped.".to_string(),
+                    reply_to: msg.message_id.clone(),
+                    trace_id: msg.trace_id.clone(),
+                    media: vec![],
+                    metadata: Default::default(),
+                };
+                if let Err(e) = self.bus.publish_outbound(reply).await {
+                    error!("Failed to send /stop reply: {e}");
                 }
+
+                // Clear any pending message for this session
+                self.pending_messages.remove(&session_key);
+                return Ok(());
             }
 
             // If session is busy, queue the message
@@ -441,7 +456,7 @@ impl AgentLoop {
 
             // Optionally spawn a StreamConsumer for Telegram streaming display
             let stream_consumer_handle = if channel_streaming && use_streaming {
-                self.spawn_stream_consumer(&msg.chat_id)
+                self.spawn_stream_consumer(&session_key, &msg.chat_id)
             } else {
                 None
             };
@@ -517,9 +532,6 @@ impl AgentLoop {
 
                 runner_with_events.run(system_prompt, messages).await
             };
-
-            // Clean up active session
-            self.active_sessions.remove(&session_key);
 
             // Wait for stream consumer to finish and get the delivered message id
             let stream_delivered_msg_id = if let Some(handle) = stream_consumer_handle {
@@ -752,9 +764,14 @@ impl AgentLoop {
                 }
             }
 
-            // Drain pending messages for this session
-            if let Some((_, pending)) = self.pending_messages.remove(&session_key) {
-                let _ = self.process_message(pending).await;
+            // Drain pending message BEFORE removing active session.
+            // This prevents a race where a new inbound message arrives between
+            // remove() and the pending drain — it would see no active session
+            // and start a concurrent process_message.
+            let pending = self.pending_messages.remove(&session_key);
+            self.active_sessions.remove(&session_key);
+            if let Some((_, pending_msg)) = pending {
+                let _ = self.process_message(pending_msg).await;
             }
 
             Ok(())
@@ -897,13 +914,20 @@ impl AgentLoop {
     /// Returns a JoinHandle that resolves to (final_text, message_id) when done.
     fn spawn_stream_consumer(
         &self,
+        session_key: &str,
         chat_id: &str,
     ) -> Option<tokio::task::JoinHandle<(String, Option<String>)>> {
         let channel = self.telegram_channel.clone()?;
         let stream_rx = self.bus.subscribe_stream();
         let cfg = StreamingConfig::default();
 
-        let consumer = StreamConsumer::new(channel, chat_id.to_string(), cfg, stream_rx);
+        let consumer = StreamConsumer::new(
+            channel,
+            chat_id.to_string(),
+            session_key.to_string(),
+            cfg,
+            stream_rx,
+        );
         let handle = tokio::spawn(async move { consumer.run().await });
 
         Some(handle)

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -32,6 +32,8 @@ pub struct AgentRunner {
     session_key: Option<String>,
     /// Full-chain trace ID propagated from the originating inbound message.
     trace_id: Option<String>,
+    /// Cancellation token for graceful abort via /stop.
+    cancel_token: Option<tokio_util::sync::CancellationToken>,
 }
 
 impl AgentRunner {
@@ -49,6 +51,7 @@ impl AgentRunner {
             mutating_guard: Arc::new(Mutex::new(())),
             session_key: None,
             trace_id: None,
+            cancel_token: None,
         }
     }
 
@@ -73,6 +76,12 @@ impl AgentRunner {
     /// Set the trace ID for full-chain correlation.
     pub fn with_trace_id(mut self, id: impl Into<String>) -> Self {
         self.trace_id = Some(id.into());
+        self
+    }
+
+    /// Set a cancellation token for graceful abort.
+    pub fn with_cancel_token(mut self, token: tokio_util::sync::CancellationToken) -> Self {
+        self.cancel_token = Some(token);
         self
     }
 
@@ -129,6 +138,21 @@ impl AgentRunner {
         let use_streaming = self.stream_tx.is_some();
 
         for iteration in 0..max_iterations {
+            // Check for cancellation between iterations
+            if let Some(ref token) = self.cancel_token {
+                if token.is_cancelled() {
+                    info!("Agent run cancelled at iteration {}", iteration + 1);
+                    self.emit_stream_chunk(String::new(), true);
+                    return Ok(RunResult {
+                        content: "Agent run was cancelled.".to_string(),
+                        usage: total_usage,
+                        tool_calls_made,
+                        iterations_used: iteration,
+                        hit_limit: false,
+                    });
+                }
+            }
+
             debug!("Agent iteration {}/{}", iteration + 1, max_iterations);
 
             let request = CompletionRequest {

--- a/crates/kestrel-bus/src/events.rs
+++ b/crates/kestrel-bus/src/events.rs
@@ -155,6 +155,11 @@ pub enum AgentEvent {
         trace_id: Option<String>,
     },
 
+    /// External interrupt request (e.g. /stop from Telegram).
+    /// Emitted directly on the bus event channel to bypass the mpsc inbound
+    /// bottleneck, allowing cancellation even while an agent run is in progress.
+    InterruptRequested { session_key: String },
+
     /// A cron job fired.
     CronFired {
         job_id: String,

--- a/crates/kestrel-channels/src/base.rs
+++ b/crates/kestrel-channels/src/base.rs
@@ -90,6 +90,30 @@ pub trait BaseChannel: Send + Sync {
         caption: Option<&str>,
     ) -> Result<SendResult>;
 
+    /// Edit an existing message's content.
+    ///
+    /// Default no-op — platforms that don't support editing can ignore this.
+    async fn edit_message(
+        &self,
+        _chat_id: &str,
+        _message_id: &str,
+        _content: &str,
+    ) -> Result<SendResult> {
+        Ok(SendResult {
+            success: false,
+            message_id: None,
+            error: Some("edit_message not supported".to_string()),
+            retryable: false,
+        })
+    }
+
+    /// Delete a message.
+    ///
+    /// Default no-op — platforms that don't support deletion can ignore this.
+    async fn delete_message(&self, _chat_id: &str, _message_id: &str) -> Result<bool> {
+        Ok(false)
+    }
+
     /// Set the message handler for inbound messages.
     fn set_message_handler(&mut self, handler: tokio::sync::mpsc::Sender<InboundMessage>);
 }

--- a/crates/kestrel-channels/src/lib.rs
+++ b/crates/kestrel-channels/src/lib.rs
@@ -7,6 +7,7 @@ pub mod commands;
 pub mod manager;
 pub mod platforms;
 pub mod registry;
+pub mod stream_consumer;
 
 pub use base::BaseChannel;
 pub use commands::{
@@ -21,6 +22,7 @@ pub use platforms::telegram::{
 };
 pub use platforms::websocket::{run_ws_stream_consumer, WebSocketChannel};
 pub use registry::ChannelRegistry;
+pub use stream_consumer::{split_message, StreamConsumer};
 
 #[cfg(test)]
 pub(crate) mod test_support {

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -840,6 +840,10 @@ impl TelegramChannel {
                 command: "menu".to_string(),
                 description: "Open the menu".to_string(),
             },
+            BotCommand {
+                command: "stop".to_string(),
+                description: "Stop current generation".to_string(),
+            },
         ]
     }
 
@@ -1954,6 +1958,82 @@ impl BaseChannel for TelegramChannel {
     fn set_message_handler(&mut self, handler: tokio::sync::mpsc::Sender<InboundMessage>) {
         self.message_handler = Some(handler);
     }
+
+    async fn edit_message(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        content: &str,
+    ) -> Result<SendResult> {
+        let result = self
+            .edit_message_text(chat_id, message_id, content, None)
+            .await?;
+
+        // "message is not modified" is not a real failure — content unchanged.
+        if !result.success {
+            if let Some(ref err) = result.error {
+                if err.contains("not modified") {
+                    return Ok(SendResult {
+                        success: true,
+                        message_id: Some(message_id.to_string()),
+                        error: None,
+                        retryable: false,
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    async fn delete_message(&self, chat_id: &str, message_id: &str) -> Result<bool> {
+        debug!(
+            "Deleting Telegram message {} in chat {}",
+            message_id, chat_id
+        );
+
+        let chat_id_num: i64 = match chat_id.parse() {
+            Ok(n) => n,
+            Err(_) => return Ok(false),
+        };
+        let message_id_num: i64 = match message_id.parse() {
+            Ok(n) => n,
+            Err(_) => return Ok(false),
+        };
+
+        #[derive(Debug, Serialize)]
+        struct DeleteMessageBody {
+            chat_id: i64,
+            message_id: i64,
+        }
+
+        let url = self.api_url("deleteMessage");
+        let resp = match self
+            .client
+            .post(&url)
+            .json(&DeleteMessageBody {
+                chat_id: chat_id_num,
+                message_id: message_id_num,
+            })
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(_) => return Ok(false),
+        };
+
+        #[derive(Debug, Deserialize)]
+        struct TgBoolResult {
+            #[allow(dead_code)]
+            ok: bool,
+        }
+        let tg_resp: TgResponse<TgBoolResult> = match resp.json().await {
+            Ok(r) => r,
+            Err(_) => return Ok(false),
+        };
+
+        Ok(tg_resp.ok)
+    }
 }
 
 impl TelegramChannel {
@@ -2038,10 +2118,22 @@ impl TelegramChannel {
                 retryable: false,
             })
         } else {
+            let err = tg_resp.description.unwrap_or_default();
+
+            // Flood control: retryable error
+            if err.contains("FLOOD_WAIT") || err.contains("retry after") {
+                return Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(err),
+                    retryable: true,
+                });
+            }
+
             Ok(SendResult {
                 success: false,
                 message_id: None,
-                error: tg_resp.description,
+                error: Some(err),
                 retryable: false,
             })
         }

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1754,6 +1754,7 @@ impl BaseChannel for TelegramChannel {
             let running = self.running.clone();
             let router = self.router.clone();
             let proxy_config = self.proxy_config.clone();
+            let event_tx = self.event_tx.clone();
 
             tokio::spawn(async move {
                 Self::poll_loop(
@@ -1763,7 +1764,7 @@ impl BaseChannel for TelegramChannel {
                     running,
                     router,
                     proxy_config,
-                    self.event_tx.clone(),
+                    event_tx,
                 )
                 .await;
             });
@@ -2062,7 +2063,7 @@ impl BaseChannel for TelegramChannel {
             Err(_) => return Ok(false),
         };
 
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, Default, Deserialize)]
         struct TgBoolResult {
             #[allow(dead_code)]
             ok: bool,

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -554,6 +554,8 @@ pub struct TelegramChannel {
     online_notify: bool,
     notify_chat_id: Option<String>,
     online_message_template: String,
+    /// Broadcast sender for emitting agent events (e.g. InterruptRequested for /stop).
+    event_tx: Option<tokio::sync::broadcast::Sender<kestrel_bus::events::AgentEvent>>,
 }
 
 impl TelegramChannel {
@@ -663,6 +665,7 @@ impl TelegramChannel {
             online_notify: false,
             notify_chat_id: None,
             online_message_template: String::new(),
+            event_tx: None,
         }
     }
 
@@ -703,6 +706,7 @@ impl TelegramChannel {
             online_notify: notifications.online_notify,
             notify_chat_id: notifications.notify_chat_id.clone(),
             online_message_template: notifications.online_message.clone(),
+            event_tx: None,
         }
     }
 
@@ -726,6 +730,7 @@ impl TelegramChannel {
             online_notify: false,
             notify_chat_id: None,
             online_message_template: String::new(),
+            event_tx: None,
         }
     }
 
@@ -751,6 +756,17 @@ impl TelegramChannel {
         template
             .replace("{version}", env!("CARGO_PKG_VERSION"))
             .replace("{channel}", channel)
+    }
+
+    /// Set the broadcast sender for emitting agent events.
+    ///
+    /// Used for /stop interrupt: the poll loop emits `InterruptRequested`
+    /// directly on this channel, bypassing the mpsc inbound bottleneck.
+    pub fn set_event_tx(
+        &mut self,
+        tx: tokio::sync::broadcast::Sender<kestrel_bus::events::AgentEvent>,
+    ) {
+        self.event_tx = Some(tx);
     }
 
     fn online_notification_payload(&self) -> Option<(String, String)> {
@@ -956,6 +972,7 @@ impl TelegramChannel {
         running: Arc<AtomicBool>,
         router: Arc<tokio::sync::Mutex<CallbackRouter>>,
         proxy_config: Option<String>,
+        event_tx: Option<tokio::sync::broadcast::Sender<kestrel_bus::events::AgentEvent>>,
     ) {
         let base_url = format!("https://api.telegram.org/bot{}", token);
         let mut offset: Option<i64> = None;
@@ -1067,6 +1084,20 @@ impl TelegramChannel {
 
                 if let Some(msg) = update.message {
                     let text = msg.text.as_deref().unwrap_or("");
+
+                    // /stop: emit InterruptRequested directly on the event bus
+                    // to bypass the mpsc sequential bottleneck, then also
+                    // dispatch through the normal path so process_message can
+                    // send the "Stopped." reply.
+                    if crate::commands::matches_command(text, "stop") {
+                        let session_key = format!("telegram:{}", msg.chat.id);
+                        if let Some(ref tx) = event_tx {
+                            let _ = tx.send(kestrel_bus::events::AgentEvent::InterruptRequested {
+                                session_key: session_key.clone(),
+                            });
+                        }
+                    }
+
                     // /reset needs the session key, so handle it separately.
                     if crate::commands::matches_command(text, "reset") {
                         let session_key = format!("telegram:{}", msg.chat.id);
@@ -1725,7 +1756,16 @@ impl BaseChannel for TelegramChannel {
             let proxy_config = self.proxy_config.clone();
 
             tokio::spawn(async move {
-                Self::poll_loop(client, token, handler, running, router, proxy_config).await;
+                Self::poll_loop(
+                    client,
+                    token,
+                    handler,
+                    running,
+                    router,
+                    proxy_config,
+                    self.event_tx.clone(),
+                )
+                .await;
             });
 
             info!("Telegram channel connected — polling started");

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -1,0 +1,377 @@
+//! Stream consumer — bridges streaming chunks to platform message editing.
+//!
+//! Subscribes to `StreamChunk` broadcast, accumulates text, rate-limits edits,
+//! and calls `edit_message` on the platform adapter. Ported from Hermes
+//! `gateway/stream_consumer.py`.
+
+use std::sync::Arc;
+
+use kestrel_bus::events::StreamChunk;
+use kestrel_config::schema::StreamingConfig;
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use crate::base::BaseChannel;
+
+const TG_MAX_MESSAGE_LENGTH: usize = 4096;
+const MAX_FLOOD_STRIKES: u32 = 3;
+
+const OPEN_THINK_TAGS: &[&str] = &[
+    "<REASONING_SCRATCHPAD>",
+    "\u{1f9e0}",
+    "<reasoning>",
+    "<THINKING>",
+    "<thinking>",
+    "<thought>",
+];
+
+const CLOSE_THINK_TAGS: &[&str] = &[
+    "</REASONING_SCRATCHPAD>",
+    "\u{1fae0}",
+    "</reasoning>",
+    "</THINKING>",
+    "</thinking>",
+    "</thought>",
+];
+
+/// Manages progressive editing of a single platform message during streaming.
+pub struct StreamConsumer {
+    channel: Arc<dyn BaseChannel>,
+    chat_id: String,
+    cfg: StreamingConfig,
+    stream_rx: broadcast::Receiver<StreamChunk>,
+    accumulated: String,
+    message_id: Option<String>,
+    last_sent_text: String,
+    last_edit_time: std::time::Instant,
+    edit_supported: bool,
+    flood_strikes: u32,
+    current_edit_interval: f64,
+    in_think_block: bool,
+    think_buffer: String,
+}
+
+impl StreamConsumer {
+    /// Create a new stream consumer.
+    pub fn new(
+        channel: Arc<dyn BaseChannel>,
+        chat_id: String,
+        cfg: StreamingConfig,
+        stream_rx: broadcast::Receiver<StreamChunk>,
+    ) -> Self {
+        let current_edit_interval = cfg.edit_interval;
+        Self {
+            channel,
+            chat_id,
+            cfg,
+            stream_rx,
+            accumulated: String::new(),
+            message_id: None,
+            last_sent_text: String::new(),
+            last_edit_time: std::time::Instant::now() - std::time::Duration::from_secs(3600),
+            edit_supported: true,
+            flood_strikes: 0,
+            current_edit_interval,
+            in_think_block: false,
+            think_buffer: String::new(),
+        }
+    }
+
+    /// Run the consumer until the stream completes.
+    ///
+    /// Returns the final accumulated text and the message_id of the last
+    /// edited/sent message (used by the caller to suppress duplicate sends).
+    pub async fn run(mut self) -> (String, Option<String>) {
+        let safe_limit = TG_MAX_MESSAGE_LENGTH
+            .saturating_sub(self.cfg.cursor.len())
+            .saturating_sub(100)
+            .max(500);
+
+        loop {
+            // Drain all available chunks
+            let mut got_done = false;
+            loop {
+                match self.stream_rx.try_recv() {
+                    Ok(chunk) => {
+                        if chunk.done {
+                            got_done = true;
+                        } else {
+                            self.filter_and_accumulate(&chunk.content);
+                        }
+                    }
+                    Err(broadcast::error::TryRecvError::Empty) => break,
+                    Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                        debug!("Stream consumer lagged by {n} chunks");
+                        break;
+                    }
+                    Err(broadcast::error::TryRecvError::Closed) => {
+                        got_done = true;
+                        break;
+                    }
+                }
+            }
+
+            if got_done {
+                self.flush_think_buffer();
+            }
+
+            let elapsed = self.last_edit_time.elapsed().as_secs_f64();
+            let should_edit = got_done
+                || (elapsed >= self.current_edit_interval && !self.accumulated.is_empty())
+                || self.accumulated.len() >= self.cfg.buffer_threshold;
+
+            if should_edit && !self.accumulated.is_empty() {
+                // Handle oversized messages: split into chunks
+                while self.accumulated.len() > safe_limit && self.edit_supported {
+                    let split_at = self
+                        .accumulated
+                        .rfind('\n', safe_limit)
+                        .unwrap_or(safe_limit);
+                    let chunk = self.accumulated[..split_at].to_string();
+                    let ok = self.send_or_edit(&chunk, false).await;
+                    if !ok {
+                        break;
+                    }
+                    self.accumulated = self.accumulated[split_at..]
+                        .trim_start_matches('\n')
+                        .to_string();
+                    self.message_id = None;
+                    self.last_sent_text = String::new();
+                }
+
+                let mut display_text = self.accumulated.clone();
+                if !got_done {
+                    display_text.push_str(&self.cfg.cursor);
+                }
+
+                self.send_or_edit(&display_text, got_done).await;
+                self.last_edit_time = std::time::Instant::now();
+            }
+
+            if got_done {
+                let msg_id = self.message_id.clone();
+                return (self.accumulated.clone(), msg_id);
+            }
+
+            // Wait for the next chunk or the edit interval
+            let interval = std::time::Duration::from_millis(50);
+            tokio::time::sleep(interval).await;
+        }
+    }
+
+    /// Handle a segment break: finalize the current message and reset state
+    /// so the next chunk creates a fresh message.
+    pub fn reset_segment(&mut self) {
+        self.message_id = None;
+        self.accumulated = String::new();
+        self.last_sent_text = String::new();
+    }
+
+    /// Get the current accumulated text.
+    pub fn accumulated(&self) -> &str {
+        &self.accumulated
+    }
+
+    /// Send or edit the message on the platform. Returns true on success.
+    async fn send_or_edit(&mut self, text: &str, _finalize: bool) -> bool {
+        let visible_without_cursor = text.replace(&self.cfg.cursor, "");
+        if visible_without_cursor.trim().is_empty() {
+            return true;
+        }
+
+        // Guard: don't create a brand-new message when the only visible content
+        // is a handful of characters alongside the cursor.
+        if self.message_id.is_none()
+            && self.cfg.cursor.contains('\u{2589}')
+            && text.contains(&self.cfg.cursor)
+            && visible_without_cursor.trim().len() < 4
+        {
+            return true;
+        }
+
+        if let Some(ref mid) = self.message_id {
+            if self.edit_supported {
+                if text == self.last_sent_text {
+                    return true;
+                }
+                let result = self.channel.edit_message(&self.chat_id, mid, text).await;
+
+                match result {
+                    Ok(r) if r.success => {
+                        self.last_sent_text = text.to_string();
+                        self.flood_strikes = 0;
+                        return true;
+                    }
+                    Ok(r) => {
+                        let is_flood = r
+                            .error
+                            .as_deref()
+                            .map(|e| {
+                                let e = e.to_lowercase();
+                                e.contains("flood") || e.contains("retry after")
+                            })
+                            .unwrap_or(false);
+
+                        if is_flood {
+                            self.flood_strikes += 1;
+                            self.current_edit_interval =
+                                (self.current_edit_interval * 2.0).min(10.0);
+                            debug!(
+                                "Flood control on edit (strike {}/{}), backoff → {:.1}s",
+                                self.flood_strikes, MAX_FLOOD_STRIKES, self.current_edit_interval
+                            );
+                            if self.flood_strikes < MAX_FLOOD_STRIKES {
+                                self.last_edit_time = std::time::Instant::now();
+                                return false;
+                            }
+                        }
+
+                        // Non-flood or strikes exhausted: enter fallback mode
+                        debug!(
+                            "Edit failed (strikes={}), entering fallback mode",
+                            self.flood_strikes
+                        );
+                        self.edit_supported = false;
+                        return false;
+                    }
+                    Err(e) => {
+                        warn!("Edit message error: {e}");
+                        self.edit_supported = false;
+                        return false;
+                    }
+                }
+            } else {
+                return false;
+            }
+        } else {
+            // First message — send new
+            let result = self.channel.send_message(&self.chat_id, text, None).await;
+
+            match result {
+                Ok(r) if r.success => {
+                    if let Some(mid) = &r.message_id {
+                        self.message_id = Some(mid.clone());
+                    } else {
+                        self.edit_supported = false;
+                    }
+                    self.last_sent_text = text.to_string();
+                    return true;
+                }
+                Ok(_) => {
+                    self.edit_supported = false;
+                    return false;
+                }
+                Err(e) => {
+                    warn!("Stream send error: {e}");
+                    self.edit_supported = false;
+                    return false;
+                }
+            }
+        }
+    }
+
+    /// Filter think/reasoning blocks from the text and accumulate.
+    fn filter_and_accumulate(&mut self, text: &str) {
+        let buf = std::mem::take(&mut self.think_buffer) + text;
+
+        let mut remaining = buf.as_str();
+        while !remaining.is_empty() {
+            if self.in_think_block {
+                let (idx, len) = find_earliest_tag(remaining, CLOSE_THINK_TAGS);
+                if len > 0 {
+                    self.in_think_block = false;
+                    remaining = &remaining[idx + len..];
+                } else {
+                    let max_tag = max_tag_len(CLOSE_THINK_TAGS);
+                    if remaining.len() > max_tag {
+                        self.think_buffer = remaining[remaining.len() - max_tag..].to_string();
+                    } else {
+                        self.think_buffer = remaining.to_string();
+                    }
+                    return;
+                }
+            } else {
+                let (idx, len) = find_earliest_tag(remaining, OPEN_THINK_TAGS);
+                if len > 0 {
+                    // Emit text before the tag
+                    self.accumulated.push_str(&remaining[..idx]);
+                    self.in_think_block = true;
+                    remaining = &remaining[idx + len..];
+                } else {
+                    // Check for partial tag at the tail
+                    let held_back = find_partial_tag_suffix(remaining, OPEN_THINK_TAGS);
+                    if held_back > 0 {
+                        self.accumulated
+                            .push_str(&remaining[..remaining.len() - held_back]);
+                        self.think_buffer = remaining[remaining.len() - held_back..].to_string();
+                    } else {
+                        self.accumulated.push_str(remaining);
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Flush any held-back partial tag buffer.
+    fn flush_think_buffer(&mut self) {
+        if !self.think_buffer.is_empty() && !self.in_think_block {
+            self.accumulated.push_str(&self.think_buffer);
+            self.think_buffer.clear();
+        }
+    }
+}
+
+fn find_earliest_tag<'a>(text: &str, tags: &[&'a str]) -> (usize, usize) {
+    let mut best_idx = usize::MAX;
+    let mut best_len = 0;
+    for tag in tags {
+        if let Some(idx) = text.find(tag) {
+            if idx < best_idx {
+                best_idx = idx;
+                best_len = tag.len();
+            }
+        }
+    }
+    if best_len > 0 {
+        (best_idx, best_len)
+    } else {
+        (0, 0)
+    }
+}
+
+fn max_tag_len(tags: &[&str]) -> usize {
+    tags.iter().map(|t| t.len()).max().unwrap_or(0)
+}
+
+fn find_partial_tag_suffix(text: &str, tags: &[&str]) -> usize {
+    let mut held = 0;
+    for tag in tags {
+        for i in 1..=tag.len().min(text.len()) {
+            if text.ends_with(&tag[..i]) && i > held {
+                held = i;
+            }
+        }
+    }
+    held
+}
+
+/// Split text into chunks that fit within `limit` characters, respecting
+/// newline boundaries.
+pub fn split_message(text: &str, limit: usize) -> Vec<String> {
+    if text.len() <= limit {
+        return vec![text.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut remaining = text;
+    while remaining.len() > limit {
+        let split_at = remaining.rfind('\n', limit).unwrap_or(limit);
+        chunks.push(remaining[..split_at].to_string());
+        remaining = remaining[split_at..].trim_start_matches('\n');
+    }
+    if !remaining.is_empty() {
+        chunks.push(remaining.to_string());
+    }
+    chunks
+}

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -197,7 +197,7 @@ impl StreamConsumer {
                     Ok(r) if r.success => {
                         self.last_sent_text = text.to_string();
                         self.flood_strikes = 0;
-                        return true;
+                        true
                     }
                     Ok(r) => {
                         let is_flood = r
@@ -229,16 +229,16 @@ impl StreamConsumer {
                             self.flood_strikes
                         );
                         self.edit_supported = false;
-                        return false;
+                        false
                     }
                     Err(e) => {
                         warn!("Edit message error: {e}");
                         self.edit_supported = false;
-                        return false;
+                        false
                     }
                 }
             } else {
-                return false;
+                false
             }
         } else {
             // First message — send new

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -252,16 +252,16 @@ impl StreamConsumer {
                         self.edit_supported = false;
                     }
                     self.last_sent_text = text.to_string();
-                    return true;
+                    true
                 }
                 Ok(_) => {
                     self.edit_supported = false;
-                    return false;
+                    false
                 }
                 Err(e) => {
                     warn!("Stream send error: {e}");
                     self.edit_supported = false;
-                    return false;
+                    false
                 }
             }
         }
@@ -319,7 +319,7 @@ impl StreamConsumer {
     }
 }
 
-fn find_earliest_tag<'a>(text: &str, tags: &[&'a str]) -> (usize, usize) {
+fn find_earliest_tag(text: &str, tags: &[&str]) -> (usize, usize) {
     let mut best_idx = usize::MAX;
     let mut best_len = 0;
     for tag in tags {

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -130,10 +130,8 @@ impl StreamConsumer {
             if should_edit && !self.accumulated.is_empty() {
                 // Handle oversized messages: split into chunks
                 while self.accumulated.len() > safe_limit && self.edit_supported {
-                    let split_at = self
-                        .accumulated
-                        .rfind('\n', safe_limit)
-                        .unwrap_or(safe_limit);
+                    let limit = safe_limit.min(self.accumulated.len());
+                    let split_at = self.accumulated[..limit].rfind('\n').unwrap_or(limit);
                     let chunk = self.accumulated[..split_at].to_string();
                     let ok = self.send_or_edit(&chunk, false).await;
                     if !ok {
@@ -365,7 +363,8 @@ pub fn split_message(text: &str, limit: usize) -> Vec<String> {
     let mut chunks = Vec::new();
     let mut remaining = text;
     while remaining.len() > limit {
-        let split_at = remaining.rfind('\n', limit).unwrap_or(limit);
+        let cap = limit.min(remaining.len());
+        let split_at = remaining[..cap].rfind('\n').unwrap_or(cap);
         chunks.push(remaining[..split_at].to_string());
         remaining = remaining[split_at..].trim_start_matches('\n');
     }

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -38,6 +38,7 @@ const CLOSE_THINK_TAGS: &[&str] = &[
 pub struct StreamConsumer {
     channel: Arc<dyn BaseChannel>,
     chat_id: String,
+    session_key: String,
     cfg: StreamingConfig,
     stream_rx: broadcast::Receiver<StreamChunk>,
     accumulated: String,
@@ -56,6 +57,7 @@ impl StreamConsumer {
     pub fn new(
         channel: Arc<dyn BaseChannel>,
         chat_id: String,
+        session_key: String,
         cfg: StreamingConfig,
         stream_rx: broadcast::Receiver<StreamChunk>,
     ) -> Self {
@@ -63,6 +65,7 @@ impl StreamConsumer {
         Self {
             channel,
             chat_id,
+            session_key,
             cfg,
             stream_rx,
             accumulated: String::new(),
@@ -88,11 +91,15 @@ impl StreamConsumer {
             .max(500);
 
         loop {
-            // Drain all available chunks
+            // Drain all available chunks, filtering by session_key
             let mut got_done = false;
             loop {
                 match self.stream_rx.try_recv() {
                     Ok(chunk) => {
+                        // Drop chunks from other sessions
+                        if chunk.session_key != self.session_key {
+                            continue;
+                        }
                         if chunk.done {
                             got_done = true;
                         } else {
@@ -157,14 +164,6 @@ impl StreamConsumer {
             let interval = std::time::Duration::from_millis(50);
             tokio::time::sleep(interval).await;
         }
-    }
-
-    /// Handle a segment break: finalize the current message and reset state
-    /// so the next chunk creates a fresh message.
-    pub fn reset_segment(&mut self) {
-        self.message_id = None;
-        self.accumulated = String::new();
-        self.last_sent_text = String::new();
     }
 
     /// Get the current accumulated text.

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -587,6 +587,52 @@ impl Default for AgentDefaults {
     }
 }
 
+/// Streaming display configuration for real-time message editing.
+///
+/// Controls how streamed tokens are rate-limited and displayed on chat platforms.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StreamingConfig {
+    /// Minimum seconds between successive edit-message calls.
+    #[serde(default = "default_edit_interval")]
+    pub edit_interval: f64,
+
+    /// Minimum accumulated characters before triggering an edit.
+    #[serde(default = "default_buffer_threshold")]
+    pub buffer_threshold: usize,
+
+    /// Cursor string appended during active streaming (e.g. " ▉").
+    #[serde(default = "default_cursor")]
+    pub cursor: String,
+
+    /// When >0, the final edit is sent as a fresh message if the original
+    /// preview has been visible for at least this many seconds.
+    /// Default 0 = always edit in place.
+    #[serde(default)]
+    pub fresh_final_after_seconds: f64,
+}
+
+impl Default for StreamingConfig {
+    fn default() -> Self {
+        Self {
+            edit_interval: default_edit_interval(),
+            buffer_threshold: default_buffer_threshold(),
+            cursor: default_cursor(),
+            fresh_final_after_seconds: 0.0,
+        }
+    }
+}
+
+fn default_edit_interval() -> f64 {
+    1.0
+}
+fn default_buffer_threshold() -> usize {
+    40
+}
+fn default_cursor() -> String {
+    " ▉".to_string()
+}
+
 /// Dream (memory consolidation) configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
## Summary
- Implement real-time Telegram streaming via progressive `editMessageText` with rate limiting, think-block filtering, and flood control adaptive backoff
- Add tool-call progress display (`Using \`shell\` tool...`) messages during agent execution
- Add `/stop` command to cancel in-progress agent runs with session locking and pending message queue
- Add `CancellationToken` support to `AgentRunner` for graceful abort between iterations
- Extend `BaseChannel` trait with `edit_message`/`delete_message` defaults
- Add `StreamingConfig` to `schema.rs` with configurable edit interval, buffer threshold, and cursor

## Test plan
- [ ] Verify Telegram streaming works with `streaming: true` in Telegram config
- [ ] Verify non-streaming mode is unaffected (backwards compatible)
- [ ] Verify `/stop` cancels an active agent run and responds appropriately
- [ ] Verify `/stop` when idle returns "Nothing to stop."
- [ ] Verify tool progress messages appear during agent execution
- [ ] CI compiles and passes all existing tests

Closes #171

Bahtya