### PR TITLE
fix: SSE streaming reliability and retry improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -250,6 +250,7 @@ impl AgentLoop {
                     let timeout_chat_id = msg.chat_id.clone();
                     let timeout_message_id = msg.message_id.clone();
                     let timeout_trace_id = msg.trace_id.clone();
+                    let timeout_session_key = msg.session_key();
 
                     let result = tokio::time::timeout(
                         std::time::Duration::from_secs(self.config.agent.message_timeout),
@@ -280,6 +281,14 @@ impl AgentLoop {
                             if let Err(e) = self.bus.publish_outbound(timeout_reply).await {
                                 error!("Failed to send timeout reply: {}", e);
                             }
+
+                            // Clean up stale session entry after timeout
+                            if let Some((_, token)) =
+                                self.active_sessions.remove(&timeout_session_key)
+                            {
+                                token.cancel();
+                            }
+                            self.pending_messages.remove(&timeout_session_key);
                         }
                     }
                 }
@@ -469,6 +478,8 @@ impl AgentLoop {
             // Run agent with events wired through, with retry for transient stream errors
             let messages = session.to_messages();
             let run_start = std::time::Instant::now();
+            let retry_deadline =
+                run_start + std::time::Duration::from_secs(self.config.agent.message_timeout);
             let max_retries = 3;
             let mut attempt = 0;
             let mut stream_consumer_handle: Option<tokio::task::JoinHandle<(String, Option<String>)>> = None;
@@ -564,7 +575,24 @@ impl AgentLoop {
                             || err_str.contains("reset by peer");
 
                         if is_transient && attempt < max_retries {
-                            let backoff = std::time::Duration::from_secs(1 << (attempt + 1));
+                            let is_stream_error = err_str.contains("Stream error")
+                                || err_str.contains("error decoding response body");
+                            let backoff = if is_stream_error {
+                                std::time::Duration::from_millis(500 << attempt)
+                            } else {
+                                std::time::Duration::from_secs(1 << (attempt + 1))
+                            };
+
+                            let now = std::time::Instant::now();
+                            if now + backoff >= retry_deadline {
+                                warn!(
+                                    remaining_ms = (retry_deadline - now).as_millis() as u64,
+                                    backoff_ms = backoff.as_millis() as u64,
+                                    "Skipping retry: would exceed message timeout budget"
+                                );
+                                break 'retry Err(e);
+                            }
+
                             warn!(
                                 attempt = attempt + 1,
                                 max_retries,
@@ -1275,7 +1303,10 @@ impl AgentLoop {
 
     /// Check if a session currently has an active agent run.
     pub fn is_session_active(&self, session_key: &str) -> bool {
-        self.active_sessions.contains_key(session_key)
+        self.active_sessions
+            .get(session_key)
+            .map(|entry| !entry.value().is_cancelled())
+            .unwrap_or(false)
     }
 }
 

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -570,6 +570,7 @@ impl AgentLoop {
                         let is_transient = err_str.contains("Stream error")
                             || err_str.contains("connection")
                             || err_str.contains("timeout")
+                            || err_str.contains("timed out")
                             || err_str.contains("error decoding response body")
                             || err_str.contains("broken pipe")
                             || err_str.contains("reset by peer");

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -296,10 +296,8 @@ impl AgentRunner {
             let mut first_byte_logged = false;
             let mut full_content = String::new();
             let mut usage: Option<Usage> = None;
-            let mut tool_calls_map: std::collections::HashMap<
-                usize,
-                (String, String, String),
-            > = std::collections::HashMap::new();
+            let mut tool_calls_map: std::collections::HashMap<usize, (String, String, String)> =
+                std::collections::HashMap::new();
 
             let first_chunk_timeout = std::time::Duration::from_secs(15);
             let idle_timeout = std::time::Duration::from_secs(30);
@@ -337,8 +335,7 @@ impl AgentRunner {
                         );
                         if stream_attempt < max_stream_retries {
                             stream_attempt += 1;
-                            let backoff =
-                                std::time::Duration::from_millis(500 << stream_attempt);
+                            let backoff = std::time::Duration::from_millis(500 << stream_attempt);
                             warn!(
                                 attempt = stream_attempt,
                                 max_retries = max_stream_retries,
@@ -361,8 +358,7 @@ impl AgentRunner {
                             || err_str.contains("timeout");
                         if is_stream_err && stream_attempt < max_stream_retries {
                             stream_attempt += 1;
-                            let backoff =
-                                std::time::Duration::from_millis(500 << stream_attempt);
+                            let backoff = std::time::Duration::from_millis(500 << stream_attempt);
                             warn!(
                                 attempt = stream_attempt,
                                 max_retries = max_stream_retries,
@@ -449,8 +445,7 @@ impl AgentRunner {
             })
             .collect();
         tool_calls_list.sort_by_key(|(idx, _)| *idx);
-        let tool_calls: Vec<CoreToolCall> =
-            tool_calls_list.into_iter().map(|(_, tc)| tc).collect();
+        let tool_calls: Vec<CoreToolCall> = tool_calls_list.into_iter().map(|(_, tc)| tc).collect();
 
         Ok(crate::StreamingResult {
             content: if full_content.is_empty() && tool_calls.is_empty() {

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -274,6 +274,14 @@ impl AgentRunner {
         let send_start = std::time::Instant::now();
         let mut stream = provider.complete_stream(request).await?;
 
+        let connect_ms = send_start.elapsed().as_millis() as u64;
+        if connect_ms > 5000 {
+            warn!(
+                elapsed_ms = connect_ms,
+                "Slow provider response: took >5s to establish stream"
+            );
+        }
+
         let mut first_byte_logged = false;
 
         let mut full_content = String::new();
@@ -284,6 +292,7 @@ impl AgentRunner {
         let first_chunk_timeout = std::time::Duration::from_secs(15);
         let idle_timeout = std::time::Duration::from_secs(30);
         let mut is_first = true;
+        let mut last_chunk_at = std::time::Instant::now();
 
         loop {
             let timeout = if is_first {
@@ -293,6 +302,16 @@ impl AgentRunner {
             };
             let chunk_result = tokio::time::timeout(timeout, stream.next()).await;
             is_first = false;
+
+            let now = std::time::Instant::now();
+            let gap = now.duration_since(last_chunk_at);
+            if gap >= std::time::Duration::from_secs(10) {
+                warn!(
+                    elapsed_ms = send_start.elapsed().as_millis() as u64,
+                    gap_ms = gap.as_millis() as u64,
+                    "SSE stream slow: long gap between chunks"
+                );
+            }
 
             let chunk_result = match chunk_result {
                 Ok(Some(r)) => r,
@@ -314,6 +333,7 @@ impl AgentRunner {
                 );
                 first_byte_logged = true;
             }
+            last_chunk_at = std::time::Instant::now();
 
             // Accumulate text content
             if let Some(delta) = &chunk.delta {

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -263,6 +263,10 @@ impl AgentRunner {
     }
 
     /// Perform a streaming completion, accumulating the full response.
+    ///
+    /// On transient stream errors (decode failure, idle timeout), retries the
+    /// provider call up to `max_stream_retries` times with short backoff before
+    /// propagating the error to the agent-loop retry.
     async fn complete_streaming(
         &self,
         provider: &Arc<dyn kestrel_providers::LlmProvider>,
@@ -271,104 +275,153 @@ impl AgentRunner {
         use futures::StreamExt;
         use kestrel_core::{FunctionCall, ToolCall as CoreToolCall};
 
-        let send_start = std::time::Instant::now();
-        let mut stream = provider.complete_stream(request).await?;
+        let max_stream_retries: u32 = 2;
+        let mut stream_attempt = 0u32;
 
-        let connect_ms = send_start.elapsed().as_millis() as u64;
-        if connect_ms > 5000 {
-            warn!(
-                elapsed_ms = connect_ms,
-                "Slow provider response: took >5s to establish stream"
-            );
-        }
-
-        let mut first_byte_logged = false;
-
-        let mut full_content = String::new();
-        let mut usage: Option<Usage> = None;
-        let mut tool_calls_map: std::collections::HashMap<usize, (String, String, String)> =
-            std::collections::HashMap::new();
-
-        let first_chunk_timeout = std::time::Duration::from_secs(15);
-        let idle_timeout = std::time::Duration::from_secs(30);
-        let mut is_first = true;
-        let mut last_chunk_at = std::time::Instant::now();
-
-        loop {
-            let timeout = if is_first {
-                first_chunk_timeout
-            } else {
-                idle_timeout
+        let result = 'stream_retry: loop {
+            let send_start = std::time::Instant::now();
+            let mut stream = match provider.complete_stream(request.clone()).await {
+                Ok(s) => s,
+                Err(e) => break 'stream_retry Err(e),
             };
-            let chunk_result = tokio::time::timeout(timeout, stream.next()).await;
-            is_first = false;
 
-            let now = std::time::Instant::now();
-            let gap = now.duration_since(last_chunk_at);
-            if gap >= std::time::Duration::from_secs(10) {
+            let connect_ms = send_start.elapsed().as_millis() as u64;
+            if connect_ms > 5000 {
                 warn!(
-                    elapsed_ms = send_start.elapsed().as_millis() as u64,
-                    gap_ms = gap.as_millis() as u64,
-                    "SSE stream slow: long gap between chunks"
+                    elapsed_ms = connect_ms,
+                    "Slow provider response: took >5s to establish stream"
                 );
             }
 
-            let chunk_result = match chunk_result {
-                Ok(Some(r)) => r,
-                Ok(None) => break,
-                Err(_) => {
-                    warn!("SSE stream idle timeout after {}s", timeout.as_secs());
-                    anyhow::bail!(
-                        "SSE stream timed out: no data received within {}s",
-                        timeout.as_secs()
+            let mut first_byte_logged = false;
+            let mut full_content = String::new();
+            let mut usage: Option<Usage> = None;
+            let mut tool_calls_map: std::collections::HashMap<
+                usize,
+                (String, String, String),
+            > = std::collections::HashMap::new();
+
+            let first_chunk_timeout = std::time::Duration::from_secs(15);
+            let idle_timeout = std::time::Duration::from_secs(30);
+            let mut is_first = true;
+            let mut last_chunk_at = std::time::Instant::now();
+
+            loop {
+                let timeout = if is_first {
+                    first_chunk_timeout
+                } else {
+                    idle_timeout
+                };
+                let chunk_result = tokio::time::timeout(timeout, stream.next()).await;
+                is_first = false;
+
+                let now = std::time::Instant::now();
+                let gap = now.duration_since(last_chunk_at);
+                if gap >= std::time::Duration::from_secs(10) {
+                    warn!(
+                        elapsed_ms = send_start.elapsed().as_millis() as u64,
+                        gap_ms = gap.as_millis() as u64,
+                        "SSE stream slow: long gap between chunks"
                     );
                 }
-            };
-            let chunk = chunk_result?;
 
-            if !first_byte_logged {
-                debug!(
-                    elapsed_ms = send_start.elapsed().as_millis() as u64,
-                    "SSE first-byte received"
-                );
-                first_byte_logged = true;
-            }
-            last_chunk_at = std::time::Instant::now();
-
-            // Accumulate text content
-            if let Some(delta) = &chunk.delta {
-                full_content.push_str(delta);
-                // Emit streaming chunk
-                self.emit_stream_chunk(delta.clone(), false);
-            }
-
-            // Accumulate tool call deltas
-            if let Some(deltas) = &chunk.tool_call_deltas {
-                for delta in deltas {
-                    let entry = tool_calls_map
-                        .entry(delta.index)
-                        .or_insert_with(|| (String::new(), String::new(), String::new()));
-                    if let Some(id) = &delta.id {
-                        entry.0 = id.clone();
+                let chunk_result = match chunk_result {
+                    Ok(Some(r)) => r,
+                    Ok(None) => {
+                        break 'stream_retry Ok((full_content, usage, tool_calls_map, send_start));
                     }
-                    if let Some(name) = &delta.function_name {
-                        entry.1 = name.clone();
+                    Err(_) => {
+                        let err = anyhow::anyhow!(
+                            "SSE stream timed out: no data received within {}s",
+                            timeout.as_secs()
+                        );
+                        if stream_attempt < max_stream_retries {
+                            stream_attempt += 1;
+                            let backoff =
+                                std::time::Duration::from_millis(500 << stream_attempt);
+                            warn!(
+                                attempt = stream_attempt,
+                                max_retries = max_stream_retries,
+                                backoff_ms = backoff.as_millis() as u64,
+                                "Stream idle timeout, retrying provider call"
+                            );
+                            tokio::time::sleep(backoff).await;
+                            continue 'stream_retry;
+                        }
+                        break 'stream_retry Err(err);
                     }
-                    if let Some(args) = &delta.function_arguments {
-                        entry.2.push_str(args);
+                };
+                let chunk = match chunk_result {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let err_str = format!("{:#}", e);
+                        let is_stream_err = err_str.contains("Stream error")
+                            || err_str.contains("error decoding response body")
+                            || err_str.contains("timed out")
+                            || err_str.contains("timeout");
+                        if is_stream_err && stream_attempt < max_stream_retries {
+                            stream_attempt += 1;
+                            let backoff =
+                                std::time::Duration::from_millis(500 << stream_attempt);
+                            warn!(
+                                attempt = stream_attempt,
+                                max_retries = max_stream_retries,
+                                backoff_ms = backoff.as_millis() as u64,
+                                error = %err_str,
+                                "Stream decode error, retrying provider call"
+                            );
+                            tokio::time::sleep(backoff).await;
+                            continue 'stream_retry;
+                        }
+                        break 'stream_retry Err(e);
+                    }
+                };
+
+                if !first_byte_logged {
+                    debug!(
+                        elapsed_ms = send_start.elapsed().as_millis() as u64,
+                        "SSE first-byte received"
+                    );
+                    first_byte_logged = true;
+                }
+                last_chunk_at = std::time::Instant::now();
+
+                // Accumulate text content
+                if let Some(delta) = &chunk.delta {
+                    full_content.push_str(delta);
+                    self.emit_stream_chunk(delta.clone(), false);
+                }
+
+                // Accumulate tool call deltas
+                if let Some(deltas) = &chunk.tool_call_deltas {
+                    for delta in deltas {
+                        let entry = tool_calls_map
+                            .entry(delta.index)
+                            .or_insert_with(|| (String::new(), String::new(), String::new()));
+                        if let Some(id) = &delta.id {
+                            entry.0 = id.clone();
+                        }
+                        if let Some(name) = &delta.function_name {
+                            entry.1 = name.clone();
+                        }
+                        if let Some(args) = &delta.function_arguments {
+                            entry.2.push_str(args);
+                        }
                     }
                 }
-            }
 
-            // Capture usage from final chunks
-            if chunk.usage.is_some() {
-                usage = chunk.usage.clone();
-            }
+                // Capture usage from final chunks
+                if chunk.usage.is_some() {
+                    usage = chunk.usage.clone();
+                }
 
-            if chunk.done {
-                break;
+                if chunk.done {
+                    break 'stream_retry Ok((full_content, usage, tool_calls_map, send_start));
+                }
             }
-        }
+        };
+
+        let (full_content, usage, tool_calls_map, send_start) = result?;
 
         debug!(
             total_ms = send_start.elapsed().as_millis() as u64,
@@ -396,7 +449,8 @@ impl AgentRunner {
             })
             .collect();
         tool_calls_list.sort_by_key(|(idx, _)| *idx);
-        let tool_calls: Vec<CoreToolCall> = tool_calls_list.into_iter().map(|(_, tc)| tc).collect();
+        let tool_calls: Vec<CoreToolCall> =
+            tool_calls_list.into_iter().map(|(_, tc)| tc).collect();
 
         Ok(crate::StreamingResult {
             content: if full_content.is_empty() && tool_calls.is_empty() {

--- a/crates/kestrel-providers/src/anthropic.rs
+++ b/crates/kestrel-providers/src/anthropic.rs
@@ -49,8 +49,7 @@ impl AnthropicProvider {
 
     /// Create with a custom HTTP client (useful for testing).
     pub fn with_client(config: AnthropicConfig, client: Client) -> Self {
-        let streaming_client = build_streaming_client(false)
-            .unwrap_or_else(|_| client.clone());
+        let streaming_client = build_streaming_client(false).unwrap_or_else(|_| client.clone());
         Self {
             config,
             client,
@@ -77,8 +76,7 @@ impl AnthropicProvider {
         client: Client,
         retry: RetryConfig,
     ) -> Self {
-        let streaming_client = build_streaming_client(false)
-            .unwrap_or_else(|_| client.clone());
+        let streaming_client = build_streaming_client(false).unwrap_or_else(|_| client.clone());
         Self {
             config,
             client,

--- a/crates/kestrel-providers/src/anthropic.rs
+++ b/crates/kestrel-providers/src/anthropic.rs
@@ -7,6 +7,7 @@ use crate::base::{
     BoxStream, CompletionChunk, CompletionRequest, CompletionResponse, LlmProvider, ToolCallDelta,
 };
 use crate::build_client;
+use crate::build_streaming_client;
 use crate::retry::{retry_with_backoff, RetryConfig};
 use anyhow::{Context, Result};
 use reqwest::Client;
@@ -28,6 +29,8 @@ pub struct AnthropicConfig {
 pub struct AnthropicProvider {
     config: AnthropicConfig,
     client: Client,
+    /// Client without total timeout for SSE streaming.
+    streaming_client: Client,
     retry: Arc<RetryConfig>,
 }
 
@@ -35,18 +38,23 @@ impl AnthropicProvider {
     pub fn new(config: AnthropicConfig) -> anyhow::Result<Self> {
         // Anthropic is a foreign API — never skip proxy.
         let client = build_client(false)?;
+        let streaming_client = build_streaming_client(false)?;
         Ok(Self {
             config,
             client,
+            streaming_client,
             retry: Arc::new(RetryConfig::default()),
         })
     }
 
     /// Create with a custom HTTP client (useful for testing).
     pub fn with_client(config: AnthropicConfig, client: Client) -> Self {
+        let streaming_client = build_streaming_client(false)
+            .unwrap_or_else(|_| client.clone());
         Self {
             config,
             client,
+            streaming_client,
             retry: Arc::new(RetryConfig::default()),
         }
     }
@@ -54,9 +62,11 @@ impl AnthropicProvider {
     /// Create with a custom retry configuration.
     pub fn with_retry(config: AnthropicConfig, retry: RetryConfig) -> anyhow::Result<Self> {
         let client = build_client(false)?;
+        let streaming_client = build_streaming_client(false)?;
         Ok(Self {
             config,
             client,
+            streaming_client,
             retry: Arc::new(retry),
         })
     }
@@ -67,9 +77,12 @@ impl AnthropicProvider {
         client: Client,
         retry: RetryConfig,
     ) -> Self {
+        let streaming_client = build_streaming_client(false)
+            .unwrap_or_else(|_| client.clone());
         Self {
             config,
             client,
+            streaming_client,
             retry: Arc::new(retry),
         }
     }
@@ -489,7 +502,7 @@ impl LlmProvider for AnthropicProvider {
             let body = body.clone();
             let api_key = api_key.clone();
             let api_version = api_version.clone();
-            let client = self.client.clone();
+            let client = self.streaming_client.clone();
             async move {
                 let resp = client
                     .post(&url)

--- a/crates/kestrel-providers/src/lib.rs
+++ b/crates/kestrel-providers/src/lib.rs
@@ -22,10 +22,10 @@ pub use rate_limit::{RateLimiter, TokenBucket};
 pub use registry::ProviderRegistry;
 pub use retry::{CircuitBreaker, CircuitBreakerConfig, RetryConfig, RetryPolicy};
 
-/// Build a reqwest client with proper proxy handling.
+/// Build a reqwest client with a total request timeout.
 ///
-/// By default, reqwest reads `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` from the environment.
-/// When `no_proxy` is true, all proxy env vars are ignored (for domestic APIs like ZAI).
+/// Used for non-streaming requests where the entire response must be read
+/// within 30 seconds.
 pub(crate) fn build_client(no_proxy: bool) -> anyhow::Result<reqwest::Client> {
     let mut builder = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
@@ -36,4 +36,22 @@ pub(crate) fn build_client(no_proxy: bool) -> anyhow::Result<reqwest::Client> {
     builder
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to create HTTP client: {}", e))
+}
+
+/// Build a reqwest client for SSE streaming without a total timeout.
+///
+/// SSE streams can last minutes. Instead of a total timeout, this client
+/// uses `connect_timeout` for the TCP/TLS handshake and relies on
+/// application-level idle timeouts (`parse_sse_stream`, `complete_streaming`)
+/// to detect dead connections.
+pub(crate) fn build_streaming_client(no_proxy: bool) -> anyhow::Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .dns_resolver(kestrel_core::dns::build_dns_resolver());
+    if no_proxy {
+        builder = builder.no_proxy();
+    }
+    builder
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to create streaming HTTP client: {}", e))
 }

--- a/crates/kestrel-providers/src/openai_compat.rs
+++ b/crates/kestrel-providers/src/openai_compat.rs
@@ -7,6 +7,7 @@ use crate::base::{
     BoxStream, CompletionChunk, CompletionRequest, CompletionResponse, LlmProvider, ToolCallDelta,
 };
 use crate::build_client;
+use crate::build_streaming_client;
 use crate::retry::{retry_with_backoff, RetryConfig};
 use anyhow::{Context, Result};
 use reqwest::Client;
@@ -32,24 +33,31 @@ pub struct OpenAiCompatConfig {
 pub struct OpenAiCompatProvider {
     config: OpenAiCompatConfig,
     client: Client,
+    /// Client without total timeout for SSE streaming.
+    streaming_client: Client,
     retry: Arc<RetryConfig>,
 }
 
 impl OpenAiCompatProvider {
     pub fn new(config: OpenAiCompatConfig) -> anyhow::Result<Self> {
         let client = build_client(config.no_proxy)?;
+        let streaming_client = build_streaming_client(config.no_proxy)?;
         Ok(Self {
             config,
             client,
+            streaming_client,
             retry: Arc::new(RetryConfig::default()),
         })
     }
 
     /// Create with a custom HTTP client (useful for testing).
     pub fn with_client(config: OpenAiCompatConfig, client: Client) -> Self {
+        let streaming_client = build_streaming_client(config.no_proxy)
+            .unwrap_or_else(|_| client.clone());
         Self {
             config,
             client,
+            streaming_client,
             retry: Arc::new(RetryConfig::default()),
         }
     }
@@ -57,9 +65,11 @@ impl OpenAiCompatProvider {
     /// Create with a custom retry configuration.
     pub fn with_retry(config: OpenAiCompatConfig, retry: RetryConfig) -> anyhow::Result<Self> {
         let client = build_client(config.no_proxy)?;
+        let streaming_client = build_streaming_client(config.no_proxy)?;
         Ok(Self {
             config,
             client,
+            streaming_client,
             retry: Arc::new(retry),
         })
     }
@@ -70,9 +80,12 @@ impl OpenAiCompatProvider {
         client: Client,
         retry: RetryConfig,
     ) -> Self {
+        let streaming_client = build_streaming_client(config.no_proxy)
+            .unwrap_or_else(|_| client.clone());
         Self {
             config,
             client,
+            streaming_client,
             retry: Arc::new(retry),
         }
     }
@@ -478,7 +491,7 @@ impl LlmProvider for OpenAiCompatProvider {
             let url = url.clone();
             let body = body.clone();
             let headers = headers.clone();
-            let client = self.client.clone();
+            let client = self.streaming_client.clone();
             async move {
                 let mut req_builder = client.post(&url);
                 for (k, v) in &headers {

--- a/crates/kestrel-providers/src/openai_compat.rs
+++ b/crates/kestrel-providers/src/openai_compat.rs
@@ -52,8 +52,8 @@ impl OpenAiCompatProvider {
 
     /// Create with a custom HTTP client (useful for testing).
     pub fn with_client(config: OpenAiCompatConfig, client: Client) -> Self {
-        let streaming_client = build_streaming_client(config.no_proxy)
-            .unwrap_or_else(|_| client.clone());
+        let streaming_client =
+            build_streaming_client(config.no_proxy).unwrap_or_else(|_| client.clone());
         Self {
             config,
             client,
@@ -80,8 +80,8 @@ impl OpenAiCompatProvider {
         client: Client,
         retry: RetryConfig,
     ) -> Self {
-        let streaming_client = build_streaming_client(config.no_proxy)
-            .unwrap_or_else(|_| client.clone());
+        let streaming_client =
+            build_streaming_client(config.no_proxy).unwrap_or_else(|_| client.clone());
         Self {
             config,
             client,

--- a/crates/kestrel-providers/src/retry.rs
+++ b/crates/kestrel-providers/src/retry.rs
@@ -647,7 +647,10 @@ fn is_retryable_err(err: &anyhow::Error, retry_on_server_error: bool) -> bool {
         }
         return false;
     }
-    msg.contains("connection") || msg.contains("timeout") || msg.contains("timed out") || msg.contains("refused")
+    msg.contains("connection")
+        || msg.contains("timeout")
+        || msg.contains("timed out")
+        || msg.contains("refused")
 }
 
 /// Check if an error is retryable using a RetryPolicy.
@@ -657,7 +660,10 @@ fn is_retryable_err_policy(err: &anyhow::Error, policy: &RetryPolicy) -> bool {
         return policy.is_retryable(code);
     }
     // Connection-level errors are always retryable.
-    msg.contains("connection") || msg.contains("timeout") || msg.contains("timed out") || msg.contains("refused")
+    msg.contains("connection")
+        || msg.contains("timeout")
+        || msg.contains("timed out")
+        || msg.contains("refused")
 }
 
 /// Extract HTTP status code from an error message like "API error (429): ..."

--- a/crates/kestrel-providers/src/retry.rs
+++ b/crates/kestrel-providers/src/retry.rs
@@ -68,6 +68,8 @@ pub struct RetryPolicy {
     /// Lower than `max_delay` (30s vs 60s) because 503 outages are typically
     /// short-lived and we want faster retry cycles.
     pub max_delay_503: Duration,
+    /// Optional deadline; retries are aborted when this instant is reached.
+    pub deadline: Option<std::time::Instant>,
 }
 
 impl Default for RetryPolicy {
@@ -80,6 +82,7 @@ impl Default for RetryPolicy {
             retryable_status_codes: vec![429, 500, 502, 503],
             max_retries_503: 5,
             max_delay_503: Duration::from_secs(30),
+            deadline: None,
         }
     }
 }
@@ -95,6 +98,7 @@ impl RetryPolicy {
             retryable_status_codes: vec![],
             max_retries_503: 0,
             max_delay_503: Duration::from_secs(30),
+            deadline: None,
         }
     }
 
@@ -144,6 +148,12 @@ impl RetryPolicy {
     pub fn is_retryable(&self, status: u16) -> bool {
         self.retryable_status_codes.contains(&status)
     }
+
+    /// Set a deadline after which retries are aborted.
+    pub fn with_deadline(mut self, deadline: std::time::Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -166,6 +176,8 @@ pub struct RetryConfig {
     pub max_retries_503: u32,
     /// Maximum delay cap for 503 retries (default 30s).
     pub max_delay_503: Duration,
+    /// Optional deadline; retries are aborted when this instant is reached.
+    pub deadline: Option<std::time::Instant>,
 }
 
 impl Default for RetryConfig {
@@ -176,6 +188,7 @@ impl Default for RetryConfig {
             retry_on_server_error: true,
             max_retries_503: 5,
             max_delay_503: Duration::from_secs(30),
+            deadline: None,
         }
     }
 }
@@ -189,12 +202,19 @@ impl RetryConfig {
             retry_on_server_error: false,
             max_retries_503: 0,
             max_delay_503: Duration::from_secs(30),
+            deadline: None,
         }
     }
 
     /// Create a config with a custom max retry count.
     pub fn with_max_retries(mut self, max: u32) -> Self {
         self.max_retries = max;
+        self
+    }
+
+    /// Set a deadline after which retries are aborted.
+    pub fn with_deadline(mut self, deadline: std::time::Instant) -> Self {
+        self.deadline = Some(deadline);
         self
     }
 }
@@ -211,6 +231,7 @@ impl From<RetryPolicy> for RetryConfig {
             retry_on_server_error,
             max_retries_503: policy.max_retries_503,
             max_delay_503: policy.max_delay_503,
+            deadline: policy.deadline,
         }
     }
 }
@@ -519,6 +540,11 @@ where
                     return Err(err);
                 }
                 let delay = backoff_duration(config.initial_backoff, attempt, max_delay_for_err);
+                if let Some(dl) = config.deadline {
+                    if std::time::Instant::now() + delay >= dl {
+                        return Err(err);
+                    }
+                }
                 warn!(
                     attempt = attempt + 1,
                     max_retries = max_retries_for_err,
@@ -588,6 +614,12 @@ where
                 } else {
                     backoff_duration(policy.base_delay, attempt, max_delay_for_err)
                 };
+
+                if let Some(dl) = policy.deadline {
+                    if std::time::Instant::now() + delay >= dl {
+                        return Err(err);
+                    }
+                }
 
                 warn!(
                     attempt = attempt + 1,

--- a/crates/kestrel-providers/src/retry.rs
+++ b/crates/kestrel-providers/src/retry.rs
@@ -647,7 +647,7 @@ fn is_retryable_err(err: &anyhow::Error, retry_on_server_error: bool) -> bool {
         }
         return false;
     }
-    msg.contains("connection") || msg.contains("timeout") || msg.contains("refused")
+    msg.contains("connection") || msg.contains("timeout") || msg.contains("timed out") || msg.contains("refused")
 }
 
 /// Check if an error is retryable using a RetryPolicy.
@@ -657,7 +657,7 @@ fn is_retryable_err_policy(err: &anyhow::Error, policy: &RetryPolicy) -> bool {
         return policy.is_retryable(code);
     }
     // Connection-level errors are always retryable.
-    msg.contains("connection") || msg.contains("timeout") || msg.contains("refused")
+    msg.contains("connection") || msg.contains("timeout") || msg.contains("timed out") || msg.contains("refused")
 }
 
 /// Extract HTTP status code from an error message like "API error (429): ..."


### PR DESCRIPTION
## Summary
- Use separate HTTP client (connect-only timeout, no total timeout) for SSE streaming to prevent reqwest from killing long-lived streams at 30s
- Add slow-provider WARN logs when SSE stream takes >5s to connect or has >10s gaps between chunks
- Match "timed out" (with space) in retryable error detection alongside "timeout"
- Add stream-error quick retry (up to 2 attempts with 500ms/1s backoff) in `complete_streaming` before falling through to the full agent-loop retry cycle

## Test plan
- [ ] Verify CI passes on all targets
- [ ] Monitor KA logs for SSE stream timeout behavior with slow providers (gpt-4o, glm-5-turbo)
- [ ] Confirm "timed out" errors now trigger retries instead of failing immediately
- [ ] Confirm stream decode errors are retried within `complete_streaming` before agent-loop retry

Bahtya