### PR TITLE
feat(version): inject git build info into --version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ matrix.target }}-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1403,6 +1403,7 @@ dependencies = [
  "filetime",
  "futures",
  "kestrel-bus",
+ "kestrel-channels",
  "kestrel-config",
  "kestrel-core",
  "kestrel-cron",
@@ -1421,13 +1422,14 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "kestrel-api"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1458,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1470,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1497,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1514,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1526,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1545,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1564,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1588,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1609,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1631,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1652,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1665,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1683,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1702,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1718,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.3.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/kestrel-core/build.rs
+++ b/crates/kestrel-core/build.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+fn main() {
+    let git_version = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let git_date = Command::new("git")
+        .args(["log", "-1", "--format=%cs"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_VERSION={}", git_version);
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=GIT_DATE={}", git_date);
+}

--- a/crates/kestrel-core/src/constants.rs
+++ b/crates/kestrel-core/src/constants.rs
@@ -1,7 +1,14 @@
 //! Constants for the kestrel project.
 
-/// Current version of kestrel.
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Current version of kestrel, combining Cargo version with git build info.
+pub const VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (",
+    env!("GIT_HASH"),
+    " ",
+    env!("GIT_DATE"),
+    ")"
+);
 
 /// Default maximum iterations for the agent loop.
 pub const DEFAULT_MAX_ITERATIONS: usize = 50;


### PR DESCRIPTION
## Summary

Add `build.rs` to `kestrel-core` that injects git commit hash and date at compile time.

**Before:** `kestrel --version` → `kestrel 0.4.3`  
**After:** `kestrel --version` → `kestrel 0.4.3 (79c49c1 2026-04-28)`

Also removes `target` from CI build cache to prevent stale binary issues (which caused v0.4.3 release binary to report v0.4.2).

## Changes
- `crates/kestrel-core/build.rs` — new build script using `git describe --tags --always --dirty`, `git rev-parse --short HEAD`, `git log -1 --format=%cs`
- `crates/kestrel-core/src/constants.rs` — `VERSION` now uses `concat!` to combine `CARGO_PKG_VERSION` + `GIT_HASH` + `GIT_DATE`
- `.github/workflows/release.yml` — remove `target` from build cache

## Test plan
- [x] `cargo check` passes
- [x] Build script correctly outputs git info
- [ ] CI passes