### PR TITLE
fix: model/provider routing — prefix precedence, reflection prefix stripping, WebSocket /models

### DIFF
--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -1324,14 +1324,18 @@ impl AgentLoop {
 /// Consecutive failures are tracked and logged at ERROR level once the
 /// threshold is exceeded.
 async fn post_task_reflect(task: ReflectionTask) {
-    let model = &task.config.agent.model;
-    let provider = match task.provider_registry.get_provider(model) {
+    let config_model = &task.config.agent.model;
+    let provider = match task.provider_registry.get_provider(config_model) {
         Some(p) => p,
         None => {
             warn!("No provider available for task reflection");
             return;
         }
     };
+
+    // Strip the provider prefix so the API receives a clean model name
+    // (e.g. "opencode_go/kimi-k2.6" → "kimi-k2.6").
+    let model = task.provider_registry.strip_provider_prefix(config_model);
 
     let reflection_prompt = REFLECTION_USER_TEMPLATE
         .replace("{user_request}", truncate_str(&task.user_message, 100))

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -152,14 +152,20 @@ impl AgentRunner {
     /// Uses streaming if a stream_tx is configured.
     pub async fn run(&self, system_prompt: String, messages: Vec<Message>) -> Result<RunResult> {
         let config_model = &self.config.agent.model;
+        let provider_override = self.config.agent.provider.as_deref();
         let max_iterations = self.config.agent.max_iterations;
         let temperature = self.config.agent.temperature;
         let max_tokens = self.config.agent.max_tokens;
 
         let provider = self
             .providers
-            .get_provider(config_model)
-            .with_context(|| format!("No provider available for model: {}", config_model))?;
+            .get_provider_with_override(config_model, provider_override)
+            .with_context(|| {
+                format!(
+                    "No provider available for model: {} (override: {:?})",
+                    config_model, provider_override
+                )
+            })?;
 
         // Strip the provider prefix so the API receives a clean model name.
         // e.g. "opencode-go/kimi-k2.6" → "kimi-k2.6"

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -6,7 +6,7 @@
 
 use kestrel_config::validate::ValidationFinding;
 use kestrel_config::{load_config, validate, Config};
-use kestrel_providers::ModelCatalog;
+use kestrel_providers::{ModelCatalog, ModelInfo};
 use kestrel_session::SessionManager;
 use kestrel_skill::{Skill, SkillRegistry};
 use std::fmt::Write;
@@ -621,6 +621,104 @@ fn save_config_to_default(config: &Config) -> Result<(), String> {
 // ---------------------------------------------------------------------------
 // /settings text-based implementation (for WebSocket and other non-keyboard channels)
 // ---------------------------------------------------------------------------
+
+/// Handle `/models` for text-only channels (WebSocket, etc.) that lack inline keyboards.
+///
+/// Two-level text-based interaction:
+/// - `/models` — list available providers with model counts
+/// - `/models <provider>` — list models for a specific provider
+/// - `/models <provider>/<model_id>` — select a model
+/// - `/models refresh` — invalidate model cache and show providers
+pub async fn handle_ws_models(text: &str) -> String {
+    let args = command_arguments(text);
+
+    if args.eq_ignore_ascii_case("refresh") {
+        let catalog = get_model_catalog().await;
+        catalog.invalidate_cache().await;
+        return ws_models_provider_list().await;
+    }
+
+    // Check if args looks like a provider/model selection (contains /).
+    if let Some((provider, model_id)) = args.split_once('/') {
+        if !provider.is_empty() && !model_id.is_empty() {
+            return ws_models_select(provider, model_id);
+        }
+    }
+
+    // If args matches a known provider name, show its models.
+    if !args.is_empty() {
+        let catalog = get_model_catalog().await;
+        let models = catalog.list_all_models().await;
+        let provider_models: Vec<_> = models
+            .iter()
+            .filter(|m| m.provider.eq_ignore_ascii_case(args))
+            .collect();
+        if !provider_models.is_empty() {
+            return ws_models_detail(args, &provider_models).await;
+        }
+    }
+
+    // Default: show provider list.
+    ws_models_provider_list().await
+}
+
+async fn ws_models_provider_list() -> String {
+    let config = match load_config(None) {
+        Ok(c) => c,
+        Err(e) => return format!("Failed to load config: {e}"),
+    };
+
+    let current_model = config.agent.model.clone();
+
+    let catalog = get_model_catalog().await;
+    let models = catalog.list_all_models().await;
+
+    if models.is_empty() {
+        return "No models discovered. Configure a provider (e.g. opencode_go) in config.yaml."
+            .to_string();
+    }
+
+    let mut provider_counts: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    for m in &models {
+        *provider_counts.entry(m.provider.clone()).or_insert(0) += 1;
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Providers (current: {}):\n", current_model);
+    for (provider, count) in &provider_counts {
+        let _ = writeln!(out, "  {} ({} models)", provider, count);
+    }
+    let _ = writeln!(out, "\nUsage:");
+    let _ = writeln!(out, "/models <provider> — list models");
+    let _ = writeln!(out, "/models <provider>/<model> — select model");
+    out
+}
+
+async fn ws_models_detail(provider: &str, models: &[&ModelInfo]) -> String {
+    let config = match load_config(None) {
+        Ok(c) => c,
+        Err(e) => return format!("Failed to load config: {e}"),
+    };
+    let current_model = config.agent.model.clone();
+
+    let mut out = String::new();
+    let _ = writeln!(out, "[{}] models (current: {}):\n", provider, current_model);
+    for m in models {
+        let ctx = m
+            .context_length
+            .map(|c| format!(" ({}K ctx)", c / 1024))
+            .unwrap_or_default();
+        let _ = writeln!(out, "  {}{}", m.id, ctx);
+    }
+    let _ = writeln!(out, "\nUse /models {}/<model_id> to select.", provider);
+    out
+}
+
+fn ws_models_select(provider: &str, model_id: &str) -> String {
+    let qualified_id = format!("{}/{}", provider, model_id);
+    handle_models_select(&qualified_id).text
+}
 
 /// Handle `/settings` for text-only channels (WebSocket, etc.) that lack inline keyboards.
 ///

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -696,6 +696,18 @@ impl WebSocketChannel {
                     );
                     handled = true;
                 }
+                // /models: text-based two-level model selection for WebSocket.
+                else if crate::commands::matches_command(&content_text, "models") {
+                    let response = crate::commands::handle_ws_models(&content_text).await;
+                    Self::send_ws_reply(
+                        &clients,
+                        &client_id,
+                        &response,
+                        envelope_msg_id.as_deref(),
+                        &trace_id,
+                    );
+                    handled = true;
+                }
                 // General command dispatch.
                 else if let Some(dispatch) =
                     crate::commands::try_handle_command(&content_text).await

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -523,6 +523,15 @@ pub struct AgentDefaults {
     #[serde(default = "default_model")]
     pub model: String,
 
+    /// Explicit provider override.
+    ///
+    /// When set, the agent routes all requests to this provider regardless of
+    /// model name keyword matching.  The provider prefix in `model` (e.g.
+    /// `"opencode_go/deepseek-v4-flash"`) still takes precedence over this
+    /// field — this field acts as a fallback when no prefix is present.
+    #[serde(default)]
+    pub provider: Option<String>,
+
     /// Default temperature.
     #[serde(default = "default_temperature")]
     pub temperature: f32,
@@ -575,6 +584,7 @@ impl Default for AgentDefaults {
     fn default() -> Self {
         Self {
             model: default_model(),
+            provider: None,
             temperature: default_temperature(),
             max_tokens: default_max_tokens(),
             max_iterations: default_max_iterations(),

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -242,13 +242,29 @@ impl ProviderRegistry {
     }
 
     /// Resolve a model name to a provider name.
+    ///
+    /// Resolution order:
+    /// 1. Explicit provider prefix (`opencode_go/model-name`) → that provider
+    /// 2. Keyword matching against [`MODEL_KEYWORD_MAP`]
+    /// 3. Fallback to the default provider
     pub fn resolve_provider_name(&self, model: &str) -> Option<&str> {
+        // 1. Check for explicit provider prefix first (e.g. "opencode_go/deepseek-v4-flash").
+        //    This takes precedence over keyword matching to avoid mis-routing.
+        if let Some((prefix, rest)) = model.split_once('/') {
+            if !rest.is_empty() && self.providers.contains_key(prefix) {
+                return Some(prefix);
+            }
+        }
+
+        // 2. Fall back to keyword matching.
         let lower = model.to_lowercase();
         for (keyword, provider_name) in MODEL_KEYWORD_MAP {
             if lower.contains(keyword) && self.providers.contains_key(*provider_name) {
                 return Some(provider_name);
             }
         }
+
+        // 3. Default provider.
         self.default_provider.as_deref()
     }
 
@@ -283,6 +299,42 @@ impl ProviderRegistry {
             return rest.to_string();
         }
         model.to_string()
+    }
+
+    /// Resolve a model name to a provider name, with an explicit provider override.
+    ///
+    /// Resolution order:
+    /// 1. Explicit `provider_override` parameter (from `agent.provider` config)
+    /// 2. Explicit provider prefix in model string
+    /// 3. Keyword matching against [`MODEL_KEYWORD_MAP`]
+    /// 4. Fallback to the default provider
+    pub fn resolve_provider_name_with_override(
+        &self,
+        model: &str,
+        provider_override: Option<&str>,
+    ) -> Option<&str> {
+        // 0. Explicit provider override takes absolute precedence.
+        if let Some(name) = provider_override {
+            if self.providers.contains_key(name) {
+                return Some(name);
+            }
+        }
+        self.resolve_provider_name(model)
+    }
+
+    /// Get a provider for a given model, with optional explicit provider override.
+    pub fn get_provider_with_override(
+        &self,
+        model: &str,
+        provider_override: Option<&str>,
+    ) -> Option<Arc<dyn LlmProvider>> {
+        if let Some(name) = self.resolve_provider_name_with_override(model, provider_override) {
+            self.providers.get(name).cloned()
+        } else {
+            self.default_provider
+                .as_ref()
+                .and_then(|name| self.providers.get(name).cloned())
+        }
     }
 
     /// Get a provider for a given model.
@@ -397,6 +449,40 @@ mod tests {
         // "gpt-4o" should resolve to "openai"
         let resolved = reg.resolve_provider_name("gpt-4o");
         assert_eq!(resolved, Some("openai"));
+    }
+
+    #[test]
+    fn test_resolve_provider_prefix_takes_precedence_over_keywords() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("opencode_go", MockProvider::new("opencode_go", "glm"));
+        reg.register("openrouter", MockProvider::new("openrouter", "deepseek"));
+
+        // "opencode_go/deepseek-v4-flash" should resolve to opencode_go,
+        // NOT openrouter (even though "deepseek-v4" keyword matches openrouter).
+        let resolved = reg.resolve_provider_name("opencode_go/deepseek-v4-flash");
+        assert_eq!(resolved, Some("opencode_go"));
+    }
+
+    #[test]
+    fn test_resolve_provider_override() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("anthropic", MockProvider::new("anthropic", "claude"));
+        reg.register("openai", MockProvider::new("openai", "gpt"));
+
+        // Override takes absolute precedence over keyword matching.
+        let resolved = reg.resolve_provider_name_with_override("claude-sonnet-4-6", Some("openai"));
+        assert_eq!(resolved, Some("openai"));
+    }
+
+    #[test]
+    fn test_resolve_provider_override_ignored_when_not_registered() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("anthropic", MockProvider::new("anthropic", "claude"));
+
+        // Unknown override falls back to keyword matching.
+        let resolved =
+            reg.resolve_provider_name_with_override("claude-sonnet-4-6", Some("nonexistent"));
+        assert_eq!(resolved, Some("anthropic"));
     }
 
     #[test]

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -219,7 +219,6 @@ impl ProviderRegistry {
         let model = &config.agent.model;
         let default = registry
             .resolve_provider_name(model)
-            .map(|s| s.to_string())
             .or_else(|| registry.providers.keys().next().cloned());
         registry.default_provider = default;
         if let Some(ref name) = registry.default_provider {
@@ -247,12 +246,12 @@ impl ProviderRegistry {
     /// 1. Explicit provider prefix (`opencode_go/model-name`) → that provider
     /// 2. Keyword matching against [`MODEL_KEYWORD_MAP`]
     /// 3. Fallback to the default provider
-    pub fn resolve_provider_name(&self, model: &str) -> Option<&str> {
+    pub fn resolve_provider_name(&self, model: &str) -> Option<String> {
         // 1. Check for explicit provider prefix first (e.g. "opencode_go/deepseek-v4-flash").
         //    This takes precedence over keyword matching to avoid mis-routing.
         if let Some((prefix, rest)) = model.split_once('/') {
             if !rest.is_empty() && self.providers.contains_key(prefix) {
-                return Some(prefix);
+                return Some(prefix.to_string());
             }
         }
 
@@ -260,12 +259,12 @@ impl ProviderRegistry {
         let lower = model.to_lowercase();
         for (keyword, provider_name) in MODEL_KEYWORD_MAP {
             if lower.contains(keyword) && self.providers.contains_key(*provider_name) {
-                return Some(provider_name);
+                return Some(provider_name.to_string());
             }
         }
 
         // 3. Default provider.
-        self.default_provider.as_deref()
+        self.default_provider.clone()
     }
 
     /// Strip the provider prefix from a qualified model name.
@@ -312,11 +311,11 @@ impl ProviderRegistry {
         &self,
         model: &str,
         provider_override: Option<&str>,
-    ) -> Option<&str> {
+    ) -> Option<String> {
         // 0. Explicit provider override takes absolute precedence.
         if let Some(name) = provider_override {
             if self.providers.contains_key(name) {
-                return Some(name);
+                return Some(name.to_string());
             }
         }
         self.resolve_provider_name(model)
@@ -329,7 +328,7 @@ impl ProviderRegistry {
         provider_override: Option<&str>,
     ) -> Option<Arc<dyn LlmProvider>> {
         if let Some(name) = self.resolve_provider_name_with_override(model, provider_override) {
-            self.providers.get(name).cloned()
+            self.providers.get(&name).cloned()
         } else {
             self.default_provider
                 .as_ref()
@@ -340,7 +339,7 @@ impl ProviderRegistry {
     /// Get a provider for a given model.
     pub fn get_provider(&self, model: &str) -> Option<Arc<dyn LlmProvider>> {
         if let Some(name) = self.resolve_provider_name(model) {
-            self.providers.get(name).cloned()
+            self.providers.get(&name).cloned()
         } else {
             self.default_provider
                 .as_ref()
@@ -444,11 +443,11 @@ mod tests {
 
         // "claude-3.5-sonnet" should resolve to "anthropic"
         let resolved = reg.resolve_provider_name("claude-3.5-sonnet");
-        assert_eq!(resolved, Some("anthropic"));
+        assert_eq!(resolved.as_deref(), Some("anthropic"));
 
         // "gpt-4o" should resolve to "openai"
         let resolved = reg.resolve_provider_name("gpt-4o");
-        assert_eq!(resolved, Some("openai"));
+        assert_eq!(resolved.as_deref(), Some("openai"));
     }
 
     #[test]
@@ -460,7 +459,7 @@ mod tests {
         // "opencode_go/deepseek-v4-flash" should resolve to opencode_go,
         // NOT openrouter (even though "deepseek-v4" keyword matches openrouter).
         let resolved = reg.resolve_provider_name("opencode_go/deepseek-v4-flash");
-        assert_eq!(resolved, Some("opencode_go"));
+        assert_eq!(resolved.as_deref(), Some("opencode_go"));
     }
 
     #[test]
@@ -471,7 +470,7 @@ mod tests {
 
         // Override takes absolute precedence over keyword matching.
         let resolved = reg.resolve_provider_name_with_override("claude-sonnet-4-6", Some("openai"));
-        assert_eq!(resolved, Some("openai"));
+        assert_eq!(resolved.as_deref(), Some("openai"));
     }
 
     #[test]
@@ -482,7 +481,7 @@ mod tests {
         // Unknown override falls back to keyword matching.
         let resolved =
             reg.resolve_provider_name_with_override("claude-sonnet-4-6", Some("nonexistent"));
-        assert_eq!(resolved, Some("anthropic"));
+        assert_eq!(resolved.as_deref(), Some("anthropic"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes three model/provider switching bugs:

1. **Provider prefix precedence** — `resolve_provider_name()` now checks the explicit `provider/model` prefix before keyword matching. Previously `"opencode_go/deepseek-v4-flash"` matched the `"deepseek-v4"` keyword and was routed to OpenRouter instead of OpenCode Go.

2. **Reflection prefix stripping** — `post_task_reflect()` now calls `strip_provider_prefix()` before the LLM API call, matching the runner behavior. Previously sent `"opencode_go/kimi-k2.6"` as the model ID, causing 400 errors.

3. **WebSocket /models command** — Added text-based two-level `/models` handler for WebSocket channels. Previously only returned inline keyboard responses (ignored by WebSocket), so users saw "Select a provider" with no way to interact.

## Changes

- `kestrel-providers/registry.rs`: `resolve_provider_name()` checks provider prefix first; adds `resolve_provider_name_with_override()` and `get_provider_with_override()` for explicit provider selection
- `kestrel-agent/loop_mod.rs`: strips provider prefix before reflection API call
- `kestrel-agent/runner.rs`: uses `get_provider_with_override()` with `agent.provider` field
- `kestrel-config/schema.rs`: adds optional `agent.provider` field to `AgentDefaults`
- `kestrel-channels/commands.rs`: adds `handle_ws_models()` with text-based two-level selection
- `kestrel-channels/websocket.rs`: routes `/models` through text-based handler

## Test plan

- [ ] Configure `agent.model: "opencode_go/deepseek-v4-flash"` and verify requests go to OpenCode Go, not OpenRouter
- [ ] Verify post-task reflection succeeds without 400 errors
- [ ] Test `/models` on WebSocket: list providers, list models for a provider, select a model
- [ ] Test `/models` on Telegram still works with inline keyboard
- [ ] Verify backward compatibility: `agent.model: "gpt-4o"` (no prefix) still routes via keyword matching

Bahtya