### PR TITLE
feat: TG streaming (alternative) — event-based /stop, CancelRegistry, session-isolated StreamConsumer

### DIFF
--- a/crates/kestrel-agent/Cargo.toml
+++ b/crates/kestrel-agent/Cargo.toml
@@ -16,6 +16,7 @@ kestrel-heartbeat = { path = "../kestrel-heartbeat" }
 kestrel-skill = { path = "../kestrel-skill" }
 kestrel-learning = { path = "../kestrel-learning" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/kestrel-agent/src/cancel_registry.rs
+++ b/crates/kestrel-agent/src/cancel_registry.rs
@@ -1,0 +1,42 @@
+//! Shared cancellation registry for agent run interruption.
+//!
+//! Provides a `CancelRegistry` that both the agent loop and channel
+//! adapters can access. When a user sends `/stop`, the channel adapter
+//! looks up the session's cancellation token and triggers it.
+
+use dashmap::DashMap;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+/// Shared registry mapping session keys to cancellation tokens.
+#[derive(Debug, Clone, Default)]
+pub struct CancelRegistry {
+    tokens: Arc<DashMap<String, CancellationToken>>,
+}
+
+impl CancelRegistry {
+    /// Create a new empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a cancellation token for a session.
+    pub fn insert(&self, session_key: String, token: CancellationToken) {
+        self.tokens.insert(session_key, token);
+    }
+
+    /// Remove and return the cancellation token for a session.
+    pub fn remove(&self, session_key: &str) -> Option<CancellationToken> {
+        self.tokens.remove(session_key).map(|(_, v)| v)
+    }
+
+    /// Cancel the running agent for a session. Returns true if a token was found.
+    pub fn cancel(&self, session_key: &str) -> bool {
+        if let Some(token) = self.tokens.get(session_key) {
+            token.cancel();
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/crates/kestrel-agent/src/lib.rs
+++ b/crates/kestrel-agent/src/lib.rs
@@ -3,6 +3,7 @@
 //! Agent loop, runner, context building, skills, subagents, and hooks.
 //! Memory operations are provided by the [`kestrel_memory`] crate.
 
+pub mod cancel_registry;
 pub mod compaction;
 pub mod context;
 pub mod context_budget;
@@ -14,6 +15,7 @@ pub mod runner;
 pub mod skills;
 pub mod subagent;
 
+pub use cancel_registry::CancelRegistry;
 pub use compaction::{compact_session, CompactionConfig, CompactionResult, CompactionStrategy};
 pub use context::ContextBuilder;
 pub use context_budget::{

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -6,6 +6,7 @@
 //! loop spawns a background [`HeartbeatService`] that periodically checks
 //! all component health.
 
+use crate::cancel_registry::CancelRegistry;
 use crate::compaction::{compact_session, CompactionConfig};
 use crate::context::ContextBuilder;
 use crate::heartbeat::{
@@ -34,6 +35,7 @@ use kestrel_tools::ToolRegistry;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn, Instrument};
 
 const REFLECTION_MAX_RETRIES: u32 = 2;
@@ -111,6 +113,9 @@ pub struct AgentLoop {
     audit_callback: Option<AuditCallback>,
     /// Consecutive reflection failure count for escalating log level.
     consecutive_reflection_failures: Arc<std::sync::atomic::AtomicU32>,
+    /// Active cancellation tokens, keyed by session_key.
+    /// Shared with channel adapters so they can cancel running agents on /stop.
+    cancel_registry: CancelRegistry,
 }
 
 impl AgentLoop {
@@ -141,6 +146,7 @@ impl AgentLoop {
             prompt_assembler: None,
             audit_callback: None,
             consecutive_reflection_failures: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            cancel_registry: CancelRegistry::new(),
         }
     }
 
@@ -155,6 +161,27 @@ impl AgentLoop {
         drop(running);
 
         info!("Agent loop started");
+
+        // Spawn a background listener for interrupt events.
+        // This runs independently of the main message processing loop
+        // so /stop can cancel a running agent even while process_message is busy.
+        {
+            let cancel_registry = self.cancel_registry.clone();
+            let mut event_rx = self.bus.subscribe_events();
+            let running = self.running.clone();
+            tokio::spawn(async move {
+                while *running.read().await {
+                    match event_rx.recv().await {
+                        Ok(AgentEvent::InterruptRequested { session_key, .. }) => {
+                            cancel_registry.cancel(&session_key);
+                        }
+                        Ok(_) => {}
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            });
+        }
 
         // Start heartbeat service if enabled
         let heartbeat_handle = if self.config.heartbeat.enabled {
@@ -176,6 +203,31 @@ impl AgentLoop {
                 Some(msg) => {
                     // Record activity for heartbeat tracking
                     *self.agent_activity.write() = Some(chrono::Local::now());
+
+                    // Handle /stop: cancel the running agent for this session
+                    // without queuing behind the current process_message call.
+                    if msg.content.trim().eq_ignore_ascii_case("/stop") {
+                        let session_key = msg.session_key();
+                        let cancelled = self.cancel_session(&session_key);
+                        let reply = if cancelled {
+                            "Stopped.".to_string()
+                        } else {
+                            "Nothing to stop.".to_string()
+                        };
+                        let stop_reply = OutboundMessage {
+                            channel: msg.channel,
+                            chat_id: msg.chat_id,
+                            content: reply,
+                            reply_to: msg.message_id,
+                            trace_id: msg.trace_id,
+                            media: vec![],
+                            metadata: Default::default(),
+                        };
+                        if let Err(e) = self.bus.publish_outbound(stop_reply).await {
+                            error!("Failed to send /stop reply: {}", e);
+                        }
+                        continue;
+                    }
 
                     // Extract fields before msg is moved into process_message,
                     // so the timeout branch can still build a reply.
@@ -360,6 +412,12 @@ impl AgentLoop {
             // Run agent with events wired through
             let messages = session.to_messages();
             let run_start = std::time::Instant::now();
+
+            // Create a cancellation token for this session
+            let cancel_token = CancellationToken::new();
+            self.cancel_registry
+                .insert(session_key.clone(), cancel_token.clone());
+
             let result = {
                 // Build a runner with event callback for this session
                 let event_bus = bus_for_stream.clone();
@@ -372,7 +430,8 @@ impl AgentLoop {
                     self.tool_registry.clone(),
                 )
                 .with_session_key(&session_key_for_runner)
-                .with_trace_id(trace_id_for_runner.clone().unwrap_or_default());
+                .with_trace_id(trace_id_for_runner.clone().unwrap_or_default())
+                .with_cancel_token(cancel_token.clone());
 
                 if self.config.agent.streaming {
                     runner_with_events =
@@ -414,6 +473,9 @@ impl AgentLoop {
 
                 runner_with_events.run(system_prompt, messages).await
             };
+
+            // Clean up the cancellation token for this session
+            self.cancel_registry.remove(&session_key);
 
             match result {
                 Ok(result) => {
@@ -482,24 +544,29 @@ impl AgentLoop {
                         }
                     }
 
-                    // Send outbound message
+                    // Send outbound message (unless the run was cancelled —
+                    // the /stop handler already sent a reply).
+                    let was_cancelled = result.content == "(stopped)";
                     let user_msg = msg.content.clone();
                     let result_content = result.content.clone();
                     let tool_calls = result.tool_calls_made;
                     let iterations = result.iterations_used;
-                    let success = !result.hit_limit;
-                    let outbound = OutboundMessage {
-                        channel: msg.channel.clone(),
-                        chat_id: msg.chat_id.clone(),
-                        content: result.content,
-                        reply_to: msg.message_id.clone(),
-                        trace_id: msg.trace_id.clone(),
-                        media: vec![],
-                        metadata: Default::default(),
-                    };
+                    let success = !result.hit_limit && !was_cancelled;
 
-                    if let Err(e) = self.bus.publish_outbound(outbound).await {
-                        error!("Failed to publish outbound message: {}", e);
+                    if !was_cancelled {
+                        let outbound = OutboundMessage {
+                            channel: msg.channel.clone(),
+                            chat_id: msg.chat_id.clone(),
+                            content: result.content,
+                            reply_to: msg.message_id.clone(),
+                            trace_id: msg.trace_id.clone(),
+                            media: vec![],
+                            metadata: Default::default(),
+                        };
+
+                        if let Err(e) = self.bus.publish_outbound(outbound).await {
+                            error!("Failed to publish outbound message: {}", e);
+                        }
                     }
 
                     // Post-task LLM reflection runs in the background after the
@@ -769,6 +836,18 @@ impl AgentLoop {
     pub async fn stop(&self) {
         info!("Stopping agent loop");
         *self.running.write().await = false;
+    }
+
+    /// Request cancellation of the running agent for a session.
+    ///
+    /// Returns true if a running agent was found and cancelled.
+    pub fn cancel_session(&self, session_key: &str) -> bool {
+        self.cancel_registry.cancel(session_key)
+    }
+
+    /// Get the shared cancel registry (for wiring into channel adapters).
+    pub fn cancel_registry(&self) -> CancelRegistry {
+        self.cancel_registry.clone()
     }
 
     /// Get a reference to the hooks for adding new hooks.

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -13,6 +13,7 @@ use kestrel_tools::ToolRegistry;
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::{broadcast, Mutex};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 /// Callback for emitting events during agent execution.
@@ -32,6 +33,9 @@ pub struct AgentRunner {
     session_key: Option<String>,
     /// Full-chain trace ID propagated from the originating inbound message.
     trace_id: Option<String>,
+    /// Cancellation token — when cancelled, the runner exits at the next
+    /// iteration boundary with a graceful "interrupted" result.
+    cancel_token: Option<CancellationToken>,
 }
 
 impl AgentRunner {
@@ -49,6 +53,7 @@ impl AgentRunner {
             mutating_guard: Arc::new(Mutex::new(())),
             session_key: None,
             trace_id: None,
+            cancel_token: None,
         }
     }
 
@@ -73,6 +78,12 @@ impl AgentRunner {
     /// Set the trace ID for full-chain correlation.
     pub fn with_trace_id(mut self, id: impl Into<String>) -> Self {
         self.trace_id = Some(id.into());
+        self
+    }
+
+    /// Set a cancellation token for interrupting the agent loop.
+    pub fn with_cancel_token(mut self, token: CancellationToken) -> Self {
+        self.cancel_token = Some(token);
         self
     }
 
@@ -129,6 +140,20 @@ impl AgentRunner {
         let use_streaming = self.stream_tx.is_some();
 
         for iteration in 0..max_iterations {
+            // Check cancellation at iteration boundary
+            if let Some(ref token) = self.cancel_token {
+                if token.is_cancelled() {
+                    info!("Agent run cancelled at iteration {}", iteration);
+                    return Ok(RunResult {
+                        content: "(stopped)".to_string(),
+                        usage: total_usage,
+                        tool_calls_made,
+                        iterations_used: iteration,
+                        hit_limit: false,
+                    });
+                }
+            }
+
             debug!("Agent iteration {}/{}", iteration + 1, max_iterations);
 
             let request = CompletionRequest {

--- a/crates/kestrel-bus/src/events.rs
+++ b/crates/kestrel-bus/src/events.rs
@@ -223,6 +223,15 @@ pub enum AgentEvent {
         /// Human-readable detail message.
         message: String,
     },
+
+    /// Request to interrupt a running agent for a session.
+    /// Emitted when a user sends /stop while an agent run is in progress.
+    InterruptRequested {
+        /// Session to interrupt.
+        session_key: String,
+        /// Trace ID for correlation.
+        trace_id: Option<String>,
+    },
 }
 
 #[cfg(test)]

--- a/crates/kestrel-channels/src/base.rs
+++ b/crates/kestrel-channels/src/base.rs
@@ -82,6 +82,30 @@ pub trait BaseChannel: Send + Sync {
         Ok(())
     }
 
+    /// Edit an existing message's text content.
+    ///
+    /// Default returns unsupported — platforms that support editing should override.
+    async fn edit_message(
+        &self,
+        _chat_id: &str,
+        _message_id: &str,
+        _content: &str,
+    ) -> Result<SendResult> {
+        Ok(SendResult {
+            success: false,
+            message_id: None,
+            error: Some("edit_message not supported".to_string()),
+            retryable: false,
+        })
+    }
+
+    /// Delete a message.
+    ///
+    /// Default returns false — platforms that support deletion should override.
+    async fn delete_message(&self, _chat_id: &str, _message_id: &str) -> Result<bool> {
+        Ok(false)
+    }
+
     /// Send an image.
     async fn send_image(
         &self,

--- a/crates/kestrel-channels/src/lib.rs
+++ b/crates/kestrel-channels/src/lib.rs
@@ -7,6 +7,7 @@ pub mod commands;
 pub mod manager;
 pub mod platforms;
 pub mod registry;
+pub mod stream_consumer;
 
 pub use base::BaseChannel;
 pub use commands::{
@@ -21,6 +22,7 @@ pub use platforms::telegram::{
 };
 pub use platforms::websocket::{run_ws_stream_consumer, WebSocketChannel};
 pub use registry::ChannelRegistry;
+pub use stream_consumer::StreamConsumer;
 
 #[cfg(test)]
 pub(crate) mod test_support {

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -554,6 +554,8 @@ pub struct TelegramChannel {
     online_notify: bool,
     notify_chat_id: Option<String>,
     online_message_template: String,
+    /// Optional bus event sender for emitting interrupt events on /stop.
+    event_tx: Option<tokio::sync::broadcast::Sender<kestrel_bus::events::AgentEvent>>,
 }
 
 impl TelegramChannel {
@@ -663,6 +665,7 @@ impl TelegramChannel {
             online_notify: false,
             notify_chat_id: None,
             online_message_template: String::new(),
+            event_tx: None,
         }
     }
 
@@ -703,6 +706,7 @@ impl TelegramChannel {
             online_notify: notifications.online_notify,
             notify_chat_id: notifications.notify_chat_id.clone(),
             online_message_template: notifications.online_message.clone(),
+            event_tx: None,
         }
     }
 
@@ -726,7 +730,16 @@ impl TelegramChannel {
             online_notify: false,
             notify_chat_id: None,
             online_message_template: String::new(),
+            event_tx: None,
         }
+    }
+
+    /// Set the bus event sender for emitting interrupt events.
+    pub fn set_event_tx(
+        &mut self,
+        tx: tokio::sync::broadcast::Sender<kestrel_bus::events::AgentEvent>,
+    ) {
+        self.event_tx = Some(tx);
     }
 
     /// Create with config-driven notification settings and a custom base URL.
@@ -835,6 +848,10 @@ impl TelegramChannel {
             BotCommand {
                 command: "reset".to_string(),
                 description: "Reset current session".to_string(),
+            },
+            BotCommand {
+                command: "stop".to_string(),
+                description: "Stop current agent run".to_string(),
             },
             BotCommand {
                 command: "menu".to_string(),
@@ -952,6 +969,7 @@ impl TelegramChannel {
         running: Arc<AtomicBool>,
         router: Arc<tokio::sync::Mutex<CallbackRouter>>,
         proxy_config: Option<String>,
+        event_tx_opt: Option<tokio::sync::broadcast::Sender<kestrel_bus::events::AgentEvent>>,
     ) {
         let base_url = format!("https://api.telegram.org/bot{}", token);
         let mut offset: Option<i64> = None;
@@ -1069,6 +1087,27 @@ impl TelegramChannel {
                         let response = crate::commands::handle_reset(&session_key);
                         Self::send_direct_reply(&client, &base_url, msg.chat.id, &response, None)
                             .await;
+                        Self::send_read_receipt(&client, &base_url, msg.chat.id, msg.message_id)
+                            .await;
+                    } else if crate::commands::matches_command(text, "stop") {
+                        // /stop interrupts a running agent for this session.
+                        let session_key = format!("telegram:{}", msg.chat.id);
+                        if let Some(ref event_tx) = event_tx_opt {
+                            let _ = event_tx.send(
+                                kestrel_bus::events::AgentEvent::InterruptRequested {
+                                    session_key: session_key.clone(),
+                                    trace_id: None,
+                                },
+                            );
+                        }
+                        Self::send_direct_reply(
+                            &client,
+                            &base_url,
+                            msg.chat.id,
+                            "Stopping...",
+                            None,
+                        )
+                        .await;
                         Self::send_read_receipt(&client, &base_url, msg.chat.id, msg.message_id)
                             .await;
                     } else if let Some(dispatch) = crate::commands::try_handle_command(text).await {
@@ -1719,9 +1758,19 @@ impl BaseChannel for TelegramChannel {
             let running = self.running.clone();
             let router = self.router.clone();
             let proxy_config = self.proxy_config.clone();
+            let event_tx_opt = self.event_tx.clone();
 
             tokio::spawn(async move {
-                Self::poll_loop(client, token, handler, running, router, proxy_config).await;
+                Self::poll_loop(
+                    client,
+                    token,
+                    handler,
+                    running,
+                    router,
+                    proxy_config,
+                    event_tx_opt,
+                )
+                .await;
             });
 
             info!("Telegram channel connected — polling started");
@@ -1953,6 +2002,147 @@ impl BaseChannel for TelegramChannel {
 
     fn set_message_handler(&mut self, handler: tokio::sync::mpsc::Sender<InboundMessage>) {
         self.message_handler = Some(handler);
+    }
+
+    async fn edit_message(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        content: &str,
+    ) -> Result<SendResult> {
+        debug!("Editing message {} in chat {}", message_id, chat_id);
+
+        let chat_id_num: i64 = match chat_id.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                return Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(format!("invalid chat_id: {chat_id}")),
+                    retryable: false,
+                });
+            }
+        };
+
+        let message_id_num: i64 = match message_id.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                return Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(format!("invalid message_id: {message_id}")),
+                    retryable: false,
+                });
+            }
+        };
+
+        let (text, parse_mode) = Self::prepare_outbound_text(content);
+
+        let body = EditMessageTextBody {
+            chat_id: chat_id_num,
+            message_id: message_id_num,
+            text,
+            parse_mode,
+            reply_markup: None,
+        };
+
+        let url = self.api_url("editMessageText");
+        let resp = match self.client.post(&url).json(&body).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(format!("HTTP request failed: {e}")),
+                    retryable: true,
+                });
+            }
+        };
+
+        let tg_resp: TgResponse<TgSentMessage> = match resp.json().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(format!("failed to parse response: {e}")),
+                    retryable: false,
+                });
+            }
+        };
+
+        if tg_resp.ok {
+            Ok(SendResult {
+                success: true,
+                message_id: Some(message_id.to_string()),
+                error: None,
+                retryable: false,
+            })
+        } else {
+            let err = tg_resp.description.unwrap_or_default();
+            // "message is not modified" is not a real failure — content unchanged
+            if err.contains("not modified") {
+                Ok(SendResult {
+                    success: true,
+                    message_id: Some(message_id.to_string()),
+                    error: None,
+                    retryable: false,
+                })
+            } else {
+                let is_flood = err.to_lowercase().contains("flood")
+                    || err.to_lowercase().contains("retry after");
+                Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(err),
+                    retryable: is_flood,
+                })
+            }
+        }
+    }
+
+    async fn delete_message(&self, chat_id: &str, message_id: &str) -> Result<bool> {
+        debug!("Deleting message {} in chat {}", message_id, chat_id);
+
+        let chat_id_num: i64 = match chat_id.parse() {
+            Ok(n) => n,
+            Err(_) => return Ok(false),
+        };
+        let message_id_num: i64 = match message_id.parse() {
+            Ok(n) => n,
+            Err(_) => return Ok(false),
+        };
+
+        #[derive(Debug, Serialize)]
+        struct DeleteMessageBody {
+            chat_id: i64,
+            message_id: i64,
+        }
+
+        let url = self.api_url("deleteMessage");
+        let resp = self
+            .client
+            .post(&url)
+            .json(&DeleteMessageBody {
+                chat_id: chat_id_num,
+                message_id: message_id_num,
+            })
+            .send()
+            .await;
+
+        match resp {
+            Ok(r) => {
+                let tg_resp: TgResponse<serde_json::Value> = match r.json().await {
+                    Ok(parsed) => parsed,
+                    Err(_) => return Ok(false),
+                };
+                Ok(tg_resp.ok)
+            }
+            Err(e) => {
+                debug!("delete_message failed: {e}");
+                Ok(false)
+            }
+        }
     }
 }
 

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -1,0 +1,259 @@
+//! Stream consumer — progressively edits a platform message with streamed tokens.
+//!
+//! Subscribes to the `StreamChunk` broadcast channel, buffers incoming deltas,
+//! and calls `edit_message` on the platform adapter at a configurable rate.
+//! Handles flood control with adaptive backoff and graceful fallback when
+//! editing is no longer viable.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use kestrel_bus::events::{AgentEvent, StreamChunk};
+use kestrel_config::schema::StreamDisplayConfig;
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use crate::base::BaseChannel;
+
+/// Maximum consecutive flood-control failures before disabling edits.
+const MAX_FLOOD_STRIKES: u32 = 3;
+
+/// Maximum Telegram message length (leaving room for cursor + overhead).
+const TG_SAFE_LIMIT: usize = 3900;
+
+/// Stream consumer that progressively edits a platform message.
+///
+/// Created per-session when streaming is active. Subscribes to the
+/// `StreamChunk` broadcast channel, accumulates text deltas, and calls
+/// `edit_message` on the channel adapter at a rate-limited interval.
+pub struct StreamConsumer {
+    session_key: String,
+    chat_id: String,
+    reply_to: Option<String>,
+    cfg: StreamDisplayConfig,
+    channel: Arc<dyn BaseChannel>,
+    stream_rx: broadcast::Receiver<StreamChunk>,
+    event_rx: broadcast::Receiver<AgentEvent>,
+}
+
+impl StreamConsumer {
+    /// Create a new stream consumer for a session.
+    pub fn new(
+        session_key: String,
+        chat_id: String,
+        reply_to: Option<String>,
+        cfg: StreamDisplayConfig,
+        channel: Arc<dyn BaseChannel>,
+        stream_rx: broadcast::Receiver<StreamChunk>,
+        event_rx: broadcast::Receiver<AgentEvent>,
+    ) -> Self {
+        Self {
+            session_key,
+            chat_id,
+            reply_to,
+            cfg,
+            channel,
+            stream_rx,
+            event_rx,
+        }
+    }
+
+    /// Run the stream consumer loop until the stream completes.
+    ///
+    /// Returns the message_id of the final edited message (if any).
+    pub async fn run(mut self) -> Option<String> {
+        let mut accumulated = String::new();
+        let mut message_id: Option<String> = None;
+        let mut last_edit = Instant::now();
+        let mut last_sent_text = String::new();
+        let mut edit_interval = Duration::from_secs_f64(self.cfg.edit_interval_secs);
+        let mut flood_strikes: u32 = 0;
+        let mut edit_supported = true;
+
+        // Send initial placeholder message
+        let initial_result = self
+            .channel
+            .send_message(
+                &self.chat_id,
+                &format!("{}{}", self.cfg.cursor, ""),
+                self.reply_to.as_deref(),
+            )
+            .await;
+
+        if initial_result.success {
+            message_id = initial_result.message_id;
+        }
+
+        loop {
+            // Drain available stream chunks
+            let mut got_done = false;
+            let mut tool_break = false;
+            let mut tool_name = None;
+
+            loop {
+                match self.stream_rx.try_recv() {
+                    Ok(chunk) => {
+                        if chunk.session_key != self.session_key {
+                            continue;
+                        }
+                        if chunk.done {
+                            got_done = true;
+                            break;
+                        }
+                        if !chunk.content.is_empty() {
+                            accumulated.push_str(&chunk.content);
+                        }
+                    }
+                    Err(broadcast::error::TryRecvError::Empty) => break,
+                    Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                        debug!("Stream consumer lagged by {n} chunks");
+                        continue;
+                    }
+                    Err(broadcast::error::TryRecvError::Closed) => {
+                        got_done = true;
+                        break;
+                    }
+                }
+            }
+
+            // Check for tool call events (segment break)
+            loop {
+                match self.event_rx.try_recv() {
+                    Ok(AgentEvent::ToolCall {
+                        session_key,
+                        tool_name: tn,
+                        ..
+                    }) if session_key == self.session_key => {
+                        tool_break = true;
+                        tool_name = Some(tn);
+                    }
+                    _ => break,
+                }
+            }
+
+            // Trim accumulated to safe limit
+            if accumulated.len() > TG_SAFE_LIMIT {
+                accumulated.truncate(TG_SAFE_LIMIT);
+                accumulated.push_str("\n\n(truncated)");
+            }
+
+            // Decide whether to flush an edit
+            let elapsed = last_edit.elapsed();
+            let should_edit = got_done
+                || tool_break
+                || (elapsed >= edit_interval && !accumulated.is_empty())
+                || accumulated.len() >= self.cfg.buffer_threshold;
+
+            if should_edit && !accumulated.is_empty() {
+                let mut display_text = accumulated.clone();
+                if !got_done && !tool_break {
+                    display_text.push_str(&self.cfg.cursor);
+                }
+
+                let delivered = if let Some(ref mid) = message_id {
+                    if edit_supported {
+                        match self
+                            .channel
+                            .edit_message(&self.chat_id, mid, &display_text)
+                            .await
+                        {
+                            Ok(result) if result.success => {
+                                last_sent_text = display_text.clone();
+                                flood_strikes = 0;
+                                edit_interval =
+                                    Duration::from_secs_f64(self.cfg.edit_interval_secs);
+                                true
+                            }
+                            Ok(result) => {
+                                let err = result.error.unwrap_or_default();
+                                let is_flood = err.to_lowercase().contains("flood")
+                                    || err.to_lowercase().contains("retry after");
+
+                                if is_flood {
+                                    flood_strikes += 1;
+                                    edit_interval =
+                                        (edit_interval * 2).min(Duration::from_secs(10));
+                                    debug!(
+                                        "Flood control strike {flood_strikes}/{MAX_FLOOD_STRIKES}"
+                                    );
+                                    if flood_strikes >= MAX_FLOOD_STRIKES {
+                                        edit_supported = false;
+                                    }
+                                }
+                                false
+                            }
+                            Err(e) => {
+                                warn!("edit_message error: {e}");
+                                false
+                            }
+                        }
+                    } else {
+                        false
+                    }
+                } else if message_id.is_none() {
+                    // First send
+                    let text_to_send = if display_text.len() < 4 && !got_done {
+                        // Too short for a standalone message — accumulate more
+                        if got_done {
+                            accumulated.clone()
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        display_text.clone()
+                    };
+
+                    match self
+                        .channel
+                        .send_message(&self.chat_id, &text_to_send, self.reply_to.as_deref())
+                        .await
+                    {
+                        Ok(result) if result.success => {
+                            message_id = result.message_id;
+                            last_sent_text = text_to_send;
+                            true
+                        }
+                        _ => false,
+                    }
+                } else {
+                    false
+                };
+
+                if delivered {
+                    last_edit = Instant::now();
+                }
+            }
+
+            // Handle tool break: send tool progress message, reset for next segment
+            if tool_break {
+                if let Some(ref tn) = tool_name {
+                    let tool_msg = format!("Using {tn}...");
+                    let _ = self
+                        .channel
+                        .send_message(&self.chat_id, &tool_msg, message_id.as_deref())
+                        .await;
+                }
+                // Reset segment state for next streaming phase
+                accumulated.clear();
+                last_sent_text.clear();
+                message_id = None;
+            }
+
+            if got_done {
+                // Final edit: remove cursor
+                if !accumulated.is_empty() && edit_supported {
+                    if let Some(ref mid) = message_id {
+                        let _ = self
+                            .channel
+                            .edit_message(&self.chat_id, mid, &accumulated)
+                            .await;
+                    }
+                }
+                return message_id;
+            }
+
+            // Small yield to avoid busy-looping
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+}

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -80,8 +80,10 @@ impl StreamConsumer {
             )
             .await;
 
-        if initial_result.success {
-            message_id = initial_result.message_id;
+        if let Ok(r) = initial_result {
+            if r.success {
+                message_id = r.message_id;
+            }
         }
 
         loop {

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -512,6 +512,45 @@ fn default_max_msg_size() -> u64 {
     1048576
 }
 
+/// Streaming display configuration for progressive message editing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StreamDisplayConfig {
+    /// Minimum seconds between Telegram message edits.
+    #[serde(default = "default_edit_interval")]
+    pub edit_interval_secs: f64,
+
+    /// Minimum characters to buffer before triggering an edit.
+    #[serde(default = "default_buffer_threshold")]
+    pub buffer_threshold: usize,
+
+    /// Cursor appended to the message during active streaming.
+    #[serde(default = "default_stream_cursor")]
+    pub cursor: String,
+}
+
+fn default_edit_interval() -> f64 {
+    1.5
+}
+
+fn default_buffer_threshold() -> usize {
+    40
+}
+
+fn default_stream_cursor() -> String {
+    " ▌".to_string()
+}
+
+impl Default for StreamDisplayConfig {
+    fn default() -> Self {
+        Self {
+            edit_interval_secs: default_edit_interval(),
+            buffer_threshold: default_buffer_threshold(),
+            cursor: default_stream_cursor(),
+        }
+    }
+}
+
 /// Agent default settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -543,6 +582,10 @@ pub struct AgentDefaults {
     /// Whether to enable streaming.
     #[serde(default = "default_true")]
     pub streaming: bool,
+
+    /// Streaming display configuration (rate-limiting, cursor, etc.).
+    #[serde(default)]
+    pub stream_display: StreamDisplayConfig,
 
     /// Tool execution timeout in seconds.
     #[serde(default = "default_tool_timeout")]
@@ -578,6 +621,7 @@ impl Default for AgentDefaults {
             workspace: None,
             system_prompt: None,
             streaming: true,
+            stream_display: StreamDisplayConfig::default(),
             tool_timeout: default_tool_timeout(),
             connect_timeout: default_connect_timeout(),
             first_byte_timeout: default_first_byte_timeout(),


### PR DESCRIPTION
## Summary

Alternative implementation of #171 (Telegram streaming message editing, tool-call display, and /stop interrupt).

This is an independent implementation meant for side-by-side comparison with PR #172. See the review comment on #172 for a detailed architectural comparison.

## Key Architectural Decisions

**Event-based /stop** — The Telegram poll loop emits `InterruptRequested` on the bus event channel. A background listener in the agent loop cancels the session's `CancellationToken`. This bypasses the mpsc inbound channel's sequential bottleneck, so `/stop` works even when the agent is currently busy processing a message.

**CancelRegistry** — A shared `CancelRegistry` (DashMap<String, CancellationToken>) lives in `kestrel-agent` and is exposed to channel adapters via `set_event_tx()`. This decouples cancellation from the inbound message flow — the Telegram channel doesn't need direct access to the agent loop.

**Session-key filtering** — StreamConsumer filters `StreamChunk` by session_key, preventing cross-contamination when multiple users chat concurrently.

**AgentEvent receiver in StreamConsumer** — Tool-call events trigger segment breaks inside the consumer itself. The current message is finalized, a tool progress message is sent, and subsequent streaming creates a fresh message below it.

**No think-block filtering in V1** — Reasoning tag stripping is deferred to the provider layer. Models that emit `<think/>` blocks should handle this upstream rather than in the display layer.

**No kestrel-agent → kestrel-channels dependency** — The StreamConsumer lives in `kestrel-channels` but is not imported by `kestrel-agent`. This avoids circular dependency risk.

## Files Changed

| File | Change |
|------|--------|
| `kestrel-config/src/schema.rs` | Add `StreamDisplayConfig` (edit_interval_secs, buffer_threshold, cursor) |
| `kestrel-bus/src/events.rs` | Add `InterruptRequested` event variant |
| `kestrel-channels/src/base.rs` | Add `edit_message()` and `delete_message()` to `BaseChannel` trait |
| `kestrel-channels/src/stream_consumer.rs` | **New**: session-isolated StreamConsumer with flood control |
| `kestrel-channels/src/platforms/telegram.rs` | Implement `edit_message`, `delete_message`, `/stop` command, `set_event_tx()` |
| `kestrel-agent/src/cancel_registry.rs` | **New**: shared CancelRegistry |
| `kestrel-agent/src/runner.rs` | Add CancellationToken, check between iterations |
| `kestrel-agent/src/loop_mod.rs` | Wire cancellation, background interrupt listener, /stop handler |

## Test Plan

- [ ] CI passes (cargo build + test)
- [ ] Manual test: send a message to Telegram bot, verify streaming edits appear progressively
- [ ] Manual test: send `/stop` during a long-running agent run, verify it stops
- [ ] Manual test: two users chatting simultaneously, verify no cross-contamination

Bahtya