### PR TITLE
fix(tools): flush and sync on append writes

### DIFF
--- a/crates/kestrel-tools/src/builtins/filesystem.rs
+++ b/crates/kestrel-tools/src/builtins/filesystem.rs
@@ -134,15 +134,21 @@ impl Tool for WriteFileTool {
         }
 
         if append {
-            tokio::fs::OpenOptions::new()
+            let mut file = tokio::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(path)
                 .await
-                .map_err(|e| ToolError::Execution(format!("Failed to open file: {}", e)))?
-                .write_all(content.as_bytes())
+                .map_err(|e| ToolError::Execution(format!("Failed to open file: {}", e)))?;
+            file.write_all(content.as_bytes())
                 .await
                 .map_err(|e| ToolError::Execution(format!("Failed to write: {}", e)))?;
+            file.flush()
+                .await
+                .map_err(|e| ToolError::Execution(format!("Failed to flush: {}", e)))?;
+            file.sync_all()
+                .await
+                .map_err(|e| ToolError::Execution(format!("Failed to sync: {}", e)))?;
         } else {
             tokio::fs::write(path, content)
                 .await


### PR DESCRIPTION
## Summary
- Append path in `WriteFileTool` now calls `flush()` + `sync_all()` before returning, ensuring data is persisted to disk before subsequent reads
- Fixes flaky `test_write_file_append` failure on GitHub Actions CI

## Test plan
- [ ] CI passes with `test_write_file_append` green
- [ ] No regressions in other filesystem tool tests

Bahtya