### PR TITLE
feat: OpenCode Go provider and extensible model selection system

### DIFF
--- a/crates/kestrel-channels/Cargo.toml
+++ b/crates/kestrel-channels/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 kestrel-core = { path = "../kestrel-core" }
 kestrel-config = { path = "../kestrel-config" }
+kestrel-providers = { path = "../kestrel-providers" }
 kestrel-bus = { path = "../kestrel-bus" }
 kestrel-session = { path = "../kestrel-session" }
 kestrel-skill = { path = "../kestrel-skill" }

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -723,7 +723,8 @@ async fn ws_settings_models_list(arg: &str) -> String {
 
     let models = catalog.list_all_models().await;
     if models.is_empty() {
-        return "No models discovered. Configure a provider (e.g. opencode_go) in config.yaml.".to_string();
+        return "No models discovered. Configure a provider (e.g. opencode_go) in config.yaml."
+            .to_string();
     }
 
     let mut out = String::new();
@@ -799,11 +800,7 @@ fn ws_settings_gateway() -> String {
             config.api.allowed_origins.join(", ")
         }
     );
-    let _ = writeln!(
-        out,
-        "Max body size: {} bytes",
-        config.api.max_body_size
-    );
+    let _ = writeln!(out, "Max body size: {} bytes", config.api.max_body_size);
     let _ = writeln!(
         out,
         "WebSocket: {}",
@@ -835,7 +832,11 @@ fn ws_settings_timeout(arg: &str) -> String {
         let _ = writeln!(out, "Timeout settings (seconds)");
         let _ = writeln!(out, "tool_timeout: {}", config.agent.tool_timeout);
         let _ = writeln!(out, "connect_timeout: {}", config.agent.connect_timeout);
-        let _ = writeln!(out, "first_byte_timeout: {}", config.agent.first_byte_timeout);
+        let _ = writeln!(
+            out,
+            "first_byte_timeout: {}",
+            config.agent.first_byte_timeout
+        );
         let _ = writeln!(out, "idle_timeout: {}", config.agent.idle_timeout);
         let _ = writeln!(out, "message_timeout: {}", config.agent.message_timeout);
         let _ = writeln!(out, "\nUsage: /settings timeout <key> <secs>");
@@ -857,7 +858,12 @@ fn ws_settings_timeout(arg: &str) -> String {
 
     let secs: u64 = match value_str.parse() {
         Ok(v) => v,
-        Err(_) => return format!("Invalid value '{}'. Must be a number in seconds.", value_str),
+        Err(_) => {
+            return format!(
+                "Invalid value '{}'. Must be a number in seconds.",
+                value_str
+            )
+        }
     };
 
     let mut config = match load_config(None) {
@@ -911,7 +917,10 @@ fn ws_settings_retry() -> String {
     let _ = writeln!(out, "retryable_codes: 429, 500, 502, 503");
     let _ = writeln!(out, "max_retries_503: 5");
     let _ = writeln!(out, "max_delay_503: 30s");
-    let _ = writeln!(out, "\nRetry is configured per-provider with circuit breaking.");
+    let _ = writeln!(
+        out,
+        "\nRetry is configured per-provider with circuit breaking."
+    );
     out
 }
 

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -6,22 +6,26 @@
 
 use kestrel_config::validate::ValidationFinding;
 use kestrel_config::{load_config, validate, Config};
+use kestrel_providers::ModelCatalog;
 use kestrel_session::SessionManager;
 use kestrel_skill::{Skill, SkillRegistry};
 use std::fmt::Write;
 use std::sync::{Arc, LazyLock};
 
 use parking_lot::RwLock;
+use tokio::sync::OnceCell;
 
 use crate::platforms::telegram::{InlineKeyboardBuilder, InlineKeyboardMarkup};
 
-/// Model names available for cycling via /settings.
+/// Fallback model names for cycling when dynamic discovery is unavailable.
 const MODEL_CYCLE: &[&str] = &[
     "gpt-4o",
     "claude-sonnet-4-6",
     "deepseek-chat",
     "deepseek/deepseek-v4-flash",
 ];
+
+static MODEL_CATALOG: OnceCell<ModelCatalog> = OnceCell::const_new();
 
 static SKILL_REGISTRY: LazyLock<RwLock<Option<Arc<SkillRegistry>>>> =
     LazyLock::new(|| RwLock::new(None));
@@ -33,6 +37,16 @@ pub fn set_skill_registry(registry: Option<Arc<SkillRegistry>>) {
 
 fn configured_skill_registry() -> Option<Arc<SkillRegistry>> {
     SKILL_REGISTRY.read().clone()
+}
+
+/// Get or initialize the shared model catalog.
+async fn get_model_catalog() -> &'static ModelCatalog {
+    MODEL_CATALOG
+        .get_or_init(|| async {
+            let config = load_config(None).unwrap_or_default();
+            kestrel_providers::build_catalog(&config)
+        })
+        .await
 }
 
 // ---------------------------------------------------------------------------
@@ -598,8 +612,10 @@ fn save_config_to_default(config: &Config) -> Result<(), String> {
 /// - `/settings model` — show current model
 /// - `/settings model next` — cycle to next model
 /// - `/settings model <name>` — set model by name
+/// - `/settings models` — list all available models from providers
+/// - `/settings models refresh` — force refresh model list from APIs
 /// - `/settings streaming` — toggle streaming
-pub fn handle_ws_settings(text: &str) -> String {
+pub async fn handle_ws_settings(text: &str) -> String {
     let args = command_arguments(text);
 
     if args.is_empty() {
@@ -619,6 +635,8 @@ pub fn handle_ws_settings(text: &str) -> String {
         let _ = writeln!(out, "/settings model — show current model");
         let _ = writeln!(out, "/settings model next — cycle to next model");
         let _ = writeln!(out, "/settings model <name> — set model by name");
+        let _ = writeln!(out, "/settings models — list all available models");
+        let _ = writeln!(out, "/settings models refresh — refresh model list");
         let _ = writeln!(out, "/settings streaming — toggle streaming");
         let _ = writeln!(out, "/settings gateway — show API gateway config");
         let _ = writeln!(out, "/settings timeout — show timeout settings");
@@ -641,9 +659,13 @@ pub fn handle_ws_settings(text: &str) -> String {
                 return format!("Current model: {}", config.agent.model);
             }
             if rest.eq_ignore_ascii_case("next") {
-                return ws_settings_model_switch();
+                return ws_settings_model_switch().await;
             }
             ws_settings_model_set(rest)
+        }
+        "models" => {
+            let rest = parts.next().unwrap_or("").trim();
+            ws_settings_models_list(rest).await
         }
         "streaming" => ws_settings_streaming_toggle(),
         "gateway" => ws_settings_gateway(),
@@ -652,29 +674,77 @@ pub fn handle_ws_settings(text: &str) -> String {
             ws_settings_timeout(rest)
         }
         "retry" => ws_settings_retry(),
-        _ => "Usage:\n/settings model [next|<name>]\n/settings streaming\n/settings gateway\n/settings timeout [key secs]\n/settings retry".to_string(),
+        _ => "Usage:\n/settings model [next|<name>]\n/settings models [refresh]\n/settings streaming\n/settings gateway\n/settings timeout [key secs]\n/settings retry".to_string(),
     }
 }
 
-fn ws_settings_model_switch() -> String {
+async fn ws_settings_model_switch() -> String {
     let mut config = match load_config(None) {
         Ok(c) => c,
         Err(e) => return format!("Failed to load config: {e}"),
     };
 
     let current = config.agent.model.to_lowercase();
-    let idx = MODEL_CYCLE
+
+    // Build cycle from discovered models + fallback list.
+    let catalog = get_model_catalog().await;
+    let discovered = catalog.list_all_models().await;
+    let cycle: Vec<String> = if discovered.is_empty() {
+        MODEL_CYCLE.iter().map(|s| s.to_string()).collect()
+    } else {
+        let mut ids: Vec<String> = discovered.iter().map(|m| m.id.clone()).collect();
+        // Also include qualified IDs for disambiguation.
+        for m in &discovered {
+            ids.push(m.qualified_id());
+        }
+        ids
+    };
+
+    let idx = cycle
         .iter()
         .position(|m| m.eq_ignore_ascii_case(&current))
-        .map(|i| (i + 1) % MODEL_CYCLE.len())
+        .map(|i| (i + 1) % cycle.len())
         .unwrap_or(0);
-    config.agent.model = MODEL_CYCLE[idx].to_string();
+    config.agent.model = cycle[idx].clone();
 
     if let Err(e) = save_config_to_default(&config) {
         return format!("Failed to save config: {e}");
     }
 
     format!("Model switched to: {}", config.agent.model)
+}
+
+async fn ws_settings_models_list(arg: &str) -> String {
+    let catalog = get_model_catalog().await;
+
+    if arg.eq_ignore_ascii_case("refresh") {
+        catalog.invalidate_cache().await;
+    }
+
+    let models = catalog.list_all_models().await;
+    if models.is_empty() {
+        return "No models discovered. Configure a provider (e.g. opencode_go) in config.yaml.".to_string();
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Available models ({}):\n", models.len());
+
+    // Group by provider for readability.
+    let mut current_provider = String::new();
+    for m in &models {
+        if m.provider != current_provider {
+            current_provider = m.provider.clone();
+            let _ = writeln!(out, "[{}]", current_provider);
+        }
+        let ctx = m
+            .context_length
+            .map(|c| format!(" ({}K ctx)", c / 1024))
+            .unwrap_or_default();
+        let _ = writeln!(out, "  {}{}", m.qualified_id(), ctx);
+    }
+
+    let _ = writeln!(out, "\nUse /settings model <id> to select.");
+    out
 }
 
 fn ws_settings_model_set(name: &str) -> String {
@@ -2522,35 +2592,36 @@ agent:
 
     // -- /settings text-based (WebSocket) tests ---------------------------------
 
-    #[test]
-    fn test_ws_settings_shows_current() {
+    #[tokio::test]
+    async fn test_ws_settings_shows_current() {
         let yaml = r#"
 providers:
   openai:
     api_key: "sk-test"
 "#;
         let _dir = with_temp_config(yaml);
-        let result = handle_ws_settings("/settings");
+        let result = handle_ws_settings("/settings").await;
         assert!(result.contains("Settings"));
         assert!(result.contains("Model:"));
         assert!(result.contains("Streaming:"));
         assert!(result.contains("/settings model"));
         assert!(result.contains("/settings streaming"));
+        assert!(result.contains("/settings models"));
     }
 
-    #[test]
-    fn test_ws_settings_model_show_current() {
+    #[tokio::test]
+    async fn test_ws_settings_model_show_current() {
         let yaml = r#"
 agent:
   model: "gpt-4o"
 "#;
         let _dir = with_temp_config(yaml);
-        let result = handle_ws_settings("/settings model");
+        let result = handle_ws_settings("/settings model").await;
         assert!(result.contains("gpt-4o"));
     }
 
-    #[test]
-    fn test_ws_settings_model_next_cycles() {
+    #[tokio::test]
+    async fn test_ws_settings_model_next_cycles() {
         let dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 agent:
@@ -2560,13 +2631,13 @@ agent:
         let config_path = dir.path().join("config.yaml");
         std::fs::write(&config_path, yaml).unwrap();
 
-        let result = handle_ws_settings("/settings model next");
+        let result = handle_ws_settings("/settings model next").await;
         assert!(result.contains("Model switched to:"));
         assert!(!result.contains("gpt-4o") || MODEL_CYCLE.len() == 1);
     }
 
-    #[test]
-    fn test_ws_settings_model_set_by_name() {
+    #[tokio::test]
+    async fn test_ws_settings_model_set_by_name() {
         let dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 agent:
@@ -2576,13 +2647,13 @@ agent:
         let config_path = dir.path().join("config.yaml");
         std::fs::write(&config_path, yaml).unwrap();
 
-        let result = handle_ws_settings("/settings model my-custom-model");
+        let result = handle_ws_settings("/settings model my-custom-model").await;
         assert!(result.contains("gpt-4o"));
         assert!(result.contains("my-custom-model"));
     }
 
-    #[test]
-    fn test_ws_settings_streaming_toggle() {
+    #[tokio::test]
+    async fn test_ws_settings_streaming_toggle() {
         let dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 agent:
@@ -2593,16 +2664,16 @@ agent:
         let config_path = dir.path().join("config.yaml");
         std::fs::write(&config_path, yaml).unwrap();
 
-        let result = handle_ws_settings("/settings streaming");
+        let result = handle_ws_settings("/settings streaming").await;
         assert!(result.contains("Streaming: off"));
 
-        let result2 = handle_ws_settings("/settings streaming");
+        let result2 = handle_ws_settings("/settings streaming").await;
         assert!(result2.contains("Streaming: on"));
     }
 
-    #[test]
-    fn test_ws_settings_unknown_subcommand() {
-        let result = handle_ws_settings("/settings foobar");
+    #[tokio::test]
+    async fn test_ws_settings_unknown_subcommand() {
+        let result = handle_ws_settings("/settings foobar").await;
         assert!(result.contains("Usage"));
     }
 
@@ -2677,5 +2748,12 @@ agent:
         assert!(result.contains("Retry policy"));
         assert!(result.contains("max_retries: 3"));
         assert!(result.contains("jitter: true"));
+    }
+
+    #[tokio::test]
+    async fn test_ws_settings_models_empty() {
+        let _dir = with_empty_home();
+        let result = handle_ws_settings("/settings models").await;
+        assert!(result.contains("No models discovered"));
     }
 }

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -686,7 +686,7 @@ impl WebSocketChannel {
                 }
                 // /settings: text-based interaction for WebSocket (no inline keyboard).
                 else if crate::commands::matches_command(&content_text, "settings") {
-                    let response = crate::commands::handle_ws_settings(&content_text);
+                    let response = crate::commands::handle_ws_settings(&content_text).await;
                     Self::send_ws_reply(
                         &clients,
                         &client_id,

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -167,6 +167,9 @@ pub struct ProvidersConfig {
     /// OpenAI Codex provider settings.
     #[serde(default)]
     pub openai_codex: Option<ProviderEntry>,
+    /// OpenCode Go provider settings (https://opencode.ai/go).
+    #[serde(default)]
+    pub opencode_go: Option<ProviderEntry>,
 }
 
 /// A generic provider entry with API key and optional base URL.

--- a/crates/kestrel-providers/src/discovery.rs
+++ b/crates/kestrel-providers/src/discovery.rs
@@ -109,7 +109,8 @@ impl ModelDiscovery for OpenAiCompatDiscovery {
             .into_iter()
             .map(|m| ModelInfo {
                 id: m.id.clone(),
-                name: m.owned_by
+                name: m
+                    .owned_by
                     .as_ref()
                     .map(|o| format!("{} ({})", m.id, o))
                     .unwrap_or_else(|| m.id.clone()),
@@ -228,11 +229,7 @@ impl ModelCatalog {
             }
         }
 
-        results.sort_by(|a, b| {
-            a.provider
-                .cmp(&b.provider)
-                .then_with(|| a.id.cmp(&b.id))
-        });
+        results.sort_by(|a, b| a.provider.cmp(&b.provider).then_with(|| a.id.cmp(&b.id)));
 
         results
     }
@@ -245,9 +242,7 @@ impl ModelCatalog {
     /// List models for a single provider.
     pub async fn list_provider_models(&self, provider: &str) -> Vec<ModelInfo> {
         let all = self.list_all_models().await;
-        all.into_iter()
-            .filter(|m| m.provider == provider)
-            .collect()
+        all.into_iter().filter(|m| m.provider == provider).collect()
     }
 }
 
@@ -285,10 +280,26 @@ pub fn build_catalog(config: &kestrel_config::schema::Config) -> ModelCatalog {
     // Any OpenAI-compatible provider with an API key can potentially list models.
     // Register discovery for the built-in providers that expose /v1/models.
     let builtins: Vec<(&str, Option<&kestrel_config::schema::ProviderEntry>, &str)> = vec![
-        ("openai", config.providers.openai.as_ref(), "https://api.openai.com/v1"),
-        ("deepseek", config.providers.deepseek.as_ref(), "https://api.deepseek.com/v1"),
-        ("groq", config.providers.groq.as_ref(), "https://api.groq.com/openai/v1"),
-        ("openrouter", config.providers.openrouter.as_ref(), "https://openrouter.ai/api/v1"),
+        (
+            "openai",
+            config.providers.openai.as_ref(),
+            "https://api.openai.com/v1",
+        ),
+        (
+            "deepseek",
+            config.providers.deepseek.as_ref(),
+            "https://api.deepseek.com/v1",
+        ),
+        (
+            "groq",
+            config.providers.groq.as_ref(),
+            "https://api.groq.com/openai/v1",
+        ),
+        (
+            "openrouter",
+            config.providers.openrouter.as_ref(),
+            "https://openrouter.ai/api/v1",
+        ),
     ];
 
     for (name, entry_opt, default_url) in builtins {

--- a/crates/kestrel-providers/src/discovery.rs
+++ b/crates/kestrel-providers/src/discovery.rs
@@ -56,12 +56,7 @@ pub struct OpenAiCompatDiscovery {
 }
 
 impl OpenAiCompatDiscovery {
-    pub fn new(
-        base_url: String,
-        api_key: String,
-        provider_name: String,
-        no_proxy: bool,
-    ) -> Self {
+    pub fn new(base_url: String, api_key: String, provider_name: String, no_proxy: bool) -> Self {
         Self {
             base_url,
             api_key,
@@ -90,7 +85,10 @@ impl ModelDiscovery for OpenAiCompatDiscovery {
         let client = crate::build_client(self.no_proxy)?;
         let url = format!("{}/models", self.base_url);
 
-        debug!("Fetching models from {} for provider {}", url, self.provider_name);
+        debug!(
+            "Fetching models from {} for provider {}",
+            url, self.provider_name
+        );
 
         let resp = client
             .get(&url)
@@ -106,7 +104,7 @@ impl ModelDiscovery for OpenAiCompatDiscovery {
         }
 
         let body: ModelsResponse = resp.json().await?;
-        let models = body
+        let models: Vec<_> = body
             .data
             .into_iter()
             .map(|m| ModelInfo {

--- a/crates/kestrel-providers/src/discovery.rs
+++ b/crates/kestrel-providers/src/discovery.rs
@@ -1,0 +1,356 @@
+//! Model discovery — fetch available models from provider APIs dynamically.
+//!
+//! Each provider can implement [`ModelDiscovery`] to list its models.
+//! [`ModelCatalog`] aggregates models from all configured providers with
+//! time-based caching so repeated `/settings models` calls don't hammer APIs.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+/// Metadata for a single model offered by a provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelInfo {
+    /// Model identifier used in API calls (e.g. "glm-5.1").
+    pub id: String,
+    /// Human-readable display name.
+    pub name: String,
+    /// Provider that serves this model (e.g. "opencode_go").
+    pub provider: String,
+    /// Maximum context window in tokens, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<u64>,
+    /// Optional description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Qualified model ID: `provider/model_id` (e.g. "opencode_go/glm-5.1").
+impl ModelInfo {
+    pub fn qualified_id(&self) -> String {
+        format!("{}/{}", self.provider, self.id)
+    }
+}
+
+/// Trait for providers that can enumerate their available models.
+#[async_trait::async_trait]
+pub trait ModelDiscovery: Send + Sync {
+    /// Fetch the list of models available from this provider.
+    async fn list_models(&self) -> Result<Vec<ModelInfo>>;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible /v1/models discovery
+// ---------------------------------------------------------------------------
+
+/// Fetch models from an OpenAI-compatible `/v1/models` endpoint.
+pub struct OpenAiCompatDiscovery {
+    base_url: String,
+    api_key: String,
+    provider_name: String,
+    no_proxy: bool,
+}
+
+impl OpenAiCompatDiscovery {
+    pub fn new(
+        base_url: String,
+        api_key: String,
+        provider_name: String,
+        no_proxy: bool,
+    ) -> Self {
+        Self {
+            base_url,
+            api_key,
+            provider_name,
+            no_proxy,
+        }
+    }
+}
+
+/// Response shape from OpenAI-compatible `/v1/models`.
+#[derive(Debug, Deserialize)]
+struct ModelsResponse {
+    data: Vec<ModelObject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelObject {
+    id: String,
+    #[serde(default)]
+    owned_by: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl ModelDiscovery for OpenAiCompatDiscovery {
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        let client = crate::build_client(self.no_proxy)?;
+        let url = format!("{}/models", self.base_url);
+
+        debug!("Fetching models from {} for provider {}", url, self.provider_name);
+
+        let resp = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Models API error ({}): {}", status, text);
+        }
+
+        let body: ModelsResponse = resp.json().await?;
+        let models = body
+            .data
+            .into_iter()
+            .map(|m| ModelInfo {
+                id: m.id.clone(),
+                name: m.owned_by
+                    .as_ref()
+                    .map(|o| format!("{} ({})", m.id, o))
+                    .unwrap_or_else(|| m.id.clone()),
+                provider: self.provider_name.clone(),
+                context_length: None,
+                description: None,
+            })
+            .collect();
+
+        debug!(
+            "Discovered {} models from provider {}",
+            models.len(),
+            self.provider_name
+        );
+
+        Ok(models)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Model catalog with caching
+// ---------------------------------------------------------------------------
+
+/// Cache TTL for model lists (5 minutes).
+const CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// A cached model list with its fetch time.
+struct CachedModels {
+    models: Vec<ModelInfo>,
+    fetched_at: Instant,
+}
+
+/// Aggregates models from multiple discovery sources with caching.
+pub struct ModelCatalog {
+    discoverers: HashMap<String, Arc<dyn ModelDiscovery>>,
+    cache: RwLock<HashMap<String, CachedModels>>,
+}
+
+impl ModelCatalog {
+    pub fn new() -> Self {
+        Self {
+            discoverers: HashMap::new(),
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register a model discovery source for a provider.
+    pub fn register(&mut self, provider_name: &str, discoverer: Arc<dyn ModelDiscovery>) {
+        self.discoverers
+            .insert(provider_name.to_string(), discoverer);
+    }
+
+    /// List all available models across all registered providers.
+    ///
+    /// Uses cached results when available (TTL: 5 minutes). Fetches from
+    /// each provider concurrently. Failures are logged but don't block
+    /// results from other providers.
+    pub async fn list_all_models(&self) -> Vec<ModelInfo> {
+        let cache = self.cache.read().await;
+        let now = Instant::now();
+
+        // Collect providers that need fresh data.
+        let mut results = Vec::new();
+        let mut to_fetch = Vec::new();
+
+        for (name, discoverer) in &self.discoverers {
+            if let Some(cached) = cache.get(name) {
+                if now.duration_since(cached.fetched_at) < CACHE_TTL {
+                    results.extend(cached.models.clone());
+                    continue;
+                }
+            }
+            to_fetch.push((name.clone(), Arc::clone(discoverer)));
+        }
+
+        drop(cache); // Release read lock before fetching.
+
+        // Fetch missing providers concurrently.
+        if !to_fetch.is_empty() {
+            let fetches: Vec<_> = to_fetch
+                .iter()
+                .map(|(name, disc)| {
+                    let name = name.clone();
+                    let disc = Arc::clone(disc);
+                    tokio::spawn(async move {
+                        let result = disc.list_models().await;
+                        (name, result)
+                    })
+                })
+                .collect();
+
+            let mut cache = self.cache.write().await;
+            for handle in fetches {
+                match handle.await {
+                    Ok((name, Ok(models))) => {
+                        results.extend(models.clone());
+                        cache.insert(
+                            name,
+                            CachedModels {
+                                models,
+                                fetched_at: Instant::now(),
+                            },
+                        );
+                    }
+                    Ok((name, Err(e))) => {
+                        warn!("Failed to fetch models from {}: {}", name, e);
+                        // Serve stale cache if available.
+                        if let Some(cached) = cache.get(&name) {
+                            results.extend(cached.models.clone());
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Model discovery task panicked: {}", e);
+                    }
+                }
+            }
+        }
+
+        results.sort_by(|a, b| {
+            a.provider
+                .cmp(&b.provider)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+
+        results
+    }
+
+    /// Invalidate cached models for all providers (force refresh on next list).
+    pub async fn invalidate_cache(&self) {
+        self.cache.write().await.clear();
+    }
+
+    /// List models for a single provider.
+    pub async fn list_provider_models(&self, provider: &str) -> Vec<ModelInfo> {
+        let all = self.list_all_models().await;
+        all.into_iter()
+            .filter(|m| m.provider == provider)
+            .collect()
+    }
+}
+
+impl Default for ModelCatalog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Build a [`ModelCatalog`] from config, registering discovery for providers
+/// that support it (currently OpenCode Go and any custom provider with a
+/// reachable `/v1/models` endpoint).
+pub fn build_catalog(config: &kestrel_config::schema::Config) -> ModelCatalog {
+    let mut catalog = ModelCatalog::new();
+
+    // OpenCode Go — primary target with dynamic model fetching.
+    if let Some(entry) = &config.providers.opencode_go {
+        if let Some(api_key) = &entry.api_key {
+            let base_url = entry
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://opencode.ai/zen/go/v1".to_string());
+            catalog.register(
+                "opencode_go",
+                Arc::new(OpenAiCompatDiscovery::new(
+                    base_url,
+                    api_key.clone(),
+                    "opencode_go".to_string(),
+                    entry.no_proxy.unwrap_or(false),
+                )),
+            );
+        }
+    }
+
+    // Any OpenAI-compatible provider with an API key can potentially list models.
+    // Register discovery for the built-in providers that expose /v1/models.
+    let builtins: Vec<(&str, Option<&kestrel_config::schema::ProviderEntry>, &str)> = vec![
+        ("openai", config.providers.openai.as_ref(), "https://api.openai.com/v1"),
+        ("deepseek", config.providers.deepseek.as_ref(), "https://api.deepseek.com/v1"),
+        ("groq", config.providers.groq.as_ref(), "https://api.groq.com/openai/v1"),
+        ("openrouter", config.providers.openrouter.as_ref(), "https://openrouter.ai/api/v1"),
+    ];
+
+    for (name, entry_opt, default_url) in builtins {
+        if let Some(entry) = entry_opt {
+            if let Some(api_key) = &entry.api_key {
+                let base_url = entry
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| default_url.to_string());
+                catalog.register(
+                    name,
+                    Arc::new(OpenAiCompatDiscovery::new(
+                        base_url,
+                        api_key.clone(),
+                        name.to_string(),
+                        entry.no_proxy.unwrap_or(false),
+                    )),
+                );
+            }
+        }
+    }
+
+    catalog
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_model_info_qualified_id() {
+        let info = ModelInfo {
+            id: "glm-5.1".to_string(),
+            name: "GLM-5.1".to_string(),
+            provider: "opencode_go".to_string(),
+            context_length: Some(200_000),
+            description: None,
+        };
+        assert_eq!(info.qualified_id(), "opencode_go/glm-5.1");
+    }
+
+    #[tokio::test]
+    async fn test_catalog_empty() {
+        let catalog = ModelCatalog::new();
+        let models = catalog.list_all_models().await;
+        assert!(models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_catalog_default() {
+        let catalog = ModelCatalog::default();
+        let models = catalog.list_all_models().await;
+        assert!(models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_catalog_invalidate() {
+        let catalog = ModelCatalog::new();
+        catalog.invalidate_cache().await;
+        let models = catalog.list_all_models().await;
+        assert!(models.is_empty());
+    }
+}

--- a/crates/kestrel-providers/src/lib.rs
+++ b/crates/kestrel-providers/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod anthropic;
 pub mod base;
+pub mod discovery;
 pub mod middleware;
 pub mod openai_compat;
 pub mod rate_limit;
@@ -17,6 +18,7 @@ pub mod registry;
 pub mod retry;
 
 pub use base::{CompletionRequest, CompletionResponse, LlmProvider};
+pub use discovery::{ModelCatalog, ModelDiscovery, ModelInfo, build_catalog};
 pub use middleware::{MiddlewareConfig, ProviderMiddleware};
 pub use rate_limit::{RateLimiter, TokenBucket};
 pub use registry::ProviderRegistry;

--- a/crates/kestrel-providers/src/lib.rs
+++ b/crates/kestrel-providers/src/lib.rs
@@ -18,7 +18,7 @@ pub mod registry;
 pub mod retry;
 
 pub use base::{CompletionRequest, CompletionResponse, LlmProvider};
-pub use discovery::{ModelCatalog, ModelDiscovery, ModelInfo, build_catalog};
+pub use discovery::{build_catalog, ModelCatalog, ModelDiscovery, ModelInfo};
 pub use middleware::{MiddlewareConfig, ProviderMiddleware};
 pub use rate_limit::{RateLimiter, TokenBucket};
 pub use registry::ProviderRegistry;

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -33,6 +33,8 @@ const MODEL_KEYWORD_MAP: &[(&str, &str)] = &[
     ("mistral", "ollama"),
     ("qwen", "ollama"),
     ("codestral", "ollama"),
+    ("opencode-go", "opencode_go"),
+    ("opencode_go", "opencode_go"),
 ];
 
 /// Registry of LLM providers.
@@ -180,6 +182,24 @@ impl ProviderRegistry {
             })?;
             registry.register("ollama", provider);
             info!("Registered Ollama provider");
+        }
+
+        // Register OpenCode Go provider (OpenAI-compatible endpoint)
+        if let Some(entry) = &config.providers.opencode_go {
+            if let Some(api_key) = &entry.api_key {
+                let provider = OpenAiCompatProvider::new(OpenAiCompatConfig {
+                    api_key: api_key.clone(),
+                    base_url: entry
+                        .base_url
+                        .clone()
+                        .unwrap_or_else(|| "https://opencode.ai/zen/go/v1".to_string()),
+                    model: entry.model.clone().unwrap_or_default(),
+                    organization: None,
+                    no_proxy: entry.no_proxy.unwrap_or(false),
+                })?;
+                registry.register("opencode_go", provider);
+                info!("Registered OpenCode Go provider");
+            }
         }
 
         // Register custom providers


### PR DESCRIPTION
## Summary

- Add **OpenCode Go** as a first-class LLM provider with dynamic model fetching via `/v1/models` API
- Create a generic **model discovery system** (`ModelDiscovery` trait + `ModelCatalog` with TTL cache) designed for easy provider additions (GLM Coding Plan, MiMo, Alibaba Bailian, etc.)
- Enhance `/settings` with dynamic model selection and three new subcommands

## Changes

### Provider infrastructure
- `kestrel-config/schema.rs`: Add `opencode_go: Option<ProviderEntry>` to `ProvidersConfig`
- `kestrel-providers/registry.rs`: Register OpenCode Go as OpenAI-compatible provider, keyword routing for `opencode-go/*`
- `kestrel-providers/discovery.rs` (new): `ModelInfo`, `ModelDiscovery` trait, `OpenAiCompatDiscovery`, `ModelCatalog` with 5-min cache

### Settings commands
- `/settings models` — list all available models grouped by provider
- `/settings models refresh` — force re-fetch from provider APIs
- `/settings model next` — cycle through dynamically discovered models (falls back to static list)
- `/settings model <name>` — set any model by ID or qualified `provider/model` format
- `/settings gateway` — show API gateway config (host, port, CORS, WebSocket)
- `/settings timeout` — show all timeout settings (tool, connect, first_byte, idle, message)
- `/settings timeout <key> <secs>` — set a specific timeout value with validation
- `/settings retry` — show built-in retry policy defaults

## Test plan

- [ ] Verify existing unit tests pass (CI)
- [ ] Configure `opencode_go` in config.yaml and confirm model discovery works
- [ ] Test `/settings models` shows models from OpenCode Go API
- [ ] Test `/settings model opencode_go/glm-5.1` switches model correctly
- [ ] Test `/settings timeout tool_timeout 300` persists correctly
- [ ] Test `/settings gateway` shows API and WebSocket config

Bahtya