### PR TITLE
feat: integrate CancelRegistry and event-driven streaming from #173

### DIFF
--- a/crates/kestrel-agent/src/cancel_registry.rs
+++ b/crates/kestrel-agent/src/cancel_registry.rs
@@ -1,0 +1,47 @@
+//! Shared cancellation registry for agent run interruption.
+//!
+//! Provides a `CancelRegistry` that both the agent loop and channel
+//! adapters can access. When a user sends `/stop`, the channel adapter
+//! looks up the session's cancellation token and triggers it.
+
+use dashmap::DashMap;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+/// Shared registry mapping session keys to cancellation tokens.
+#[derive(Debug, Clone, Default)]
+pub struct CancelRegistry {
+    tokens: Arc<DashMap<String, CancellationToken>>,
+}
+
+impl CancelRegistry {
+    /// Create a new empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a cancellation token for a session.
+    pub fn insert(&self, session_key: String, token: CancellationToken) {
+        self.tokens.insert(session_key, token);
+    }
+
+    /// Remove and return the cancellation token for a session.
+    pub fn remove(&self, session_key: &str) -> Option<CancellationToken> {
+        self.tokens.remove(session_key).map(|(_, v)| v)
+    }
+
+    /// Cancel the running agent for a session. Returns true if a token was found.
+    pub fn cancel(&self, session_key: &str) -> bool {
+        if let Some(token) = self.tokens.get(session_key) {
+            token.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Check if a session has an active (registered) token.
+    pub fn contains(&self, session_key: &str) -> bool {
+        self.tokens.contains_key(session_key)
+    }
+}

--- a/crates/kestrel-agent/src/lib.rs
+++ b/crates/kestrel-agent/src/lib.rs
@@ -3,6 +3,7 @@
 //! Agent loop, runner, context building, skills, subagents, and hooks.
 //! Memory operations are provided by the [`kestrel_memory`] crate.
 
+pub mod cancel_registry;
 pub mod compaction;
 pub mod context;
 pub mod context_budget;
@@ -14,6 +15,7 @@ pub mod runner;
 pub mod skills;
 pub mod subagent;
 
+pub use cancel_registry::CancelRegistry;
 pub use compaction::{compact_session, CompactionConfig, CompactionResult, CompactionStrategy};
 pub use context::ContextBuilder;
 pub use context_budget::{

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -221,6 +221,29 @@ impl AgentLoop {
                     // Record activity for heartbeat tracking
                     *self.agent_activity.write() = Some(chrono::Local::now());
 
+                    // Pre-process /stop: cancel active agent run without
+                    // queuing behind the current process_message call.
+                    let content_trimmed = msg.content.trim().to_lowercase();
+                    if content_trimmed == "/stop" {
+                        let session_key = msg.session_key();
+                        self.cancel_session(&session_key);
+                        self.pending_messages.remove(&session_key);
+
+                        let reply = OutboundMessage {
+                            channel: msg.channel.clone(),
+                            chat_id: msg.chat_id.clone(),
+                            content: "Stopped.".to_string(),
+                            reply_to: msg.message_id.clone(),
+                            trace_id: msg.trace_id.clone(),
+                            media: vec![],
+                            metadata: Default::default(),
+                        };
+                        if let Err(e) = self.bus.publish_outbound(reply).await {
+                            error!("Failed to send /stop reply: {e}");
+                        }
+                        continue;
+                    }
+
                     // Extract fields before msg is moved into process_message,
                     // so the timeout branch can still build a reply.
                     let timeout_channel = msg.channel.clone();
@@ -288,32 +311,6 @@ impl AgentLoop {
 
         async move {
             let session_key = msg.session_key();
-
-            // Handle /stop command: cancel active agent run.
-            // The Telegram poll loop already emitted InterruptRequested on the
-            // bus event channel (bypassing the mpsc bottleneck), but we also
-            // try to cancel here for non-Telegram channels or edge cases.
-            let content_trimmed = msg.content.trim().to_lowercase();
-            if content_trimmed == "/stop" {
-                self.cancel_session(&session_key);
-
-                let reply = OutboundMessage {
-                    channel: msg.channel.clone(),
-                    chat_id: msg.chat_id.clone(),
-                    content: "Stopped.".to_string(),
-                    reply_to: msg.message_id.clone(),
-                    trace_id: msg.trace_id.clone(),
-                    media: vec![],
-                    metadata: Default::default(),
-                };
-                if let Err(e) = self.bus.publish_outbound(reply).await {
-                    error!("Failed to send /stop reply: {e}");
-                }
-
-                // Clear any pending message for this session
-                self.pending_messages.remove(&session_key);
-                return Ok(());
-            }
 
             // If session is busy, queue the message
             if self.is_session_active(&session_key) {
@@ -469,8 +466,6 @@ impl AgentLoop {
                 let event_bus = bus_for_stream.clone();
                 let session_key_for_runner = session_key.clone();
                 let trace_id_for_runner = msg.trace_id.clone();
-                let channel_for_tool_display = self.telegram_channel.clone();
-                let chat_id_for_tool = msg.chat_id.clone();
 
                 let mut runner_with_events = AgentRunner::new(
                     self.config.clone(),
@@ -514,17 +509,6 @@ impl AgentLoop {
                                     iteration: *iteration,
                                     trace_id: trace_id_for_runner.clone(),
                                 });
-
-                                // Send tool progress message to Telegram
-                                if let Some(ref channel) = channel_for_tool_display {
-                                    let ch = channel.clone();
-                                    let cid = chat_id_for_tool.clone();
-                                    let progress =
-                                        format!("Using `{}` tool...", tool_name);
-                                    tokio::spawn(async move {
-                                        let _ = ch.send_message(&cid, &progress, None).await;
-                                    });
-                                }
                             }
                             _ => {}
                         }
@@ -919,6 +903,7 @@ impl AgentLoop {
     ) -> Option<tokio::task::JoinHandle<(String, Option<String>)>> {
         let channel = self.telegram_channel.clone()?;
         let stream_rx = self.bus.subscribe_stream();
+        let event_rx = self.bus.subscribe_events();
         let cfg = StreamingConfig::default();
 
         let consumer = StreamConsumer::new(
@@ -927,6 +912,7 @@ impl AgentLoop {
             session_key.to_string(),
             cfg,
             stream_rx,
+            event_rx,
         );
         let handle = tokio::spawn(async move { consumer.run().await });
 

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use kestrel_bus::events::StreamChunk;
+use kestrel_bus::events::{AgentEvent, StreamChunk};
 use kestrel_config::schema::StreamingConfig;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
@@ -41,6 +41,7 @@ pub struct StreamConsumer {
     session_key: String,
     cfg: StreamingConfig,
     stream_rx: broadcast::Receiver<StreamChunk>,
+    event_rx: broadcast::Receiver<AgentEvent>,
     accumulated: String,
     message_id: Option<String>,
     last_sent_text: String,
@@ -60,6 +61,7 @@ impl StreamConsumer {
         session_key: String,
         cfg: StreamingConfig,
         stream_rx: broadcast::Receiver<StreamChunk>,
+        event_rx: broadcast::Receiver<AgentEvent>,
     ) -> Self {
         let current_edit_interval = cfg.edit_interval;
         Self {
@@ -68,6 +70,7 @@ impl StreamConsumer {
             session_key,
             cfg,
             stream_rx,
+            event_rx,
             accumulated: String::new(),
             message_id: None,
             last_sent_text: String::new(),
@@ -122,8 +125,26 @@ impl StreamConsumer {
                 self.flush_think_buffer();
             }
 
+            // Check for tool call events (segment break)
+            let mut tool_break = false;
+            let mut tool_name_opt = None;
+            loop {
+                match self.event_rx.try_recv() {
+                    Ok(AgentEvent::ToolCall {
+                        session_key,
+                        tool_name,
+                        ..
+                    }) if session_key == self.session_key => {
+                        tool_break = true;
+                        tool_name_opt = Some(tool_name);
+                    }
+                    _ => break,
+                }
+            }
+
             let elapsed = self.last_edit_time.elapsed().as_secs_f64();
             let should_edit = got_done
+                || tool_break
                 || (elapsed >= self.current_edit_interval && !self.accumulated.is_empty())
                 || self.accumulated.len() >= self.cfg.buffer_threshold;
 
@@ -145,12 +166,28 @@ impl StreamConsumer {
                 }
 
                 let mut display_text = self.accumulated.clone();
-                if !got_done {
+                if !got_done && !tool_break {
                     display_text.push_str(&self.cfg.cursor);
                 }
 
-                self.send_or_edit(&display_text, got_done).await;
+                self.send_or_edit(&display_text, got_done || tool_break)
+                    .await;
                 self.last_edit_time = std::time::Instant::now();
+            }
+
+            // Handle tool break: send tool progress message, reset for next segment
+            if tool_break {
+                if let Some(tn) = tool_name_opt {
+                    let reply_to = self.message_id.as_deref();
+                    let tool_msg = format!("Using `{}`...", tn);
+                    let _ = self
+                        .channel
+                        .send_message(&self.chat_id, &tool_msg, reply_to)
+                        .await;
+                }
+                self.accumulated.clear();
+                self.last_sent_text.clear();
+                self.message_id = None;
             }
 
             if got_done {


### PR DESCRIPTION
## Summary
- Add `CancelRegistry` for shared session cancellation tokens (from PR #173)
- Upgrade `StreamConsumer` with `event_rx` for ToolCall segment breaks — tool progress messages are now sent by the consumer instead of a separate `tokio::spawn` in the event callback
- Move `/stop` to pre-process interception in `run()` before the timeout call, so cancellation isn't blocked by a running `process_message`

## Test plan
- [ ] CI passes (`cargo build`, `cargo test`, `cargo clippy`)
- [ ] Telegram streaming displays tool progress messages between segments
- [ ] `/stop` cancels running agents immediately (even during tool execution)

Bahtya