### PR TITLE
fix(channels): split long Telegram messages instead of silent failure

### DIFF
--- a/crates/kestrel-channels/src/manager.rs
+++ b/crates/kestrel-channels/src/manager.rs
@@ -3,6 +3,7 @@
 use crate::base::BaseChannel;
 use crate::platforms::websocket;
 use crate::registry::ChannelRegistry;
+use crate::split_message;
 use anyhow::Result;
 use dashmap::DashMap;
 use kestrel_bus::events::{AgentEvent, OutboundMessage, StreamChunk};
@@ -90,25 +91,35 @@ impl ChannelManager {
         match self.running_channels.get(&channel_name) {
             Some(channel) => {
                 let channel = channel.lock().await;
-                match channel
-                    .send_message_with_trace(
-                        &msg.chat_id,
-                        &msg.content,
-                        msg.reply_to.as_deref(),
-                        msg.trace_id.as_deref(),
-                    )
-                    .await
-                {
-                    Ok(result) => {
-                        if !result.success {
-                            error!(
-                                "Failed to send message to {} via {}: {:?}",
-                                msg.chat_id, channel_name, result.error
-                            );
+                let chunks = split_message(&msg.content, 4096);
+                let mut first = true;
+                for chunk in chunks {
+                    let reply = if first {
+                        first = false;
+                        msg.reply_to.as_deref()
+                    } else {
+                        None
+                    };
+                    match channel
+                        .send_message_with_trace(
+                            &msg.chat_id,
+                            &chunk,
+                            reply,
+                            msg.trace_id.as_deref(),
+                        )
+                        .await
+                    {
+                        Ok(result) => {
+                            if !result.success {
+                                error!(
+                                    "Failed to send message to {} via {}: {:?}",
+                                    msg.chat_id, channel_name, result.error
+                                );
+                            }
                         }
-                    }
-                    Err(e) => {
-                        error!("Error sending message via {}: {}", channel_name, e);
+                        Err(e) => {
+                            error!("Error sending message via {}: {}", channel_name, e);
+                        }
                     }
                 }
             }

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1793,71 +1793,42 @@ impl BaseChannel for TelegramChannel {
     ) -> Result<SendResult> {
         debug!("Sending Telegram message to chat {}", chat_id);
 
-        let chat_id_num: i64 = match chat_id.parse() {
-            Ok(n) => n,
-            Err(_) => {
-                return Ok(SendResult {
-                    success: false,
-                    message_id: None,
-                    error: Some(format!("invalid chat_id: {chat_id}")),
-                    retryable: false,
-                });
-            }
-        };
-
-        let reply_to_id = reply_to.and_then(|r| r.parse::<i64>().ok());
+        // Defensive split: if content exceeds 4096 chars after markdown
+        // conversion, split on newline boundaries and send multiple messages.
         let (text, parse_mode) = Self::prepare_outbound_text(content);
-
-        let body = SendMessageBody {
-            chat_id: chat_id_num,
-            text,
-            parse_mode,
-            reply_to_message_id: reply_to_id,
-            reply_markup: None,
-        };
-
-        let url = self.api_url("sendMessage");
-        let resp = match self.client.post(&url).json(&body).send().await {
-            Ok(r) => r,
-            Err(e) => {
-                return Ok(SendResult {
-                    success: false,
-                    message_id: None,
-                    error: Some(format!("HTTP request failed: {e}")),
-                    retryable: true,
-                });
-            }
-        };
-
-        let tg_resp: TgResponse<TgSentMessage> = match resp.json().await {
-            Ok(r) => r,
-            Err(e) => {
-                return Ok(SendResult {
-                    success: false,
-                    message_id: None,
-                    error: Some(format!("failed to parse response: {e}")),
-                    retryable: false,
-                });
-            }
-        };
-
-        if tg_resp.ok {
-            let msg_id = tg_resp.result.map(|m| m.message_id.to_string());
-
-            Ok(SendResult {
-                success: true,
-                message_id: msg_id,
-                error: None,
-                retryable: false,
-            })
-        } else {
-            Ok(SendResult {
-                success: false,
-                message_id: None,
-                error: tg_resp.description,
-                retryable: false,
-            })
+        if text.len() <= 4096 {
+            return self
+                .send_single_message(chat_id, &text, parse_mode, reply_to)
+                .await;
         }
+
+        // Split original content (pre-conversion) and send each chunk.
+        let chunks = crate::split_message(content, 4096);
+        let mut last_result: Option<SendResult> = None;
+        let mut first = true;
+        for chunk in &chunks {
+            let reply = if first {
+                first = false;
+                reply_to
+            } else {
+                None
+            };
+            let (chunk_text, chunk_parse_mode) = Self::prepare_outbound_text(chunk);
+            let result = self
+                .send_single_message(chat_id, &chunk_text, chunk_parse_mode, reply)
+                .await?;
+            if !result.success {
+                return Ok(result);
+            }
+            last_result = Some(result);
+        }
+
+        Ok(last_result.unwrap_or(SendResult {
+            success: true,
+            message_id: None,
+            error: None,
+            retryable: false,
+        }))
     }
 
     async fn send_typing(&self, chat_id: &str, _trace_id: Option<&str>) -> Result<()> {
@@ -2078,6 +2049,78 @@ impl BaseChannel for TelegramChannel {
 }
 
 impl TelegramChannel {
+    /// Send a single Telegram message (no splitting).
+    async fn send_single_message(
+        &self,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<String>,
+        reply_to: Option<&str>,
+    ) -> Result<SendResult> {
+        let chat_id_num: i64 = match chat_id.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                return Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(format!("invalid chat_id: {chat_id}")),
+                    retryable: false,
+                });
+            }
+        };
+
+        let reply_to_id = reply_to.and_then(|r| r.parse::<i64>().ok());
+        let body = SendMessageBody {
+            chat_id: chat_id_num,
+            text: text.to_string(),
+            parse_mode,
+            reply_to_message_id: reply_to_id,
+            reply_markup: None,
+        };
+
+        let url = self.api_url("sendMessage");
+        let resp = match self.client.post(&url).json(&body).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(format!("HTTP request failed: {e}")),
+                    retryable: true,
+                });
+            }
+        };
+
+        let tg_resp: TgResponse<TgSentMessage> = match resp.json().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(SendResult {
+                    success: false,
+                    message_id: None,
+                    error: Some(format!("failed to parse response: {e}")),
+                    retryable: false,
+                });
+            }
+        };
+
+        if tg_resp.ok {
+            let msg_id = tg_resp.result.map(|m| m.message_id.to_string());
+            Ok(SendResult {
+                success: true,
+                message_id: msg_id,
+                error: None,
+                retryable: false,
+            })
+        } else {
+            Ok(SendResult {
+                success: false,
+                message_id: None,
+                error: tg_resp.description,
+                retryable: false,
+            })
+        }
+    }
+
     /// Edit the text of a previously sent message.
     ///
     /// Optionally attach or update an inline keyboard via `reply_markup`.

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -184,6 +184,10 @@ impl StreamConsumer {
                     let chunk = self.accumulated[..split_at].to_string();
                     let ok = self.send_or_edit(&chunk, false).await;
                     if !ok {
+                        warn!(
+                            "Stream chunk split-and-send failed ({} bytes remaining), dropping rest",
+                            self.accumulated.len()
+                        );
                         break;
                     }
                     self.accumulated = self.accumulated[split_at..]

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -946,29 +946,30 @@ mod tests {
             .get("greeting")
             .await
             .expect("greeting should exist");
-        let guard = skill.read();
-        let m = guard.manifest();
+        {
+            let guard = skill.read();
+            let m = guard.manifest();
 
-        // Verify bundled manifest fields are preserved (not re-derived)
-        assert_eq!(m.category, "social");
-        assert!(
-            m.triggers.contains(&"hello".to_string()),
-            "triggers should include 'hello': {:?}",
-            m.triggers
-        );
-        assert!(
-            m.triggers.contains(&"hi".to_string()),
-            "triggers should include 'hi': {:?}",
-            m.triggers
-        );
-        assert!(
-            m.triggers.contains(&"hey".to_string()),
-            "triggers should include 'hey': {:?}",
-            m.triggers
-        );
+            // Verify bundled manifest fields are preserved (not re-derived)
+            assert_eq!(m.category, "social");
+            assert!(
+                m.triggers.contains(&"hello".to_string()),
+                "triggers should include 'hello': {:?}",
+                m.triggers
+            );
+            assert!(
+                m.triggers.contains(&"hi".to_string()),
+                "triggers should include 'hi': {:?}",
+                m.triggers
+            );
+            assert!(
+                m.triggers.contains(&"hey".to_string()),
+                "triggers should include 'hey': {:?}",
+                m.triggers
+            );
+        }
 
         // Verify matching works with bundled triggers
-        drop(guard);
         assert_eq!(registry.match_skills("hello").await.len(), 1);
         assert_eq!(registry.match_skills("hey").await.len(), 1);
 


### PR DESCRIPTION
## Summary
- **manager.rs `handle_outbound`**: use `split_message` to chunk content at 4096 chars before sending; only the first chunk gets `reply_to`
- **telegram.rs `send_message`**: defensive auto-split as safety net — if the markdown-converted text exceeds 4096, split the original content and send each chunk independently via new `send_single_message` helper
- **stream_consumer.rs**: replace silent `break` on split-and-send failure with `warn!` log so failures are observable

## Root cause
When `stream_consumer`'s split fails (message_id returns None), `loop_mod` falls back to `publish_outbound` → `handle_outbound`, which had no splitting logic. The oversized content hits TG API directly, gets "message is too long", and the reply is silently lost.

## Test plan
- [ ] CI passes (`cargo check` / tests)
- [ ] Manual: send a message that triggers a >4096 char reply on TG and verify it arrives in multiple parts
- [ ] Verify short messages still send normally (single message, with reply_to)

Bahtya