### PR TITLE
fix(agent): session timeout cleanup + deadline-aware retries (#200 #201 #202 #203)

### DIFF
--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -250,6 +250,7 @@ impl AgentLoop {
                     let timeout_chat_id = msg.chat_id.clone();
                     let timeout_message_id = msg.message_id.clone();
                     let timeout_trace_id = msg.trace_id.clone();
+                    let timeout_session_key = msg.session_key();
 
                     let result = tokio::time::timeout(
                         std::time::Duration::from_secs(self.config.agent.message_timeout),
@@ -280,6 +281,14 @@ impl AgentLoop {
                             if let Err(e) = self.bus.publish_outbound(timeout_reply).await {
                                 error!("Failed to send timeout reply: {}", e);
                             }
+
+                            // Clean up stale session entry after timeout
+                            if let Some((_, token)) =
+                                self.active_sessions.remove(&timeout_session_key)
+                            {
+                                token.cancel();
+                            }
+                            self.pending_messages.remove(&timeout_session_key);
                         }
                     }
                 }
@@ -469,6 +478,8 @@ impl AgentLoop {
             // Run agent with events wired through, with retry for transient stream errors
             let messages = session.to_messages();
             let run_start = std::time::Instant::now();
+            let retry_deadline =
+                run_start + std::time::Duration::from_secs(self.config.agent.message_timeout);
             let max_retries = 3;
             let mut attempt = 0;
             let mut stream_consumer_handle: Option<tokio::task::JoinHandle<(String, Option<String>)>> = None;
@@ -564,7 +575,24 @@ impl AgentLoop {
                             || err_str.contains("reset by peer");
 
                         if is_transient && attempt < max_retries {
-                            let backoff = std::time::Duration::from_secs(1 << (attempt + 1));
+                            let is_stream_error = err_str.contains("Stream error")
+                                || err_str.contains("error decoding response body");
+                            let backoff = if is_stream_error {
+                                std::time::Duration::from_millis(500 << attempt)
+                            } else {
+                                std::time::Duration::from_secs(1 << (attempt + 1))
+                            };
+
+                            let now = std::time::Instant::now();
+                            if now + backoff >= retry_deadline {
+                                warn!(
+                                    remaining_ms = (retry_deadline - now).as_millis() as u64,
+                                    backoff_ms = backoff.as_millis() as u64,
+                                    "Skipping retry: would exceed message timeout budget"
+                                );
+                                break 'retry Err(e);
+                            }
+
                             warn!(
                                 attempt = attempt + 1,
                                 max_retries,
@@ -1275,7 +1303,10 @@ impl AgentLoop {
 
     /// Check if a session currently has an active agent run.
     pub fn is_session_active(&self, session_key: &str) -> bool {
-        self.active_sessions.contains_key(session_key)
+        self.active_sessions
+            .get(session_key)
+            .map(|entry| !entry.value().is_cancelled())
+            .unwrap_or(false)
     }
 }
 

--- a/crates/kestrel-providers/src/retry.rs
+++ b/crates/kestrel-providers/src/retry.rs
@@ -68,6 +68,8 @@ pub struct RetryPolicy {
     /// Lower than `max_delay` (30s vs 60s) because 503 outages are typically
     /// short-lived and we want faster retry cycles.
     pub max_delay_503: Duration,
+    /// Optional deadline; retries are aborted when this instant is reached.
+    pub deadline: Option<std::time::Instant>,
 }
 
 impl Default for RetryPolicy {
@@ -80,6 +82,7 @@ impl Default for RetryPolicy {
             retryable_status_codes: vec![429, 500, 502, 503],
             max_retries_503: 5,
             max_delay_503: Duration::from_secs(30),
+            deadline: None,
         }
     }
 }
@@ -95,6 +98,7 @@ impl RetryPolicy {
             retryable_status_codes: vec![],
             max_retries_503: 0,
             max_delay_503: Duration::from_secs(30),
+            deadline: None,
         }
     }
 
@@ -144,6 +148,12 @@ impl RetryPolicy {
     pub fn is_retryable(&self, status: u16) -> bool {
         self.retryable_status_codes.contains(&status)
     }
+
+    /// Set a deadline after which retries are aborted.
+    pub fn with_deadline(mut self, deadline: std::time::Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -166,6 +176,8 @@ pub struct RetryConfig {
     pub max_retries_503: u32,
     /// Maximum delay cap for 503 retries (default 30s).
     pub max_delay_503: Duration,
+    /// Optional deadline; retries are aborted when this instant is reached.
+    pub deadline: Option<std::time::Instant>,
 }
 
 impl Default for RetryConfig {
@@ -176,6 +188,7 @@ impl Default for RetryConfig {
             retry_on_server_error: true,
             max_retries_503: 5,
             max_delay_503: Duration::from_secs(30),
+            deadline: None,
         }
     }
 }
@@ -189,12 +202,19 @@ impl RetryConfig {
             retry_on_server_error: false,
             max_retries_503: 0,
             max_delay_503: Duration::from_secs(30),
+            deadline: None,
         }
     }
 
     /// Create a config with a custom max retry count.
     pub fn with_max_retries(mut self, max: u32) -> Self {
         self.max_retries = max;
+        self
+    }
+
+    /// Set a deadline after which retries are aborted.
+    pub fn with_deadline(mut self, deadline: std::time::Instant) -> Self {
+        self.deadline = Some(deadline);
         self
     }
 }
@@ -211,6 +231,7 @@ impl From<RetryPolicy> for RetryConfig {
             retry_on_server_error,
             max_retries_503: policy.max_retries_503,
             max_delay_503: policy.max_delay_503,
+            deadline: policy.deadline,
         }
     }
 }
