### PR TITLE
perf(test): eliminate websocket test sleeps, remove redundant CI Build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,31 +37,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-
 
       - run: cargo clippy --workspace -- -D warnings
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt-get install -y protobuf-compiler
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
-
-      - run: cargo build --workspace
 
   test:
     name: Test
@@ -90,9 +70,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
 
       - run: cargo test --workspace
 

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -1297,6 +1297,21 @@ mod tests {
         (channel, addr, rx)
     }
 
+    /// Helper: wait until the server has exactly `n` registered clients.
+    async fn wait_for_client_count(channel: &WebSocketChannel, n: usize) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while channel.client_count() != n {
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "timed out waiting for {} clients (have {})",
+                    n,
+                    channel.client_count()
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    }
+
     /// Helper: drain the next text message from a WebSocket client.
     async fn drain_next_text(
         ws: &mut tokio_tungstenite::WebSocketStream<
@@ -1352,8 +1367,7 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-        assert_eq!(channel.client_count(), 1);
+        wait_for_client_count(&channel, 1).await;
 
         channel.disconnect().await.unwrap();
     }
@@ -1367,7 +1381,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let client_id: String = channel
@@ -1400,7 +1413,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let legacy_msg = r#"{"role":"user","content":"legacy hello"}"#;
@@ -1425,7 +1437,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let envelope = WsEnvelope::message("envelope hello");
@@ -1452,7 +1463,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let legacy_msg = r#"{"role":"user","content":"legacy"}"#;
@@ -1477,7 +1487,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let ping_json = r#"{"type":"ping","id":"ping-1"}"#;
@@ -1502,7 +1511,8 @@ mod tests {
             drop(ws);
         }
 
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // Wait for server to detect the disconnect and remove the client.
+        wait_for_client_count(&channel, 0).await;
 
         let result = channel
             .send_message("nonexistent_client", "Hello", None)
@@ -1523,7 +1533,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let client_id: String = channel
@@ -1559,8 +1568,7 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        assert_eq!(channel.client_count(), 2);
+        wait_for_client_count(&channel, 2).await;
 
         let _w1 = drain_next_text(&mut ws1).await;
         let _w2 = drain_next_text(&mut ws2).await;
@@ -1617,7 +1625,7 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        wait_for_client_count(&channel, 1).await;
 
         // Send auth message with correct token.
         let auth_json = r#"{"type":"auth","token":"secret123"}"#;
@@ -1652,7 +1660,7 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        wait_for_client_count(&channel, 1).await;
 
         // Send auth with wrong token.
         let auth_json = r#"{"type":"auth","token":"wrong"}"#;
@@ -1675,7 +1683,7 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        wait_for_client_count(&channel, 1).await;
 
         // Send a regular message without auth.
         let msg_json = r#"{"type":"message","content":"hello"}"#;
@@ -1697,8 +1705,6 @@ mod tests {
         let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
             .await
             .unwrap();
-
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
         // Welcome should arrive immediately (no auth required).
         let parsed = drain_next_text(&mut ws).await;
@@ -1728,7 +1734,7 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        wait_for_client_count(&channel, 1).await;
 
         // Send legacy format without auth — should be rejected.
         let legacy = r#"{"role":"user","content":"hello"}"#;
@@ -1750,7 +1756,7 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        wait_for_client_count(&channel, 1).await;
 
         // Send ping before auth — should be rejected.
         let ping = r#"{"type":"ping"}"#;
@@ -1808,7 +1814,7 @@ mod tests {
         });
 
         // Give the consumer time to subscribe to the broadcast channel.
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
         // Publish a streaming chunk.
         bus.publish_stream_chunk(StreamChunk {
@@ -1881,7 +1887,7 @@ mod tests {
         });
 
         // Give it a moment to process.
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
         running_flag.store(false, Ordering::Relaxed);
         bus.publish_stream_chunk(StreamChunk {
@@ -1906,7 +1912,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         // Send /help — should be intercepted locally.
@@ -1939,7 +1944,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let envelope = WsEnvelope::message("/status");
@@ -1964,7 +1968,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let envelope = WsEnvelope::message("/settings");
@@ -1992,7 +1995,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         let mut envelope = WsEnvelope::message("/help");
@@ -2016,7 +2018,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let _welcome = drain_next_text(&mut ws).await;
 
         // Non-command message should reach the bus.

--- a/crates/kestrel-channels/tests/websocket_integration.rs
+++ b/crates/kestrel-channels/tests/websocket_integration.rs
@@ -68,13 +68,13 @@ async fn test_full_cycle_no_auth() {
         });
     }
     // Give streaming consumer time to subscribe.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     // Connect client.
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     // 1. Receive welcome.
     let welcome = drain_text(&mut ws).await;
@@ -137,7 +137,7 @@ async fn test_full_cycle_with_auth() {
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     // 1. Sending a message before auth should fail.
     let msg = WsEnvelope::message("premature");
@@ -153,7 +153,7 @@ async fn test_full_cycle_with_auth() {
     let (mut ws2, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     let auth_msg = r#"{"type":"auth","token":"my-token"}"#;
     ws2.send(WsMessage::Text(auth_msg.into())).await.unwrap();
@@ -215,7 +215,7 @@ async fn test_streaming_end_to_end() {
             .await;
         });
     }
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     // Publish streaming chunks.
     bus.publish_stream_chunk(StreamChunk {
@@ -288,7 +288,7 @@ async fn test_multiple_clients_individual_sessions() {
     let (mut ws2, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
     // Drain welcomes.
     let w1 = drain_text(&mut ws1).await;
@@ -358,7 +358,7 @@ async fn test_trace_id_from_envelope_to_inbound_message() {
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     // Drain welcome.
     let _welcome = drain_text(&mut ws).await;
@@ -399,7 +399,7 @@ async fn test_trace_id_auto_generated_when_missing() {
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     let _welcome = drain_text(&mut ws).await;
 
@@ -469,7 +469,7 @@ async fn test_outbound_message_carries_trace_id() {
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     let welcome = drain_text(&mut ws).await;
     let client_id = welcome["client_id"].as_str().unwrap().to_string();
@@ -510,7 +510,7 @@ async fn test_trace_id_round_trip_full_chain() {
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     let welcome = drain_text(&mut ws).await;
     // The client_id from welcome equals the chat_id in InboundMessage.
@@ -573,7 +573,7 @@ async fn test_inbound_metadata_contains_ws_ids() {
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{}", addr))
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     let welcome = drain_text(&mut ws).await;
     let client_id = welcome["client_id"].as_str().unwrap().to_string();
@@ -631,7 +631,7 @@ async fn test_streaming_chunk_carries_trace_id() {
             .await;
         });
     }
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     // Publish a streaming chunk WITH trace_id.
     bus.publish_stream_chunk(StreamChunk {


### PR DESCRIPTION
## Summary
- Replace 22 × `sleep(150/200ms)` in websocket tests with `wait_for_client_count()` (polls every 5ms, 2s timeout) or remove entirely (drain already has timeout)
- Reduce streaming consumer subscribe wait from 150ms → 20ms
- Reduce integration test sleeps from 100/200ms → 10/20ms
- Remove redundant CI Build job (`cargo build`) since Test job already compiles everything
- Unify CI cache key across Clippy and Test jobs for artifact reuse

## Test plan
- [ ] CI Test job completes without flaky timeouts
- [ ] Test job duration is lower than current main (~3m51s)
- [ ] All 2,054 workspace tests pass

Bahtya