### PR TITLE
fix(channels): avoid UTF-8 panic in find_partial_tag_suffix

### DIFF
--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -409,7 +409,10 @@ fn max_tag_len(tags: &[&str]) -> usize {
 fn find_partial_tag_suffix(text: &str, tags: &[&str]) -> usize {
     let mut held = 0;
     for tag in tags {
-        for i in 1..=tag.len().min(text.len()) {
+        for (i, _) in tag.char_indices() {
+            if i == 0 || i > text.len() {
+                continue;
+            }
             if text.ends_with(&tag[..i]) && i > held {
                 held = i;
             }


### PR DESCRIPTION
## Summary
- `find_partial_tag_suffix` iterated byte indices `1..=tag.len()` to slice `tag` into prefixes, but multi-byte UTF-8 tags like 🧠 (`\u{1f9e0}`, 4 bytes) have no char boundary at byte indices 1–3, causing `byte index 1 is not a char boundary` panic on `&tag[..i]`
- Replace the byte-index loop with `tag.char_indices()` so only valid UTF-8 boundaries are used for slicing

## Test plan
- [ ] CI passes (`cargo check` / `cargo test`)
- [ ] Verify no regression with ASCII tags (`<thinking>`, `<reasoning>`, etc.)
- [ ] Verify emoji tags (🧠, 🪠) no longer panic during stream consumption

Bahtya