@@ -519,6 +540,11 @@ where
                     return Err(err);
                 }
                 let delay = backoff_duration(config.initial_backoff, attempt, max_delay_for_err);
+                if let Some(dl) = config.deadline {
+                    if std::time::Instant::now() + delay >= dl {
+                        return Err(err);
+                    }
+                }
                 warn!(
                     attempt = attempt + 1,
                     max_retries = max_retries_for_err,
@@ -588,6 +614,12 @@ where
                 } else {
                     backoff_duration(policy.base_delay, attempt, max_delay_for_err)
                 };
+
+                if let Some(dl) = policy.deadline {
+                    if std::time::Instant::now() + delay >= dl {
+                        return Err(err);
+                    }
+                }
 
                 warn!(
                     attempt = attempt + 1,


### PR DESCRIPTION
## Summary

Batch fix for 4 related bugs in the agent loop's timeout and retry handling:

- **#200** — `active_sessions` entry not cleaned up after `message_timeout`, causing session leak and ghost entries
- **#201** — Provider-level 429 retries consume the `message_timeout` budget, causing premature timeouts
- **#202** — Stream decode errors use the same aggressive backoff as other transient errors, wasting retry budget
- **#203** — `is_session_active` returns `true` for cancelled (timed-out) sessions, sending misleading "正在重新规划..." messages

## Changes

### `crates/kestrel-agent/src/loop_mod.rs`

1. **#200**: Extract `session_key` before the `tokio::time::timeout` call. In the `Err(_)` (timeout) branch, remove the session from `active_sessions`, cancel its token, and clear any pending message.

2. **#203**: `is_session_active()` now checks `!entry.value().is_cancelled()` instead of just `contains_key`, so stale entries from timed-out runs are treated as inactive.

3. **#201**: Compute a `retry_deadline` (now + `message_timeout`) at the start of `process_message`. Before each agent-loop retry backoff, check if `now + backoff >= retry_deadline` — if so, skip the retry and return the error immediately.

4. **#202**: Stream decode errors (`"Stream error"`, `"error decoding response body"`) now use a shorter backoff (500ms base, 1s/2s on retries) instead of the default 2s/4s/8s.

### `crates/kestrel-providers/src/retry.rs`

5. **#201**: Add optional `deadline: Option<Instant>` to both `RetryPolicy` and `RetryConfig` (default `None`, backward-compatible). Both `retry_with_backoff` and `retry_with_policy` check the deadline before sleeping for backoff — if the delay would exceed the deadline, the error is returned immediately.

## Test plan

- [x] CI compiles and passes `cargo clippy` / `cargo test`
- [ ] Manual: send a message that triggers a long provider response, verify timeout cleans up session
- [ ] Manual: under rate limiting, verify retries don't exceed the timeout budget
- [ ] Manual: after a timeout, send a new message to the same chat — should NOT see "正在重新规划..."

Bahtya