### PR TITLE
fix(agent): wire StreamConsumer by calling with_telegram_channel in gateway command

### DIFF
--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -397,6 +397,17 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
 
     // ── Channel manager (wrapped in Arc for shared access) ────
     let channel_registry = ChannelRegistry::new_with_config(&config);
+    let telegram_stream_channel = if config
+        .channels
+        .telegram
+        .as_ref()
+        .map(|c| c.enabled)
+        .unwrap_or(false)
+    {
+        channel_registry.create_channel("telegram").ok()
+    } else {
+        None
+    };
     let channel_manager = Arc::new(ChannelManager::new(channel_registry, bus.clone()));
 
     // ── Skill registry ───────────────────────────────────────
@@ -481,6 +492,12 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         // Wire prompt assembler for dynamic system prompt construction
         al = al.with_prompt_assembler(PromptAssembler::new());
         info!("Prompt assembler wired into agent loop");
+
+        // Wire Telegram channel for streaming display
+        if let Some(tg) = telegram_stream_channel {
+            al = al.with_telegram_channel(Arc::from(tg));
+            info!("Telegram streaming channel wired into agent loop");
+        }
 
         al
     };


### PR DESCRIPTION
Closes #176

## Problem

PR #175 introduced the `StreamConsumer` infrastructure and PR #172 added Telegram streaming/tool display support. However, the `StreamConsumer` was never actually activated because `gateway.rs` did not call `with_telegram_channel()` when constructing `AgentLoop`.

## Root Cause

The `AgentLoop` was wired with `audit_callback`, `memory_store`, `skill_registry`, `learning_bus`, and `prompt_assembler`, but `telegram_channel` remained `None`. This caused:

- `spawn_stream_consumer()` (loop_mod.rs:455) to never execute
- `StreamConsumer` task to never spawn
- All `AgentEvent::StreamingChunk` and `AgentEvent::ToolCall` events to go unconsumed for Telegram display

## Fix

1. **Extract Telegram channel from registry** before `ChannelManager` consumes it:
   ```rust
   let telegram_stream_channel = if config.channels.telegram.as_ref().map(|c| c.enabled).unwrap_or(false) {
       channel_registry.create_channel("telegram").ok()
   } else { None };
   ```

2. **Wire into AgentLoop** after all other `.with_*()` calls:
   ```rust
   if let Some(tg) = telegram_stream_channel {
       al = al.with_telegram_channel(Arc::from(tg));
   }
   ```

## Verification

- Adversarial review by independent CC agent confirmed correctness across 4 scenarios:
  - Telegram disabled → no wiring, correct
  - Telegram enabled + streaming disabled → wired but spawn gated by config, correct
  - Channel creation fails → `.ok()` graceful no-op, correct
  - Non-Telegram messages → `is_telegram` check prevents spawn, correct

## Related

- #176
- PR #172 (Telegram streaming display)
- PR #175 (StreamConsumer infrastructure)