### PR TITLE
ci: free disk space before test job to prevent runner disk full errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get install -y protobuf-compiler
 


### PR DESCRIPTION
## Summary

GitHub Actions `ubuntu-latest` runners occasionally hit "No space left on device" errors (e.g. PR #193 Test job failed with `System.IO.IOException: No space left on device`). The pre-installed tools (Android SDK, .NET, Haskell, GHC, Boost, CodeQL, Docker images) consume 15-20 GB on a ~84 GB disk.

## Change

Add `jlumbroso/free-disk-space@main` action to the Test job, configured to remove:
- Android SDK/NDK
- .NET runtime
- Haskell/GHC
- Large packages
- Docker images
- Swap storage

Expected to reclaim **5-10 GB** of disk space before `cargo test --workspace` runs.

Only the Test job is affected — this is where the cache restore + compilation + test execution has the highest disk demand.