### PR TITLE
fix(agent): stream tool execution progress to Telegram (#177)

### DIFF
--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -510,6 +510,19 @@ impl AgentLoop {
                                     trace_id: trace_id_for_runner.clone(),
                                 });
                             }
+                            AgentEvent::ToolResult {
+                                session_key,
+                                tool_name,
+                                duration_ms,
+                                ..
+                            } => {
+                                event_bus.emit_event(AgentEvent::ToolResult {
+                                    session_key: session_key.clone(),
+                                    tool_name: tool_name.clone(),
+                                    duration_ms: *duration_ms,
+                                    trace_id: trace_id_for_runner.clone(),
+                                });
+                            }
                             _ => {}
                         }
                     }));

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -445,10 +445,7 @@ impl AgentRunner {
 
         // Emit a progress indicator so Telegram doesn't go silent while tools run.
         self.emit_stream_chunk(
-            format!(
-                "\n\u{1f527} Executing {} tool(s)...\n",
-                tool_calls.len()
-            ),
+            format!("\n\u{1f527} Executing {} tool(s)...\n", tool_calls.len()),
             false,
         );
 

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -445,30 +445,58 @@ impl AgentRunner {
 
         // Emit a progress indicator so Telegram doesn't go silent while tools run.
         self.emit_stream_chunk(
-            format!("\n\u{1f527} Executing {} tool(s)...\n", tool_calls.len()),
+            format!(
+                "\n\u{1f527} Executing {} tool(s)...\n",
+                tool_calls.len()
+            ),
             false,
         );
 
-        let mut results = Vec::new();
+        let total = handles.len();
+        let mut results: Vec<(String, u64)> = Vec::with_capacity(total);
+        let overall_start = std::time::Instant::now();
+        let heartbeat_interval = std::time::Duration::from_secs(10);
+
         for (i, handle) in handles.into_iter().enumerate() {
-            match handle.await {
-                Ok((result, duration)) => {
-                    self.emit_event(AgentEvent::ToolResult {
-                        session_key: self.session_key.clone().unwrap_or_default(),
-                        tool_name: tool_calls[i].function.name.clone(),
-                        duration_ms: duration,
-                        trace_id: self.trace_id.clone(),
-                    });
-                    results.push((result, duration));
-                }
-                Err(e) => {
-                    self.emit_event(AgentEvent::ToolResult {
-                        session_key: self.session_key.clone().unwrap_or_default(),
-                        tool_name: tool_calls[i].function.name.clone(),
-                        duration_ms: 0,
-                        trace_id: self.trace_id.clone(),
-                    });
-                    results.push((format!("Tool execution failed: {}", e), 0));
+            // Poll this handle with a heartbeat timeout loop.
+            let mut h = handle;
+            loop {
+                match tokio::time::timeout(heartbeat_interval, &mut h).await {
+                    Ok(join_res) => {
+                        match join_res {
+                            Ok((result, duration)) => {
+                                self.emit_event(AgentEvent::ToolResult {
+                                    session_key: self.session_key.clone().unwrap_or_default(),
+                                    tool_name: tool_calls[i].function.name.clone(),
+                                    duration_ms: duration,
+                                    trace_id: self.trace_id.clone(),
+                                });
+                                results.push((result, duration));
+                            }
+                            Err(e) => {
+                                self.emit_event(AgentEvent::ToolResult {
+                                    session_key: self.session_key.clone().unwrap_or_default(),
+                                    tool_name: tool_calls[i].function.name.clone(),
+                                    duration_ms: 0,
+                                    trace_id: self.trace_id.clone(),
+                                });
+                                results.push((format!("Tool execution failed: {}", e), 0));
+                            }
+                        }
+                        break;
+                    }
+                    Err(_) => {
+                        // Timeout — emit heartbeat and keep waiting on the same handle.
+                        let elapsed = overall_start.elapsed().as_secs();
+                        let remaining = total - i;
+                        self.emit_stream_chunk(
+                            format!(
+                                "\n\u{23f3} Still running... ({}s elapsed, {} pending)\n",
+                                elapsed, remaining
+                            ),
+                            false,
+                        );
+                    }
                 }
             }
         }

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -443,11 +443,33 @@ impl AgentRunner {
             handles.push(handle);
         }
 
+        // Emit a progress indicator so Telegram doesn't go silent while tools run.
+        self.emit_stream_chunk(
+            format!("\n\u{1f527} Executing {} tool(s)...\n", tool_calls.len()),
+            false,
+        );
+
         let mut results = Vec::new();
-        for handle in handles {
+        for (i, handle) in handles.into_iter().enumerate() {
             match handle.await {
-                Ok((result, duration)) => results.push((result, duration)),
-                Err(e) => results.push((format!("Tool execution failed: {}", e), 0)),
+                Ok((result, duration)) => {
+                    self.emit_event(AgentEvent::ToolResult {
+                        session_key: self.session_key.clone().unwrap_or_default(),
+                        tool_name: tool_calls[i].function.name.clone(),
+                        duration_ms: duration,
+                        trace_id: self.trace_id.clone(),
+                    });
+                    results.push((result, duration));
+                }
+                Err(e) => {
+                    self.emit_event(AgentEvent::ToolResult {
+                        session_key: self.session_key.clone().unwrap_or_default(),
+                        tool_name: tool_calls[i].function.name.clone(),
+                        duration_ms: 0,
+                        trace_id: self.trace_id.clone(),
+                    });
+                    results.push((format!("Tool execution failed: {}", e), 0));
+                }
             }
         }
 

--- a/crates/kestrel-bus/src/events.rs
+++ b/crates/kestrel-bus/src/events.rs
@@ -140,6 +140,14 @@ pub enum AgentEvent {
         trace_id: Option<String>,
     },
 
+    /// Tool execution completed.
+    ToolResult {
+        session_key: String,
+        tool_name: String,
+        duration_ms: u64,
+        trace_id: Option<String>,
+    },
+
     /// Agent completed processing.
     Completed {
         session_key: String,

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -128,6 +128,7 @@ impl StreamConsumer {
             // Check for tool call events (segment break)
             let mut tool_break = false;
             let mut tool_name_opt = None;
+            let mut completed_tools: Vec<(String, u64)> = Vec::new();
             loop {
                 match self.event_rx.try_recv() {
                     Ok(AgentEvent::ToolCall {
@@ -144,20 +145,29 @@ impl StreamConsumer {
                         duration_ms,
                         ..
                     }) if session_key == self.session_key => {
-                        let duration_str = if duration_ms >= 1000 {
-                            format!("{:.1}s", duration_ms as f64 / 1000.0)
-                        } else {
-                            format!("{}ms", duration_ms)
-                        };
-                        let reply_to = self.message_id.as_deref();
-                        let done_msg = format!("\u{2705} `{}` done ({})", tool_name, duration_str);
-                        let _ = self
-                            .channel
-                            .send_message(&self.chat_id, &done_msg, reply_to)
-                            .await;
+                        completed_tools.push((tool_name, duration_ms));
                     }
                     _ => break,
                 }
+            }
+
+            // Batch-render completed tools into a single message.
+            if !completed_tools.is_empty() {
+                let mut lines = Vec::with_capacity(completed_tools.len());
+                for (name, duration_ms) in &completed_tools {
+                    let duration_str = if *duration_ms >= 1000 {
+                        format!("{:.1}s", *duration_ms as f64 / 1000.0)
+                    } else {
+                        format!("{}ms", duration_ms)
+                    };
+                    lines.push(format!("\u{2705} `{}` done ({})", name, duration_str));
+                }
+                let reply_to = self.message_id.as_deref();
+                let done_msg = lines.join("\n");
+                let _ = self
+                    .channel
+                    .send_message(&self.chat_id, &done_msg, reply_to)
+                    .await;
             }
 
             let elapsed = self.last_edit_time.elapsed().as_secs_f64();

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -138,6 +138,24 @@ impl StreamConsumer {
                         tool_break = true;
                         tool_name_opt = Some(tool_name);
                     }
+                    Ok(AgentEvent::ToolResult {
+                        session_key,
+                        tool_name,
+                        duration_ms,
+                        ..
+                    }) if session_key == self.session_key => {
+                        let duration_str = if duration_ms >= 1000 {
+                            format!("{:.1}s", duration_ms as f64 / 1000.0)
+                        } else {
+                            format!("{}ms", duration_ms)
+                        };
+                        let reply_to = self.message_id.as_deref();
+                        let done_msg = format!("\u{2705} `{}` done ({})", tool_name, duration_str);
+                        let _ = self
+                            .channel
+                            .send_message(&self.chat_id, &done_msg, reply_to)
+                            .await;
+                    }
                     _ => break,
                 }
             }


### PR DESCRIPTION
## Summary

Implements progress event streaming for tool execution so Telegram users see real-time updates instead of silence during long-running tools.

### Changes
- **events.rs**: Added ToolResult variant to AgentEvent enum
- **runner.rs**: Emits progress chunk before tools + ToolResult events after each tool completes. Added 10s heartbeat loop for long-running tools.
- **loop_mod.rs**: Forwards ToolResult events through the event bus
- **stream_consumer.rs**: Renders ToolResult as Telegram message (batched for concurrent tools)

### Review
Adversarial review completed. Approved with minor notes for follow-up (pending count accuracy, heartbeat accumulation).