### PR TITLE
feat: model selection UI and provider prefix stripping

### DIFF
--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -151,15 +151,19 @@ impl AgentRunner {
     /// Run the agent loop with a system prompt and message history.
     /// Uses streaming if a stream_tx is configured.
     pub async fn run(&self, system_prompt: String, messages: Vec<Message>) -> Result<RunResult> {
-        let model = &self.config.agent.model;
+        let config_model = &self.config.agent.model;
         let max_iterations = self.config.agent.max_iterations;
         let temperature = self.config.agent.temperature;
         let max_tokens = self.config.agent.max_tokens;
 
         let provider = self
             .providers
-            .get_provider(model)
-            .with_context(|| format!("No provider available for model: {}", model))?;
+            .get_provider(config_model)
+            .with_context(|| format!("No provider available for model: {}", config_model))?;
+
+        // Strip the provider prefix so the API receives a clean model name.
+        // e.g. "opencode-go/kimi-k2.6" → "kimi-k2.6"
+        let model = self.providers.strip_provider_prefix(config_model);
 
         info!(
             llm_model = %model,

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -40,13 +40,17 @@ fn configured_skill_registry() -> Option<Arc<SkillRegistry>> {
 }
 
 /// Get or initialize the shared model catalog.
-async fn get_model_catalog() -> &'static ModelCatalog {
+pub async fn get_model_catalog_static() -> &'static ModelCatalog {
     MODEL_CATALOG
         .get_or_init(|| async {
             let config = load_config(None).unwrap_or_default();
             kestrel_providers::build_catalog(&config)
         })
         .await
+}
+
+async fn get_model_catalog() -> &'static ModelCatalog {
+    get_model_catalog_static().await
 }
 
 // ---------------------------------------------------------------------------
@@ -139,7 +143,15 @@ fn command_name(text: &str) -> Option<&str> {
 fn is_reserved_command(command: &str) -> bool {
     matches!(
         command.to_ascii_lowercase().as_str(),
-        "help" | "status" | "validate" | "skill" | "settings" | "history" | "reset" | "menu"
+        "help"
+            | "status"
+            | "validate"
+            | "skill"
+            | "settings"
+            | "history"
+            | "reset"
+            | "menu"
+            | "models"
     )
 }
 
@@ -253,6 +265,10 @@ pub async fn try_handle_command(text: &str) -> Option<CommandDispatch> {
         Some(CommandDispatch::Respond(handle_settings()))
     } else if matches_command(text, "history") {
         Some(CommandDispatch::Respond(handle_history_page(0)))
+    } else if matches_command(text, "models") {
+        Some(CommandDispatch::Respond(
+            handle_models_provider_list().await,
+        ))
     } else if matches_command(text, "skill") {
         Some(CommandDispatch::Respond(handle_skill_command(text).await))
     } else if let (Some(registry), Some(name)) = (configured_skill_registry(), command_name(text)) {
@@ -447,6 +463,7 @@ fn handle_help() -> String {
     let _ = writeln!(out, "/skill    - List, view, and search registered skills");
     let _ = writeln!(out, "/validate - Validate config.yaml and show results");
     let _ = writeln!(out, "/settings - Toggle preferences (notifications, model)");
+    let _ = writeln!(out, "/models   - Browse and select models from providers");
     let _ = writeln!(out, "/history  - Browse recent conversation history");
     let _ = writeln!(out, "/reset    - Reset conversation context for this chat");
     let _ = writeln!(out, "/menu     - Show interactive menu");
@@ -546,8 +563,8 @@ fn build_settings_response(config: &Config) -> CommandResponse {
 
     let keyboard = InlineKeyboardBuilder::new()
         .row_pair(
-            "Model: switch",
-            "settings:model:switch",
+            "Models: pick",
+            "models:providers",
             "Streaming: toggle",
             "settings:streaming:toggle",
         )
@@ -1578,6 +1595,149 @@ pub fn handle_reset(session_key: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// /models implementation (two-level provider → model selection)
+// ---------------------------------------------------------------------------
+
+/// Show the provider list as an inline keyboard.
+///
+/// Level 1: User picks a provider to see its models.
+pub async fn handle_models_provider_list() -> CommandResponse {
+    let config = match load_config(None) {
+        Ok(c) => c,
+        Err(e) => return CommandResponse::text(format!("Failed to load config: {e}")),
+    };
+
+    let current_model = config.agent.model.clone();
+
+    let catalog = get_model_catalog().await;
+    let models = catalog.list_all_models().await;
+
+    if models.is_empty() {
+        return CommandResponse::text(
+            "No models discovered. Configure a provider (e.g. opencode_go) in config.yaml.",
+        );
+    }
+
+    // Group models by provider and count.
+    let mut provider_counts: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    for m in &models {
+        *provider_counts.entry(m.provider.clone()).or_insert(0) += 1;
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Select a provider:");
+    let _ = writeln!(out, "Current: {}", current_model);
+
+    let mut kb = InlineKeyboardBuilder::new();
+    for (provider, count) in &provider_counts {
+        let label = format!("{} ({} models)", provider, count);
+        let data = format!("models:provider:{}", provider);
+        kb = kb.button(&label, &data);
+        kb = kb.new_row();
+    }
+    kb = kb.button("Refresh", "models:refresh");
+
+    CommandResponse::with_keyboard(out, kb.build())
+}
+
+/// Show models for a specific provider as an inline keyboard.
+///
+/// Level 2: User picks a model to set as active.
+pub async fn handle_models_provider_detail(provider: &str) -> CommandResponse {
+    let config = match load_config(None) {
+        Ok(c) => c,
+        Err(e) => return CommandResponse::text(format!("Failed to load config: {e}")),
+    };
+
+    let current_model = config.agent.model.clone();
+
+    let catalog = get_model_catalog().await;
+    let models = catalog.list_provider_models(provider).await;
+
+    if models.is_empty() {
+        return CommandResponse::text(format!("No models found for provider: {}", provider));
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "[{}] models:", provider);
+    let _ = writeln!(out, "Current: {}", current_model);
+
+    let mut kb = InlineKeyboardBuilder::new();
+    for m in &models {
+        let marker = if m.qualified_id() == current_model || m.id == current_model {
+            " *"
+        } else {
+            ""
+        };
+        let ctx = m
+            .context_length
+            .map(|c| format!(" ({}K)", c / 1024))
+            .unwrap_or_default();
+        let label = format!("{}{}{}", m.id, ctx, marker);
+        let data = format!("models:select:{}/{}", m.provider, m.id);
+        kb = kb.button(&label, &data);
+        kb = kb.new_row();
+    }
+    kb = kb.button("<< Back to providers", "models:providers");
+
+    CommandResponse::with_keyboard(out, kb.build())
+}
+
+/// Select a model (provider/model_id format) and persist to config.
+pub fn handle_models_select(qualified_id: &str) -> CommandResponse {
+    let mut config = match load_config(None) {
+        Ok(c) => c,
+        Err(e) => return CommandResponse::text(format!("Failed to load config: {e}")),
+    };
+
+    let old = config.agent.model.clone();
+    config.agent.model = qualified_id.to_string();
+
+    if let Err(e) = save_config_to_default(&config) {
+        return CommandResponse::text(format!("Failed to save config: {e}"));
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Model changed:");
+    let _ = writeln!(out, "  {} -> {}", old, qualified_id);
+
+    let keyboard = InlineKeyboardBuilder::new()
+        .button("Select another model", "models:providers")
+        .new_row()
+        .button("Settings", "settings:show")
+        .build();
+
+    CommandResponse::with_keyboard(out, keyboard)
+}
+
+/// Handle a callback from the /models inline keyboard.
+pub fn handle_models_callback(action: &str, payload: Option<&str>) -> Option<CommandResponse> {
+    match action {
+        "providers" => {
+            // Synchronous wrapper — we need to block on async here.
+            // Use tokio::task::block_in_place for a minimal synchronous path.
+            // Actually, let's just show the provider list synchronously from cached data.
+            // The async version is called from the router.
+            None // Handled by the async router
+        }
+        "provider" => {
+            // Handled by async router
+            None
+        }
+        "select" => {
+            let qualified_id = payload?;
+            Some(handle_models_select(qualified_id))
+        }
+        "refresh" => {
+            // Handled by async router
+            None
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Callback handler (for inline keyboard button presses)
 // ---------------------------------------------------------------------------
 
@@ -1599,6 +1759,7 @@ pub fn handle_callback(data: &str) -> Option<CommandResponse> {
         "settings" => match action {
             "model" if payload == Some("switch") => Some(handle_settings_model_switch()),
             "streaming" if payload == Some("toggle") => Some(handle_settings_streaming_toggle()),
+            "show" => Some(handle_settings()),
             _ => None,
         },
         "history" => {
@@ -2112,12 +2273,12 @@ providers:
         let _dir = with_temp_config(yaml);
         let r = handle_settings();
         let kb = r.keyboard.unwrap();
-        // Should have the row with model switch + streaming toggle.
+        // Should have the row with models picker + streaming toggle.
         assert!(!kb.inline_keyboard.is_empty());
         let row = &kb.inline_keyboard[0];
         assert_eq!(row.len(), 2);
-        assert!(row[0].callback_data.as_ref().unwrap().contains("settings"));
-        assert!(row[1].callback_data.as_ref().unwrap().contains("settings"));
+        assert!(row[0].callback_data.as_ref().unwrap().contains("models"));
+        assert!(row[1].callback_data.as_ref().unwrap().contains("streaming"));
     }
 
     // -- /settings tests (paginated view) -------------------------------------
@@ -2770,5 +2931,74 @@ agent:
         let _dir = with_empty_home();
         let result = handle_ws_settings("/settings models").await;
         assert!(result.contains("No models discovered"));
+    }
+
+    // -- /models tests (Telegram two-level selection) -------------------------
+
+    #[tokio::test]
+    async fn test_handle_models_provider_list_no_models() {
+        let _dir = with_empty_home();
+        let resp = handle_models_provider_list().await;
+        assert!(resp.text.contains("No models discovered"));
+        assert!(resp.keyboard.is_none());
+    }
+
+    #[test]
+    fn test_handle_models_select_sets_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = r#"
+agent:
+  model: "gpt-4o"
+"#;
+        let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
+        let config_path = dir.path().join("config.yaml");
+        std::fs::write(&config_path, yaml).unwrap();
+
+        let resp = handle_models_select("opencode_go/kimi-k2.6");
+        assert!(resp.text.contains("Model changed"));
+        assert!(resp.text.contains("gpt-4o"));
+        assert!(resp.text.contains("opencode_go/kimi-k2.6"));
+        assert!(resp.keyboard.is_some());
+    }
+
+    #[test]
+    fn test_handle_models_select_invalid_config() {
+        // No KESTREL_HOME set — should handle gracefully.
+        let resp = handle_models_select("test/model");
+        assert!(resp.text.contains("Failed to") || resp.text.contains("Model changed"));
+    }
+
+    #[test]
+    fn test_handle_models_callback_select() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = r#"
+agent:
+  model: "gpt-4o"
+"#;
+        let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
+        let config_path = dir.path().join("config.yaml");
+        std::fs::write(&config_path, yaml).unwrap();
+
+        let resp = handle_models_callback("select", Some("openai/gpt-4o-mini")).unwrap();
+        assert!(resp.text.contains("Model changed"));
+    }
+
+    #[test]
+    fn test_handle_models_callback_unknown_action() {
+        assert!(handle_models_callback("unknown", None).is_none());
+    }
+
+    #[test]
+    fn test_handle_models_callback_select_no_payload() {
+        assert!(handle_models_callback("select", None).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_try_handle_command_models() {
+        let _dir = with_empty_home();
+        let result = try_handle_command("/models").await;
+        assert!(result.is_some());
+        let resp = expect_response(result.unwrap());
+        assert!(resp.text.contains("No models discovered"));
     }
 }

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -845,6 +845,10 @@ impl TelegramChannel {
                 description: "Show settings".to_string(),
             },
             BotCommand {
+                command: "models".to_string(),
+                description: "Browse and select models".to_string(),
+            },
+            BotCommand {
                 command: "history".to_string(),
                 description: "Browse recent history".to_string(),
             },
@@ -1652,6 +1656,52 @@ impl TelegramChannel {
                     CallbackResponse::EditMessage {
                         text: response.text,
                         keyboard: response.keyboard,
+                    }
+                }
+            });
+        }
+
+        // Models selection handler (provider list, provider detail, model select)
+        if !router.has_handler("models") {
+            router.register("models", |ctx| {
+                let action = ctx.action.action.clone();
+                let payload = ctx.action.payload.clone();
+                async move {
+                    match action.as_str() {
+                        "providers" => {
+                            let response = crate::commands::handle_models_provider_list().await;
+                            CallbackResponse::EditMessage {
+                                text: response.text,
+                                keyboard: response.keyboard,
+                            }
+                        }
+                        "provider" => {
+                            let provider = payload.as_deref().unwrap_or("");
+                            let response =
+                                crate::commands::handle_models_provider_detail(provider).await;
+                            CallbackResponse::EditMessage {
+                                text: response.text,
+                                keyboard: response.keyboard,
+                            }
+                        }
+                        "refresh" => {
+                            let catalog = crate::commands::get_model_catalog_static().await;
+                            catalog.invalidate_cache().await;
+                            let response = crate::commands::handle_models_provider_list().await;
+                            CallbackResponse::EditMessage {
+                                text: response.text,
+                                keyboard: response.keyboard,
+                            }
+                        }
+                        "select" => {
+                            let qualified_id = payload.as_deref().unwrap_or("");
+                            let response = crate::commands::handle_models_select(qualified_id);
+                            CallbackResponse::EditMessage {
+                                text: response.text,
+                                keyboard: response.keyboard,
+                            }
+                        }
+                        _ => CallbackResponse::Acknowledged,
                     }
                 }
             });
@@ -3927,7 +3977,8 @@ mod tests {
         assert!(router.has_handler("settings"));
         assert!(router.has_handler("settings_view"));
         assert!(router.has_handler("history"));
-        assert_eq!(router.handler_count(), 4);
+        assert!(router.has_handler("models"));
+        assert_eq!(router.handler_count(), 5);
     }
 
     #[test]
@@ -3937,7 +3988,7 @@ mod tests {
         TelegramChannel::register_default_handlers(&mut router, &session_keys);
         TelegramChannel::register_default_handlers(&mut router, &session_keys);
         // Should not double-register.
-        assert_eq!(router.handler_count(), 4);
+        assert_eq!(router.handler_count(), 5);
     }
 
     #[tokio::test]

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -252,6 +252,39 @@ impl ProviderRegistry {
         self.default_provider.as_deref()
     }
 
+    /// Strip the provider prefix from a qualified model name.
+    ///
+    /// If `model` contains a `/` and the part before it matches a known provider
+    /// (either by keyword or exact name), returns the part after the `/`.
+    /// Otherwise returns `model` unchanged.
+    ///
+    /// Examples:
+    /// - `"opencode-go/kimi-k2.6"` → `"kimi-k2.6"` (matches "opencode-go" keyword)
+    /// - `"opencode_go/glm-5.1"` → `"glm-5.1"` (matches "opencode_go" keyword)
+    /// - `"claude-sonnet-4-6"` → `"claude-sonnet-4-6"` (no slash, unchanged)
+    /// - `"deepseek/deepseek-v4-flash"` → `"deepseek-v4-flash"` (matches "deepseek" keyword)
+    pub fn strip_provider_prefix(&self, model: &str) -> String {
+        let Some((prefix, rest)) = model.split_once('/') else {
+            return model.to_string();
+        };
+        if rest.is_empty() {
+            return model.to_string();
+        }
+        let lower_prefix = prefix.to_lowercase();
+        for (keyword, provider_name) in MODEL_KEYWORD_MAP {
+            if (lower_prefix == *keyword || lower_prefix == *provider_name)
+                && self.providers.contains_key(*provider_name)
+            {
+                return rest.to_string();
+            }
+        }
+        // Also check if prefix is an exact provider name (handles custom providers).
+        if self.providers.contains_key(prefix) {
+            return rest.to_string();
+        }
+        model.to_string()
+    }
+
     /// Get a provider for a given model.
     pub fn get_provider(&self, model: &str) -> Option<Arc<dyn LlmProvider>> {
         if let Some(name) = self.resolve_provider_name(model) {
@@ -371,5 +404,78 @@ mod tests {
         let reg = ProviderRegistry::default();
         assert!(reg.provider_names().is_empty());
         assert!(reg.default_provider.is_none());
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_with_keyword() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("opencode_go", MockProvider::new("opencode_go", "glm"));
+
+        // "opencode-go/kimi-k2.6" → "kimi-k2.6"
+        assert_eq!(
+            reg.strip_provider_prefix("opencode-go/kimi-k2.6"),
+            "kimi-k2.6"
+        );
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_with_provider_name() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("opencode_go", MockProvider::new("opencode_go", "glm"));
+
+        // "opencode_go/glm-5.1" → "glm-5.1"
+        assert_eq!(reg.strip_provider_prefix("opencode_go/glm-5.1"), "glm-5.1");
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_no_slash() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("openai", MockProvider::new("openai", "gpt"));
+
+        // No slash → unchanged
+        assert_eq!(reg.strip_provider_prefix("gpt-4o"), "gpt-4o");
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_unknown_prefix() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("openai", MockProvider::new("openai", "gpt"));
+
+        // Unknown prefix with slash → unchanged
+        assert_eq!(reg.strip_provider_prefix("unknown/model"), "unknown/model");
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_deepseek() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("deepseek", MockProvider::new("deepseek", "deepseek"));
+        reg.register("openrouter", MockProvider::new("openrouter", "deepseek"));
+
+        // "deepseek/deepseek-v4-flash" → "deepseek-v4-flash"
+        assert_eq!(
+            reg.strip_provider_prefix("deepseek/deepseek-v4-flash"),
+            "deepseek-v4-flash"
+        );
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_empty_after_slash() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("opencode_go", MockProvider::new("opencode_go", "glm"));
+
+        // Empty after slash → unchanged
+        assert_eq!(reg.strip_provider_prefix("opencode-go/"), "opencode-go/");
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_custom_provider() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("my_custom", MockProvider::new("my_custom", "test"));
+
+        // Custom provider by exact name match
+        assert_eq!(
+            reg.strip_provider_prefix("my_custom/mymodel-v1"),
+            "mymodel-v1"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two improvements to the model/provider system added in PR #205:

### 1. Strip provider prefix from model name before API call
When using qualified model names like `opencode-go/kimi-k2.6` in `agent.model`, the provider prefix was sent verbatim to the API, causing `ModelNotFoundError`. Now `ProviderRegistry::strip_provider_prefix()` strips the `provider/` prefix before constructing `CompletionRequest`, so the API receives just `kimi-k2.6`.

- Handles keyword matches (`opencode-go`), exact provider names (`opencode_go`), and custom providers
- Plain model names like `claude-sonnet-4-6` pass through unchanged
- Comprehensive test coverage for prefix stripping edge cases

### 2. Two-level model/provider selection UI for Telegram
New `/models` command with inline keyboard-driven selection:
- **Level 1**: Shows discovered providers with model counts
- **Level 2**: Shows models for a selected provider (with context length info)
- Selecting a model sets `agent.model` to `provider/model_id` format and persists
- `/settings` page now links to `/models` picker instead of simple cycle
- Refresh button invalidates model discovery cache
- Back navigation between provider list and model detail

## Files changed
- `kestrel-providers/src/registry.rs` — `strip_provider_prefix()` + tests
- `kestrel-agent/src/runner.rs` — Use stripped model name in CompletionRequest
- `kestrel-channels/src/commands.rs` — `/models` command handlers + tests
- `kestrel-channels/src/platforms/telegram.rs` — `models` callback router + bot command registration

## Test plan
- [ ] CI passes (cargo build + test)
- [ ] Manual: Set `agent.model: opencode-go/kimi-k2.6` and verify API receives `kimi-k2.6`
- [ ] Manual: `/models` in Telegram shows provider list → model list → selection works
- [ ] Manual: `/settings` shows "Models: pick" button linking to provider list
- [ ] Manual: WebSocket `/settings models` still works as before

Bahtya