### PR TITLE
fix(stream_consumer): UTF-8 boundary panic in filter_and_accumulate

### DIFF
--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -350,7 +350,13 @@ impl StreamConsumer {
                 } else {
                     let max_tag = max_tag_len(CLOSE_THINK_TAGS);
                     if remaining.len() > max_tag {
-                        self.think_buffer = remaining[remaining.len() - max_tag..].to_string();
+                        // Use char-boundary-safe floor to avoid splitting
+                        // a multi-byte UTF-8 character when slicing the tail.
+                        let mut cut = remaining.len() - max_tag;
+                        while cut < remaining.len() && !remaining.is_char_boundary(cut) {
+                            cut += 1;
+                        }
+                        self.think_buffer = remaining[cut..].to_string();
                     } else {
                         self.think_buffer = remaining.to_string();
                     }
@@ -367,9 +373,12 @@ impl StreamConsumer {
                     // Check for partial tag at the tail
                     let held_back = find_partial_tag_suffix(remaining, OPEN_THINK_TAGS);
                     if held_back > 0 {
-                        self.accumulated
-                            .push_str(&remaining[..remaining.len() - held_back]);
-                        self.think_buffer = remaining[remaining.len() - held_back..].to_string();
+                        let mut cut = remaining.len() - held_back;
+                        while cut < remaining.len() && !remaining.is_char_boundary(cut) {
+                            cut += 1;
+                        }
+                        self.accumulated.push_str(&remaining[..cut]);
+                        self.think_buffer = remaining[cut..].to_string();
                     } else {
                         self.accumulated.push_str(remaining);
                     }


### PR DESCRIPTION
## Summary

PR #181 fixed `find_partial_tag_suffix` (L413), but two other byte-index slicing sites in `filter_and_accumulate` still panic on CJK text:

**L353**: `remaining[remaining.len() - max_tag..]` — when retaining the tail for partial close-tag matching, `max_tag` is ASCII length but the cut point can land inside a multi-byte UTF-8 character.

**L377-378**: `remaining[..remaining.len() - held_back]` and `remaining[remaining.len() - held_back..]` — same issue for partial open-tag suffix detection.

### Panic observed in production
```
start byte index 5 is not a char boundary; it is inside '动' (bytes 4..7) of ` 自动记忆（质量评分`
```

### Fix
Use `is_char_boundary()` loop to advance to the nearest valid UTF-8 boundary before slicing — same defensive pattern as PR #181.

## Test plan
- [x] Code review — two symmetric fixes matching existing pattern
- [ ] CI passes (fmt + clippy + test)