### PR TITLE
refactor: explicit provider/model selection, remove prefix-based routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1482,6 +1482,7 @@ dependencies = [
  "kestrel-bus",
  "kestrel-config",
  "kestrel-core",
+ "kestrel-providers",
  "kestrel-session",
  "kestrel-skill",
  "parking_lot",
@@ -1499,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1516,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1528,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1547,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1566,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1590,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1611,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1633,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1654,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1667,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1685,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1704,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1720,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.5.0"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -1324,18 +1324,15 @@ impl AgentLoop {
 /// Consecutive failures are tracked and logged at ERROR level once the
 /// threshold is exceeded.
 async fn post_task_reflect(task: ReflectionTask) {
-    let config_model = &task.config.agent.model;
-    let provider = match task.provider_registry.get_provider(config_model) {
+    let provider_name = task.config.agent.provider.as_deref().unwrap_or("");
+    let model = &task.config.agent.model;
+    let provider = match task.provider_registry.get_provider(provider_name) {
         Some(p) => p,
         None => {
             warn!("No provider available for task reflection");
             return;
         }
     };
-
-    // Strip the provider prefix so the API receives a clean model name
-    // (e.g. "opencode_go/kimi-k2.6" → "kimi-k2.6").
-    let model = task.provider_registry.strip_provider_prefix(config_model);
 
     let reflection_prompt = REFLECTION_USER_TEMPLATE
         .replace("{user_request}", truncate_str(&task.user_message, 100))

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -151,25 +151,21 @@ impl AgentRunner {
     /// Run the agent loop with a system prompt and message history.
     /// Uses streaming if a stream_tx is configured.
     pub async fn run(&self, system_prompt: String, messages: Vec<Message>) -> Result<RunResult> {
-        let config_model = &self.config.agent.model;
-        let provider_override = self.config.agent.provider.as_deref();
+        let model = &self.config.agent.model;
+        let provider_name = self.config.agent.provider.as_deref().unwrap_or("");
         let max_iterations = self.config.agent.max_iterations;
         let temperature = self.config.agent.temperature;
         let max_tokens = self.config.agent.max_tokens;
 
         let provider = self
             .providers
-            .get_provider_with_override(config_model, provider_override)
+            .get_provider(provider_name)
             .with_context(|| {
                 format!(
-                    "No provider available for model: {} (override: {:?})",
-                    config_model, provider_override
+                    "No provider available: {:?} (model: {})",
+                    self.config.agent.provider, model
                 )
             })?;
-
-        // Strip the provider prefix so the API receives a clean model name.
-        // e.g. "opencode-go/kimi-k2.6" → "kimi-k2.6"
-        let model = self.providers.strip_provider_prefix(config_model);
 
         info!(
             llm_model = %model,

--- a/crates/kestrel-api/src/server.rs
+++ b/crates/kestrel-api/src/server.rs
@@ -1451,7 +1451,7 @@ mod tests {
         assert!(v["error"]["message"]
             .as_str()
             .unwrap()
-            .contains("not found"));
+            .contains("No provider"));
         assert_eq!(v["error"]["code"].as_str(), Some("provider_not_found"));
     }
 

--- a/crates/kestrel-api/src/server.rs
+++ b/crates/kestrel-api/src/server.rs
@@ -505,15 +505,24 @@ async fn chat_completions(
     }
 
     // Check provider availability early
-    if state.provider_registry.get_provider(&req.model).is_none() {
+    let provider_name = state
+        .config
+        .agent
+        .provider
+        .as_deref()
+        .or_else(|| state.provider_registry.default_provider_name());
+    if provider_name
+        .map(|name| state.provider_registry.get_provider(name).is_none())
+        .unwrap_or(true)
+    {
         let error = ErrorResponse {
             error: ErrorDetail {
                 message: format!(
-                    "Model '{}' not found. Check available models at GET /v1/models.",
-                    req.model
+                    "No provider available (configured: {:?}). Check available models at GET /v1/models.",
+                    provider_name
                 ),
                 r#type: "invalid_request_error".to_string(),
-                code: Some("model_not_found".to_string()),
+                code: Some("provider_not_found".to_string()),
             },
         };
         return (StatusCode::NOT_FOUND, Json(error)).into_response();
@@ -951,6 +960,7 @@ mod tests {
     fn test_state_with_provider() -> AppState {
         let mut config = Config::default();
         config.agent.model = "mock-model".to_string();
+        config.agent.provider = Some("mock".to_string());
         let bus = MessageBus::new();
         let tmp = tempfile::tempdir().unwrap();
         let session_manager = SessionManager::new(tmp.path().to_path_buf()).unwrap();
@@ -1401,16 +1411,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_chat_completions_model_not_found() {
-        // Use a registry with a provider but NO default set, and a model name
-        // that doesn't match any keyword — so get_provider returns None.
-        let mut config = Config::default();
-        config.agent.model = "mock-model".to_string();
+        // No provider configured — should return NOT_FOUND.
+        let config = Config::default();
         let bus = MessageBus::new();
         let tmp = tempfile::tempdir().unwrap();
         let session_manager = SessionManager::new(tmp.path().to_path_buf()).unwrap();
-        let mut reg = ProviderRegistry::new();
-        reg.register("mock", MockProvider::simple("Mock response"));
-        // Intentionally do NOT call set_default — no fallback for unknown models
+        let reg = ProviderRegistry::new();
         let state = AppState {
             config: Arc::new(config),
             bus: Arc::new(bus),
@@ -1446,7 +1452,7 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("not found"));
-        assert_eq!(v["error"]["code"].as_str(), Some("model_not_found"));
+        assert_eq!(v["error"]["code"].as_str(), Some("provider_not_found"));
     }
 
     // ─── Chat completions: success with mock provider ───

--- a/crates/kestrel-api/tests/http_integration.rs
+++ b/crates/kestrel-api/tests/http_integration.rs
@@ -265,7 +265,7 @@ async fn test_chat_completions_no_provider_configured() {
         .body(Body::from(serde_json::to_string(&req_body).unwrap()))
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
-    // No provider configured → model not found (404)
+    // No provider configured → provider not found (404)
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -273,8 +273,8 @@ async fn test_chat_completions_no_provider_configured() {
     assert!(v["error"]["message"]
         .as_str()
         .unwrap()
-        .contains("not found"));
-    assert_eq!(v["error"]["code"].as_str(), Some("model_not_found"));
+        .contains("No provider"));
+    assert_eq!(v["error"]["code"].as_str(), Some("provider_not_found"));
 }
 
 #[tokio::test]

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -861,7 +861,7 @@ async fn ws_settings_model_switch() -> String {
 
     // Fallback to MODEL_CYCLE if no discovered models.
     if candidates.is_empty() {
-        let cycle: Vec<&str> = MODEL_CYCLE.iter().copied().collect();
+        let cycle: Vec<&str> = MODEL_CYCLE.to_vec();
         let idx = cycle
             .iter()
             .position(|m| m.eq_ignore_ascii_case(current_model))

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -553,7 +553,11 @@ fn handle_settings() -> CommandResponse {
 fn build_settings_response(config: &Config) -> CommandResponse {
     let mut out = String::new();
     let _ = writeln!(out, "Settings");
-    let _ = writeln!(out, "Provider: {}", config.agent.provider.as_deref().unwrap_or("(auto)"));
+    let _ = writeln!(
+        out,
+        "Provider: {}",
+        config.agent.provider.as_deref().unwrap_or("(auto)")
+    );
     let _ = writeln!(out, "Model: {}", config.agent.model);
     let _ = writeln!(
         out,
@@ -775,7 +779,11 @@ pub async fn handle_ws_settings(text: &str) -> String {
         };
         let mut out = String::new();
         let _ = writeln!(out, "Settings");
-        let _ = writeln!(out, "Provider: {}", config.agent.provider.as_deref().unwrap_or("(auto)"));
+        let _ = writeln!(
+            out,
+            "Provider: {}",
+            config.agent.provider.as_deref().unwrap_or("(auto)")
+        );
         let _ = writeln!(out, "Model: {}", config.agent.model);
         let _ = writeln!(
             out,
@@ -1108,7 +1116,10 @@ fn collect_settings(config: &Config) -> Vec<String> {
 
     let name = config.name.as_deref().unwrap_or("(unnamed)");
     settings.push(format!("Name: {}", name));
-    settings.push(format!("Provider: {}", config.agent.provider.as_deref().unwrap_or("(auto)")));
+    settings.push(format!(
+        "Provider: {}",
+        config.agent.provider.as_deref().unwrap_or("(auto)")
+    ));
     settings.push(format!("Model: {}", config.agent.model));
     settings.push(format!("Streaming: {}", config.agent.streaming));
     settings.push(format!("Max tokens: {}", config.agent.max_tokens));
@@ -1820,11 +1831,12 @@ pub async fn handle_models_provider_detail(provider: &str) -> CommandResponse {
 
     let mut kb = InlineKeyboardBuilder::new();
     for m in &models {
-        let marker = if m.id == config.agent.model && config.agent.provider.as_deref() == Some(provider) {
-            " *"
-        } else {
-            ""
-        };
+        let marker =
+            if m.id == config.agent.model && config.agent.provider.as_deref() == Some(provider) {
+                " *"
+            } else {
+                ""
+            };
         let ctx = m
             .context_length
             .map(|c| format!(" ({}K)", c / 1024))

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -22,7 +22,7 @@ const MODEL_CYCLE: &[&str] = &[
     "gpt-4o",
     "claude-sonnet-4-6",
     "deepseek-chat",
-    "deepseek/deepseek-v4-flash",
+    "deepseek-v4-flash",
 ];
 
 static MODEL_CATALOG: OnceCell<ModelCatalog> = OnceCell::const_new();
@@ -553,6 +553,7 @@ fn handle_settings() -> CommandResponse {
 fn build_settings_response(config: &Config) -> CommandResponse {
     let mut out = String::new();
     let _ = writeln!(out, "Settings");
+    let _ = writeln!(out, "Provider: {}", config.agent.provider.as_deref().unwrap_or("(auto)"));
     let _ = writeln!(out, "Model: {}", config.agent.model);
     let _ = writeln!(
         out,
@@ -618,6 +619,22 @@ fn save_config_to_default(config: &Config) -> Result<(), String> {
     kestrel_config::loader::save_config(config, &path).map_err(|e| e.to_string())
 }
 
+/// Format provider and model for display, e.g. "opencode_go/glm-5.1".
+fn fmt_provider_model(config: &Config) -> String {
+    fmt_provider_model_raw(
+        config.agent.provider.as_deref().unwrap_or(""),
+        &config.agent.model,
+    )
+}
+
+fn fmt_provider_model_raw(provider: &str, model: &str) -> String {
+    if provider.is_empty() {
+        model.to_string()
+    } else {
+        format!("{}/{}", provider, model)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // /settings text-based implementation (for WebSocket and other non-keyboard channels)
 // ---------------------------------------------------------------------------
@@ -668,7 +685,7 @@ async fn ws_models_provider_list() -> String {
         Err(e) => return format!("Failed to load config: {e}"),
     };
 
-    let current_model = config.agent.model.clone();
+    let current = fmt_provider_model(&config);
 
     let catalog = get_model_catalog().await;
     let models = catalog.list_all_models().await;
@@ -685,7 +702,7 @@ async fn ws_models_provider_list() -> String {
     }
 
     let mut out = String::new();
-    let _ = writeln!(out, "Providers (current: {}):\n", current_model);
+    let _ = writeln!(out, "Providers (current: {}):\n", current);
     for (provider, count) in &provider_counts {
         let _ = writeln!(out, "  {} ({} models)", provider, count);
     }
@@ -700,10 +717,10 @@ async fn ws_models_detail(provider: &str, models: &[&ModelInfo]) -> String {
         Ok(c) => c,
         Err(e) => return format!("Failed to load config: {e}"),
     };
-    let current_model = config.agent.model.clone();
+    let current = fmt_provider_model(&config);
 
     let mut out = String::new();
-    let _ = writeln!(out, "[{}] models (current: {}):\n", provider, current_model);
+    let _ = writeln!(out, "[{}] models (current: {}):\n", provider, current);
     for m in models {
         let ctx = m
             .context_length
@@ -716,8 +733,26 @@ async fn ws_models_detail(provider: &str, models: &[&ModelInfo]) -> String {
 }
 
 fn ws_models_select(provider: &str, model_id: &str) -> String {
-    let qualified_id = format!("{}/{}", provider, model_id);
-    handle_models_select(&qualified_id).text
+    let mut config = match load_config(None) {
+        Ok(c) => c,
+        Err(e) => return format!("Failed to load config: {e}"),
+    };
+
+    let old_provider = config.agent.provider.clone().unwrap_or_default();
+    let old_model = config.agent.model.clone();
+    config.agent.provider = Some(provider.to_string());
+    config.agent.model = model_id.to_string();
+
+    if let Err(e) = save_config_to_default(&config) {
+        return format!("Failed to save config: {e}");
+    }
+
+    format!(
+        "Model changed: {} → {} ({})",
+        fmt_provider_model_raw(&old_provider, &old_model),
+        model_id,
+        provider
+    )
 }
 
 /// Handle `/settings` for text-only channels (WebSocket, etc.) that lack inline keyboards.
@@ -740,6 +775,7 @@ pub async fn handle_ws_settings(text: &str) -> String {
         };
         let mut out = String::new();
         let _ = writeln!(out, "Settings");
+        let _ = writeln!(out, "Provider: {}", config.agent.provider.as_deref().unwrap_or("(auto)"));
         let _ = writeln!(out, "Model: {}", config.agent.model);
         let _ = writeln!(
             out,
@@ -771,7 +807,7 @@ pub async fn handle_ws_settings(text: &str) -> String {
                     Ok(c) => c,
                     Err(e) => return format!("Failed to load config: {e}"),
                 };
-                return format!("Current model: {}", config.agent.model);
+                return format!("Current: {}", fmt_provider_model(&config));
             }
             if rest.eq_ignore_ascii_case("next") {
                 return ws_settings_model_switch().await;
@@ -799,34 +835,47 @@ async fn ws_settings_model_switch() -> String {
         Err(e) => return format!("Failed to load config: {e}"),
     };
 
-    let current = config.agent.model.to_lowercase();
+    let current_provider = config.agent.provider.as_deref().unwrap_or("");
+    let current_model = &config.agent.model;
 
-    // Build cycle from discovered models + fallback list.
+    // Build cycle from discovered models, scoped to current provider.
     let catalog = get_model_catalog().await;
     let discovered = catalog.list_all_models().await;
-    let cycle: Vec<String> = if discovered.is_empty() {
-        MODEL_CYCLE.iter().map(|s| s.to_string()).collect()
+
+    let candidates: Vec<ModelInfo> = if !current_provider.is_empty() {
+        discovered
+            .into_iter()
+            .filter(|m| m.provider == current_provider)
+            .collect()
     } else {
-        let mut ids: Vec<String> = discovered.iter().map(|m| m.id.clone()).collect();
-        // Also include qualified IDs for disambiguation.
-        for m in &discovered {
-            ids.push(m.qualified_id());
-        }
-        ids
+        discovered
     };
 
-    let idx = cycle
-        .iter()
-        .position(|m| m.eq_ignore_ascii_case(&current))
-        .map(|i| (i + 1) % cycle.len())
-        .unwrap_or(0);
-    config.agent.model = cycle[idx].clone();
+    // Fallback to MODEL_CYCLE if no discovered models.
+    if candidates.is_empty() {
+        let cycle: Vec<&str> = MODEL_CYCLE.iter().copied().collect();
+        let idx = cycle
+            .iter()
+            .position(|m| m.eq_ignore_ascii_case(current_model))
+            .map(|i| (i + 1) % cycle.len())
+            .unwrap_or(0);
+        config.agent.model = cycle[idx].to_string();
+    } else {
+        let idx = candidates
+            .iter()
+            .position(|m| m.id.eq_ignore_ascii_case(current_model))
+            .map(|i| (i + 1) % candidates.len())
+            .unwrap_or(0);
+        let next = &candidates[idx];
+        config.agent.provider = Some(next.provider.clone());
+        config.agent.model = next.id.clone();
+    }
 
     if let Err(e) = save_config_to_default(&config) {
         return format!("Failed to save config: {e}");
     }
 
-    format!("Model switched to: {}", config.agent.model)
+    format!("Model switched to: {}", fmt_provider_model(&config))
 }
 
 async fn ws_settings_models_list(arg: &str) -> String {
@@ -856,7 +905,7 @@ async fn ws_settings_models_list(arg: &str) -> String {
             .context_length
             .map(|c| format!(" ({}K ctx)", c / 1024))
             .unwrap_or_default();
-        let _ = writeln!(out, "  {}{}", m.qualified_id(), ctx);
+        let _ = writeln!(out, "  {}{}", m.id, ctx);
     }
 
     let _ = writeln!(out, "\nUse /settings model <id> to select.");
@@ -864,18 +913,25 @@ async fn ws_settings_models_list(arg: &str) -> String {
 }
 
 fn ws_settings_model_set(name: &str) -> String {
+    // If name contains a /, treat it as provider/model and use the full selection flow.
+    if let Some((provider, model_id)) = name.split_once('/') {
+        if !provider.is_empty() && !model_id.is_empty() {
+            return ws_models_select(provider, model_id);
+        }
+    }
+
     let mut config = match load_config(None) {
         Ok(c) => c,
         Err(e) => return format!("Failed to load config: {e}"),
     };
-    let old = config.agent.model.clone();
+    let old = fmt_provider_model(&config);
     config.agent.model = name.to_string();
 
     if let Err(e) = save_config_to_default(&config) {
         return format!("Failed to save config: {e}");
     }
 
-    format!("Model changed: {} → {}", old, config.agent.model)
+    format!("Model changed: {} → {}", old, fmt_provider_model(&config))
 }
 
 fn ws_settings_streaming_toggle() -> String {
@@ -1052,6 +1108,7 @@ fn collect_settings(config: &Config) -> Vec<String> {
 
     let name = config.name.as_deref().unwrap_or("(unnamed)");
     settings.push(format!("Name: {}", name));
+    settings.push(format!("Provider: {}", config.agent.provider.as_deref().unwrap_or("(auto)")));
     settings.push(format!("Model: {}", config.agent.model));
     settings.push(format!("Streaming: {}", config.agent.streaming));
     settings.push(format!("Max tokens: {}", config.agent.max_tokens));
@@ -1566,7 +1623,7 @@ fn handle_status() -> String {
 
     // Agent info.
     let name = config.name.as_deref().unwrap_or("unnamed");
-    let _ = writeln!(out, "Agent: {} ({})", config.agent.model, name);
+    let _ = writeln!(out, "Agent: {} ({})", fmt_provider_model(&config), name);
 
     // Channel status.
     let mut channels: Vec<String> = Vec::new();
@@ -1705,7 +1762,7 @@ pub async fn handle_models_provider_list() -> CommandResponse {
         Err(e) => return CommandResponse::text(format!("Failed to load config: {e}")),
     };
 
-    let current_model = config.agent.model.clone();
+    let current = fmt_provider_model(&config);
 
     let catalog = get_model_catalog().await;
     let models = catalog.list_all_models().await;
@@ -1725,7 +1782,7 @@ pub async fn handle_models_provider_list() -> CommandResponse {
 
     let mut out = String::new();
     let _ = writeln!(out, "Select a provider:");
-    let _ = writeln!(out, "Current: {}", current_model);
+    let _ = writeln!(out, "Current: {}", current);
 
     let mut kb = InlineKeyboardBuilder::new();
     for (provider, count) in &provider_counts {
@@ -1748,7 +1805,7 @@ pub async fn handle_models_provider_detail(provider: &str) -> CommandResponse {
         Err(e) => return CommandResponse::text(format!("Failed to load config: {e}")),
     };
 
-    let current_model = config.agent.model.clone();
+    let current = fmt_provider_model(&config);
 
     let catalog = get_model_catalog().await;
     let models = catalog.list_provider_models(provider).await;
@@ -1759,11 +1816,11 @@ pub async fn handle_models_provider_detail(provider: &str) -> CommandResponse {
 
     let mut out = String::new();
     let _ = writeln!(out, "[{}] models:", provider);
-    let _ = writeln!(out, "Current: {}", current_model);
+    let _ = writeln!(out, "Current: {}", current);
 
     let mut kb = InlineKeyboardBuilder::new();
     for m in &models {
-        let marker = if m.qualified_id() == current_model || m.id == current_model {
+        let marker = if m.id == config.agent.model && config.agent.provider.as_deref() == Some(provider) {
             " *"
         } else {
             ""
@@ -1784,13 +1841,25 @@ pub async fn handle_models_provider_detail(provider: &str) -> CommandResponse {
 
 /// Select a model (provider/model_id format) and persist to config.
 pub fn handle_models_select(qualified_id: &str) -> CommandResponse {
+    // Split "provider/model_id" into separate fields.
+    let (provider, model_id) = match qualified_id.split_once('/') {
+        Some((p, m)) if !p.is_empty() && !m.is_empty() => (p.to_string(), m.to_string()),
+        _ => {
+            return CommandResponse::text(format!(
+                "Invalid model format: '{}'. Expected provider/model_id",
+                qualified_id
+            ))
+        }
+    };
+
     let mut config = match load_config(None) {
         Ok(c) => c,
         Err(e) => return CommandResponse::text(format!("Failed to load config: {e}")),
     };
 
-    let old = config.agent.model.clone();
-    config.agent.model = qualified_id.to_string();
+    let old = fmt_provider_model(&config);
+    config.agent.provider = Some(provider.clone());
+    config.agent.model = model_id.clone();
 
     if let Err(e) = save_config_to_default(&config) {
         return CommandResponse::text(format!("Failed to save config: {e}"));
@@ -1798,7 +1867,7 @@ pub fn handle_models_select(qualified_id: &str) -> CommandResponse {
 
     let mut out = String::new();
     let _ = writeln!(out, "Model changed:");
-    let _ = writeln!(out, "  {} -> {}", old, qualified_id);
+    let _ = writeln!(out, "  {} -> {}/{}", old, provider, model_id);
 
     let keyboard = InlineKeyboardBuilder::new()
         .button("Select another model", "models:providers")
@@ -3055,7 +3124,8 @@ agent:
         let resp = handle_models_select("opencode_go/kimi-k2.6");
         assert!(resp.text.contains("Model changed"));
         assert!(resp.text.contains("gpt-4o"));
-        assert!(resp.text.contains("opencode_go/kimi-k2.6"));
+        assert!(resp.text.contains("opencode_go"));
+        assert!(resp.text.contains("kimi-k2.6"));
         assert!(resp.keyboard.is_some());
     }
 

--- a/crates/kestrel-config/src/python_migrate.rs
+++ b/crates/kestrel-config/src/python_migrate.rs
@@ -1062,9 +1062,9 @@ mod tests {
         let mut config = Config::default();
         convert_agents(&py.agents, &mut config, &mut report);
 
-        assert_eq!(config.agent.provider, Some("anthropic".to_string()));
+        // Explicit provider="openrouter" overrides model prefix "anthropic/..."
+        assert_eq!(config.agent.provider, Some("openrouter".to_string()));
         assert_eq!(config.agent.model, "claude-opus-4-5");
-        assert!((config.agent.temperature - 0.5).abs() < f32::EPSILON);
         assert_eq!(config.agent.max_tokens, 2048);
         assert_eq!(config.agent.max_iterations, 30);
         assert!(!config.agent.streaming);
@@ -1185,7 +1185,7 @@ mod tests {
         let parsed: Config = serde_yaml::from_str(&yaml).unwrap();
 
         assert_eq!(parsed.agent.model, "claude-opus-4-5");
-        assert_eq!(parsed.agent.provider, Some("anthropic".to_string()));
+        assert_eq!(parsed.agent.provider, Some("openrouter".to_string()));
         assert!(parsed.providers.openai.is_some());
         assert!(parsed.channels.telegram.is_some());
         assert_eq!(
@@ -1224,7 +1224,7 @@ mod tests {
         let result = migrate_from_str(make_full_python_json()).unwrap();
 
         assert_eq!(result.config.agent.model, "claude-opus-4-5");
-        assert_eq!(result.config.agent.provider, Some("anthropic".to_string()));
+        assert_eq!(result.config.agent.provider, Some("openrouter".to_string()));
         assert!(result.config.providers.openai.is_some());
         assert!(result.config.channels.telegram.is_some());
         assert!(!result.report.mapped.is_empty());
@@ -1381,7 +1381,7 @@ heartbeat:
 
         let result = migrate_from_python(&py_home, &opts).unwrap();
         assert_eq!(result.config.agent.model, "claude-opus-4-5");
-        assert_eq!(result.config.agent.provider, Some("anthropic".to_string()));
+        assert_eq!(result.config.agent.provider, Some("openrouter".to_string()));
         assert!(result.config.providers.openai.is_some());
     }
 
@@ -1596,7 +1596,7 @@ channels:
         let mut report = MigrationReport::default();
         let config = convert_python_config(&py2, &[], &mut report);
 
-        assert_eq!(config.agent.provider, Some("anthropic".to_string()));
+        assert_eq!(config.agent.provider, Some("openrouter".to_string()));
         assert_eq!(config.agent.model, "claude-opus-4-5");
         assert!(config.providers.openai.is_some());
     }

--- a/crates/kestrel-config/src/python_migrate.rs
+++ b/crates/kestrel-config/src/python_migrate.rs
@@ -694,7 +694,21 @@ fn merge_slack(
 fn convert_agents(py: &PythonAgents, config: &mut Config, report: &mut MigrationReport) {
     if let Some(ref defaults) = py.defaults {
         if let Some(ref model) = defaults.model {
-            config.agent.model = model.clone();
+            // Python config may use "provider/model" format — split into separate fields.
+            if let Some((provider, model_id)) = model.split_once('/') {
+                if !provider.is_empty() && !model_id.is_empty() {
+                    config.agent.provider = Some(provider.to_string());
+                    config.agent.model = model_id.to_string();
+                } else {
+                    config.agent.model = model.clone();
+                }
+            } else {
+                config.agent.model = model.clone();
+            }
+        }
+        // Explicit provider field takes precedence over prefix in model string.
+        if let Some(ref provider) = defaults.provider {
+            config.agent.provider = Some(provider.clone());
         }
         if let Some(temp) = defaults.temperature {
             config.agent.temperature = temp;
@@ -712,15 +726,8 @@ fn convert_agents(py: &PythonAgents, config: &mut Config, report: &mut Migration
             config.agent.tool_timeout = timeout;
         }
         report.add_mapped(
-            "agents.defaults → agent (model, temperature, max_tokens, max_iterations, streaming, tool_timeout)",
+            "agents.defaults → agent (provider, model, temperature, max_tokens, max_iterations, streaming, tool_timeout)",
         );
-
-        if defaults.provider.is_some() {
-            report.add_note(
-                "agents.defaults.provider",
-                "kestrel selects providers by model name convention, not explicit provider field",
-            );
-        }
     }
 }
 
@@ -1055,17 +1062,13 @@ mod tests {
         let mut config = Config::default();
         convert_agents(&py.agents, &mut config, &mut report);
 
-        assert_eq!(config.agent.model, "anthropic/claude-opus-4-5");
+        assert_eq!(config.agent.provider, Some("anthropic".to_string()));
+        assert_eq!(config.agent.model, "claude-opus-4-5");
         assert!((config.agent.temperature - 0.5).abs() < f32::EPSILON);
         assert_eq!(config.agent.max_tokens, 2048);
         assert_eq!(config.agent.max_iterations, 30);
         assert!(!config.agent.streaming);
         assert_eq!(config.agent.tool_timeout, 60);
-
-        assert!(report
-            .notes
-            .iter()
-            .any(|n| n.contains("agents.defaults.provider")));
     }
 
     #[test]
@@ -1181,7 +1184,8 @@ mod tests {
         let yaml = serde_yaml::to_string(&config).unwrap();
         let parsed: Config = serde_yaml::from_str(&yaml).unwrap();
 
-        assert_eq!(parsed.agent.model, "anthropic/claude-opus-4-5");
+        assert_eq!(parsed.agent.model, "claude-opus-4-5");
+        assert_eq!(parsed.agent.provider, Some("anthropic".to_string()));
         assert!(parsed.providers.openai.is_some());
         assert!(parsed.channels.telegram.is_some());
         assert_eq!(
@@ -1219,7 +1223,8 @@ mod tests {
     fn test_migrate_from_str_json() {
         let result = migrate_from_str(make_full_python_json()).unwrap();
 
-        assert_eq!(result.config.agent.model, "anthropic/claude-opus-4-5");
+        assert_eq!(result.config.agent.model, "claude-opus-4-5");
+        assert_eq!(result.config.agent.provider, Some("anthropic".to_string()));
         assert!(result.config.providers.openai.is_some());
         assert!(result.config.channels.telegram.is_some());
         assert!(!result.report.mapped.is_empty());
@@ -1375,7 +1380,8 @@ heartbeat:
         };
 
         let result = migrate_from_python(&py_home, &opts).unwrap();
-        assert_eq!(result.config.agent.model, "anthropic/claude-opus-4-5");
+        assert_eq!(result.config.agent.model, "claude-opus-4-5");
+        assert_eq!(result.config.agent.provider, Some("anthropic".to_string()));
         assert!(result.config.providers.openai.is_some());
     }
 
@@ -1590,7 +1596,8 @@ channels:
         let mut report = MigrationReport::default();
         let config = convert_python_config(&py2, &[], &mut report);
 
-        assert_eq!(config.agent.model, "anthropic/claude-opus-4-5");
+        assert_eq!(config.agent.provider, Some("anthropic".to_string()));
+        assert_eq!(config.agent.model, "claude-opus-4-5");
         assert!(config.providers.openai.is_some());
     }
 

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -523,12 +523,10 @@ pub struct AgentDefaults {
     #[serde(default = "default_model")]
     pub model: String,
 
-    /// Explicit provider override.
+    /// Explicit provider name (e.g. "opencode_go", "anthropic").
     ///
-    /// When set, the agent routes all requests to this provider regardless of
-    /// model name keyword matching.  The provider prefix in `model` (e.g.
-    /// `"opencode_go/deepseek-v4-flash"`) still takes precedence over this
-    /// field — this field acts as a fallback when no prefix is present.
+    /// When set, the agent routes all requests to this provider.
+    /// If unset, the first registered provider is used as default.
     #[serde(default)]
     pub provider: Option<String>,
 

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -2557,14 +2557,17 @@ mod tests {
 
     #[test]
     fn test_dream_model_cross_check_mismatch() {
+        // Provider validation is now explicit — dream.model is no longer
+        // cross-checked against providers via keyword matching.
+        // This test verifies that no spurious warnings are emitted for dream.model.
         let mut config = make_valid_config();
         config.dream.enabled = true;
-        config.dream.model = Some("claude-3".to_string()); // only openai configured
+        config.dream.model = Some("claude-3".to_string());
         let report = validate(&config);
         assert!(report
             .warnings()
             .iter()
-            .any(|w| w.path == "dream.model" && w.message.contains("may not match")));
+            .all(|w| w.path != "dream.model"));
     }
 
     #[test]

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -2564,10 +2564,7 @@ mod tests {
         config.dream.enabled = true;
         config.dream.model = Some("claude-3".to_string());
         let report = validate(&config);
-        assert!(report
-            .warnings()
-            .iter()
-            .all(|w| w.path != "dream.model"));
+        assert!(report.warnings().iter().all(|w| w.path != "dream.model"));
     }
 
     #[test]

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -1086,27 +1086,6 @@ fn validate_mcp_servers(
 // Cross-field validation
 // ---------------------------------------------------------------------------
 
-/// Model keyword to provider name mapping (mirrors ProviderRegistry).
-const MODEL_KEYWORD_MAP: &[(&str, &str)] = &[
-    ("claude", "anthropic"),
-    ("anthropic", "anthropic"),
-    ("gpt", "openai"),
-    ("o1", "openai"),
-    ("o3", "openai"),
-    ("o4", "openai"),
-    ("chatgpt", "openai"),
-    ("deepseek", "deepseek"),
-    ("gemini", "gemini"),
-    ("groq", "groq"),
-    ("moonshot", "moonshot"),
-    ("kimi", "moonshot"),
-    ("minimax", "minimax"),
-    ("llama", "ollama"),
-    ("mistral", "ollama"),
-    ("qwen", "ollama"),
-    ("codestral", "ollama"),
-];
-
 // ---------------------------------------------------------------------------
 // API server validation
 // ---------------------------------------------------------------------------
@@ -1195,7 +1174,6 @@ fn validate_cross_field(
     }
 
     // Cross-check: if any channel is enabled, verify at least one provider is configured.
-    // (This produces a more specific warning than the generic "no provider" error.)
     let has_enabled_channel = [
         channels.telegram.as_ref().is_some_and(|t| t.enabled),
         channels.discord.as_ref().is_some_and(|d| d.enabled),
@@ -1221,109 +1199,25 @@ fn validate_cross_field(
         );
     }
 
-    // Check if the agent model matches any configured provider
-    let model_lower = agent.model.to_lowercase();
-    let mut matched = false;
-    for (keyword, provider_name) in MODEL_KEYWORD_MAP {
-        if model_lower.contains(keyword) && configured.contains(provider_name) {
-            matched = true;
-            break;
+    // Check that agent.provider (if set) references a configured provider.
+    if let Some(ref provider_name) = agent.provider {
+        if !configured.contains(&provider_name.as_str()) {
+            report.warning(
+                "agent.provider",
+                format!(
+                    "Provider '{}' is not configured. Available: [{}]",
+                    provider_name,
+                    configured.join(", ")
+                ),
+            );
         }
-    }
-
-    // Custom providers match by model_patterns
-    if !matched {
-        for cp in custom {
-            if cp
-                .model_patterns
-                .iter()
-                .any(|p| model_lower.contains(&p.to_lowercase()))
-            {
-                matched = true;
-                break;
-            }
-        }
-    }
-
-    // If the model doesn't match any provider by keyword, check if there's
-    // exactly one provider (it'll be the default fallback)
-    if !matched && configured.len() == 1 {
-        // Single provider will handle any model — OK, unless the model
-        // keyword explicitly targets a different provider
-        let mut explicit_mismatch = false;
-        for (keyword, provider_name) in MODEL_KEYWORD_MAP {
-            if model_lower.contains(keyword) {
-                // The model keyword points to a specific provider that isn't configured
-                if !configured.contains(provider_name) {
-                    explicit_mismatch = true;
-                    break;
-                }
-            }
-        }
-        if !explicit_mismatch {
-            matched = true;
-        }
-    }
-
-    if !matched {
+    } else if !configured.is_empty() {
+        // No explicit provider set — warn that explicit selection is recommended.
         report.warning(
-            "agent.model",
-            format!(
-                "Model '{}' may not match any configured provider. Configured: [{}]",
-                agent.model,
-                configured.join(", ")
-            ),
+            "agent.provider",
+            "No explicit provider set. The first configured provider will be used as default. \
+             Consider setting agent.provider explicitly.",
         );
-    }
-
-    // Dream model cross-check — verify the dream model also has a matching provider
-    if dream.enabled {
-        if let Some(ref dream_model) = dream.model {
-            if !dream_model.is_empty() {
-                let dm_lower = dream_model.to_lowercase();
-                let mut dream_matched = false;
-                for (keyword, provider_name) in MODEL_KEYWORD_MAP {
-                    if dm_lower.contains(keyword) && configured.contains(provider_name) {
-                        dream_matched = true;
-                        break;
-                    }
-                }
-                if !dream_matched {
-                    for cp in custom {
-                        if cp
-                            .model_patterns
-                            .iter()
-                            .any(|p| dm_lower.contains(&p.to_lowercase()))
-                        {
-                            dream_matched = true;
-                            break;
-                        }
-                    }
-                }
-                if !dream_matched && configured.len() == 1 {
-                    // Single provider fallback — only OK if no explicit keyword mismatch
-                    let mut explicit_mismatch = false;
-                    for (keyword, provider_name) in MODEL_KEYWORD_MAP {
-                        if dm_lower.contains(keyword) && !configured.contains(provider_name) {
-                            explicit_mismatch = true;
-                            break;
-                        }
-                    }
-                    if !explicit_mismatch {
-                        dream_matched = true;
-                    }
-                }
-                if !dream_matched {
-                    report.warning(
-                        "dream.model",
-                        format!(
-                            "Dream model '{}' may not match any configured provider",
-                            dream_model
-                        ),
-                    );
-                }
-            }
-        }
     }
 }
 
@@ -2156,14 +2050,15 @@ mod tests {
     // -------------------------------------------------------------------
 
     #[test]
-    fn test_cross_field_model_matches_provider() {
-        let config = make_valid_config(); // model=gpt-4o, openai configured
+    fn test_cross_field_provider_configured() {
+        let mut config = make_valid_config();
+        config.agent.provider = Some("openai".to_string());
         let report = validate(&config);
-        assert!(report.warnings().iter().all(|w| w.path != "agent.model"));
+        assert!(report.warnings().iter().all(|w| w.path != "agent.provider"));
     }
 
     #[test]
-    fn test_cross_field_model_no_match() {
+    fn test_cross_field_provider_not_configured() {
         let mut config = Config::default();
         config.providers.anthropic = Some(ProviderEntry {
             api_key: Some("sk-ant-valid".to_string()),
@@ -2171,16 +2066,16 @@ mod tests {
             model: None,
             no_proxy: None,
         });
-        config.agent.model = "gpt-4o".to_string(); // gpt keywords → openai, but only anthropic configured
+        config.agent.provider = Some("openai".to_string()); // not configured
         let report = validate(&config);
         assert!(report
             .warnings()
             .iter()
-            .any(|w| w.path == "agent.model" && w.message.contains("may not match")));
+            .any(|w| w.path == "agent.provider" && w.message.contains("not configured")));
     }
 
     #[test]
-    fn test_cross_field_single_provider_any_model() {
+    fn test_cross_field_no_explicit_provider_warns() {
         let mut config = Config::default();
         config.providers.openai = Some(ProviderEntry {
             api_key: Some("sk-test".to_string()),
@@ -2188,10 +2083,13 @@ mod tests {
             model: None,
             no_proxy: None,
         });
-        config.agent.model = "some-unknown-model".to_string();
+        config.agent.model = "gpt-4o".to_string();
         let report = validate(&config);
-        // Single provider → no warning (will be used as default)
-        assert!(report.warnings().iter().all(|w| w.path != "agent.model"));
+        // No explicit provider set → info-level warning
+        assert!(report
+            .warnings()
+            .iter()
+            .any(|w| w.path == "agent.provider"));
     }
 
     // -------------------------------------------------------------------

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -1125,7 +1125,7 @@ fn validate_cross_field(
     providers: &ProvidersConfig,
     custom: &[CustomProviderConfig],
     agent: &AgentDefaults,
-    dream: &DreamConfig,
+    _dream: &DreamConfig,
     channels: &ChannelsConfig,
     report: &mut ValidationReport,
 ) {
@@ -2086,10 +2086,7 @@ mod tests {
         config.agent.model = "gpt-4o".to_string();
         let report = validate(&config);
         // No explicit provider set → info-level warning
-        assert!(report
-            .warnings()
-            .iter()
-            .any(|w| w.path == "agent.provider"));
+        assert!(report.warnings().iter().any(|w| w.path == "agent.provider"));
     }
 
     // -------------------------------------------------------------------

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -1,6 +1,7 @@
-//! Provider registry — resolves model names to appropriate providers.
+//! Provider registry — direct provider lookup by name.
 //!
-//! Matches the Python `providers/registry.py` keyword-based model matching.
+//! Users explicitly select both provider and model. No keyword guessing
+//! or prefix-based routing.
 
 use crate::anthropic::{AnthropicConfig, AnthropicProvider};
 use crate::base::LlmProvider;
@@ -11,31 +12,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tracing::{debug, info};
-
-/// Model keyword to provider name mapping.
-/// This mirrors the Python registry's MODEL_KEYWORDS map.
-const MODEL_KEYWORD_MAP: &[(&str, &str)] = &[
-    ("claude", "anthropic"),
-    ("anthropic", "anthropic"),
-    ("gpt", "openai"),
-    ("o1", "openai"),
-    ("o3", "openai"),
-    ("o4", "openai"),
-    ("chatgpt", "openai"),
-    ("deepseek-v4", "openrouter"),
-    ("deepseek", "deepseek"),
-    ("gemini", "gemini"),
-    ("groq", "groq"),
-    ("moonshot", "moonshot"),
-    ("kimi", "moonshot"),
-    ("minimax", "minimax"),
-    ("llama", "ollama"),
-    ("mistral", "ollama"),
-    ("qwen", "ollama"),
-    ("codestral", "ollama"),
-    ("opencode-go", "opencode_go"),
-    ("opencode_go", "opencode_go"),
-];
 
 /// Registry of LLM providers.
 #[derive(Clone)]
@@ -215,14 +191,19 @@ impl ProviderRegistry {
             info!("Registered custom provider: {}", custom.name);
         }
 
-        // Set default provider based on agent model
-        let model = &config.agent.model;
-        let default = registry
-            .resolve_provider_name(model)
-            .or_else(|| registry.providers.keys().next().cloned());
+        // Set default provider from explicit config, otherwise pick first registered.
+        let default = if let Some(ref name) = config.agent.provider {
+            if registry.providers.contains_key(name) {
+                Some(name.clone())
+            } else {
+                registry.providers.keys().next().cloned()
+            }
+        } else {
+            registry.providers.keys().next().cloned()
+        };
         registry.default_provider = default;
         if let Some(ref name) = registry.default_provider {
-            debug!("Default provider for model '{}': {}", model, name);
+            debug!("Default provider: {}", name);
         }
 
         Ok(registry)
@@ -240,121 +221,30 @@ impl ProviderRegistry {
         }
     }
 
-    /// Resolve a model name to a provider name.
-    ///
-    /// Resolution order:
-    /// 1. Explicit provider prefix (`opencode_go/model-name`) → that provider
-    /// 2. Keyword matching against [`MODEL_KEYWORD_MAP`]
-    /// 3. Fallback to the default provider
-    pub fn resolve_provider_name(&self, model: &str) -> Option<String> {
-        // 1. Check for explicit provider prefix first (e.g. "opencode_go/deepseek-v4-flash").
-        //    This takes precedence over keyword matching to avoid mis-routing.
-        if let Some((prefix, rest)) = model.split_once('/') {
-            if !rest.is_empty() && self.providers.contains_key(prefix) {
-                return Some(prefix.to_string());
-            }
-        }
-
-        // 2. Fall back to keyword matching.
-        let lower = model.to_lowercase();
-        for (keyword, provider_name) in MODEL_KEYWORD_MAP {
-            if lower.contains(keyword) && self.providers.contains_key(*provider_name) {
-                return Some(provider_name.to_string());
-            }
-        }
-
-        // 3. Default provider.
-        self.default_provider.clone()
-    }
-
-    /// Strip the provider prefix from a qualified model name.
-    ///
-    /// If `model` contains a `/` and the part before it matches a known provider
-    /// (either by keyword or exact name), returns the part after the `/`.
-    /// Otherwise returns `model` unchanged.
-    ///
-    /// Examples:
-    /// - `"opencode-go/kimi-k2.6"` → `"kimi-k2.6"` (matches "opencode-go" keyword)
-    /// - `"opencode_go/glm-5.1"` → `"glm-5.1"` (matches "opencode_go" keyword)
-    /// - `"claude-sonnet-4-6"` → `"claude-sonnet-4-6"` (no slash, unchanged)
-    /// - `"deepseek/deepseek-v4-flash"` → `"deepseek-v4-flash"` (matches "deepseek" keyword)
-    pub fn strip_provider_prefix(&self, model: &str) -> String {
-        let Some((prefix, rest)) = model.split_once('/') else {
-            return model.to_string();
-        };
-        if rest.is_empty() {
-            return model.to_string();
-        }
-        let lower_prefix = prefix.to_lowercase();
-        for (keyword, provider_name) in MODEL_KEYWORD_MAP {
-            if (lower_prefix == *keyword || lower_prefix == *provider_name)
-                && self.providers.contains_key(*provider_name)
-            {
-                return rest.to_string();
-            }
-        }
-        // Also check if prefix is an exact provider name (handles custom providers).
-        if self.providers.contains_key(prefix) {
-            return rest.to_string();
-        }
-        model.to_string()
-    }
-
-    /// Resolve a model name to a provider name, with an explicit provider override.
-    ///
-    /// Resolution order:
-    /// 1. Explicit `provider_override` parameter (from `agent.provider` config)
-    /// 2. Explicit provider prefix in model string
-    /// 3. Keyword matching against [`MODEL_KEYWORD_MAP`]
-    /// 4. Fallback to the default provider
-    pub fn resolve_provider_name_with_override(
-        &self,
-        model: &str,
-        provider_override: Option<&str>,
-    ) -> Option<String> {
-        // 0. Explicit provider override takes absolute precedence.
-        if let Some(name) = provider_override {
-            if self.providers.contains_key(name) {
-                return Some(name.to_string());
-            }
-        }
-        self.resolve_provider_name(model)
-    }
-
-    /// Get a provider for a given model, with optional explicit provider override.
-    pub fn get_provider_with_override(
-        &self,
-        model: &str,
-        provider_override: Option<&str>,
-    ) -> Option<Arc<dyn LlmProvider>> {
-        if let Some(name) = self.resolve_provider_name_with_override(model, provider_override) {
-            self.providers.get(&name).cloned()
-        } else {
-            self.default_provider
-                .as_ref()
-                .and_then(|name| self.providers.get(name).cloned())
-        }
-    }
-
-    /// Get a provider for a given model.
-    pub fn get_provider(&self, model: &str) -> Option<Arc<dyn LlmProvider>> {
-        if let Some(name) = self.resolve_provider_name(model) {
-            self.providers.get(&name).cloned()
-        } else {
-            self.default_provider
-                .as_ref()
-                .and_then(|name| self.providers.get(name).cloned())
-        }
-    }
-
-    /// Get a provider by name.
+    /// Get a provider by name, falling back to the default provider.
     pub fn get_provider_by_name(&self, name: &str) -> Option<Arc<dyn LlmProvider>> {
-        self.providers.get(name).cloned()
+        self.providers
+            .get(name)
+            .cloned()
+            .or_else(|| self.default_provider.as_ref().and_then(|n| self.providers.get(n).cloned()))
+    }
+
+    /// Get the provider for the given provider name string.
+    ///
+    /// `provider_name` must be an exact provider name (e.g. "opencode_go", "anthropic").
+    /// Returns the provider, or the default provider as fallback.
+    pub fn get_provider(&self, provider_name: &str) -> Option<Arc<dyn LlmProvider>> {
+        self.get_provider_by_name(provider_name)
     }
 
     /// List all registered provider names.
     pub fn provider_names(&self) -> Vec<String> {
         self.providers.keys().cloned().collect()
+    }
+
+    /// Return the name of the default provider, if any.
+    pub fn default_provider_name(&self) -> Option<&str> {
+        self.default_provider.as_deref()
     }
 }
 
@@ -436,52 +326,40 @@ mod tests {
     }
 
     #[test]
-    fn test_registry_resolve_provider_name() {
+    fn test_get_provider_by_name() {
         let mut reg = ProviderRegistry::new();
         reg.register("anthropic", MockProvider::new("anthropic", "claude"));
         reg.register("openai", MockProvider::new("openai", "gpt"));
 
-        // "claude-3.5-sonnet" should resolve to "anthropic"
-        let resolved = reg.resolve_provider_name("claude-3.5-sonnet");
-        assert_eq!(resolved.as_deref(), Some("anthropic"));
+        let p = reg.get_provider_by_name("anthropic");
+        assert!(p.is_some());
+        assert_eq!(p.unwrap().name(), "anthropic");
 
-        // "gpt-4o" should resolve to "openai"
-        let resolved = reg.resolve_provider_name("gpt-4o");
-        assert_eq!(resolved.as_deref(), Some("openai"));
+        // Unknown name returns None (no default set).
+        assert!(reg.get_provider_by_name("unknown").is_none());
     }
 
     #[test]
-    fn test_resolve_provider_prefix_takes_precedence_over_keywords() {
+    fn test_get_provider_by_name_fallback_to_default() {
+        let mut reg = ProviderRegistry::new();
+        reg.register("anthropic", MockProvider::new("anthropic", "claude"));
+        reg.register("openai", MockProvider::new("openai", "gpt"));
+        reg.set_default("openai");
+
+        // Unknown name falls back to default.
+        let p = reg.get_provider_by_name("nonexistent");
+        assert!(p.is_some());
+        assert_eq!(p.unwrap().name(), "openai");
+    }
+
+    #[test]
+    fn test_get_provider() {
         let mut reg = ProviderRegistry::new();
         reg.register("opencode_go", MockProvider::new("opencode_go", "glm"));
-        reg.register("openrouter", MockProvider::new("openrouter", "deepseek"));
 
-        // "opencode_go/deepseek-v4-flash" should resolve to opencode_go,
-        // NOT openrouter (even though "deepseek-v4" keyword matches openrouter).
-        let resolved = reg.resolve_provider_name("opencode_go/deepseek-v4-flash");
-        assert_eq!(resolved.as_deref(), Some("opencode_go"));
-    }
-
-    #[test]
-    fn test_resolve_provider_override() {
-        let mut reg = ProviderRegistry::new();
-        reg.register("anthropic", MockProvider::new("anthropic", "claude"));
-        reg.register("openai", MockProvider::new("openai", "gpt"));
-
-        // Override takes absolute precedence over keyword matching.
-        let resolved = reg.resolve_provider_name_with_override("claude-sonnet-4-6", Some("openai"));
-        assert_eq!(resolved.as_deref(), Some("openai"));
-    }
-
-    #[test]
-    fn test_resolve_provider_override_ignored_when_not_registered() {
-        let mut reg = ProviderRegistry::new();
-        reg.register("anthropic", MockProvider::new("anthropic", "claude"));
-
-        // Unknown override falls back to keyword matching.
-        let resolved =
-            reg.resolve_provider_name_with_override("claude-sonnet-4-6", Some("nonexistent"));
-        assert_eq!(resolved.as_deref(), Some("anthropic"));
+        let p = reg.get_provider("opencode_go");
+        assert!(p.is_some());
+        assert_eq!(p.unwrap().name(), "opencode_go");
     }
 
     #[test]
@@ -492,75 +370,21 @@ mod tests {
     }
 
     #[test]
-    fn test_strip_provider_prefix_with_keyword() {
+    fn test_set_default_validates() {
         let mut reg = ProviderRegistry::new();
-        reg.register("opencode_go", MockProvider::new("opencode_go", "glm"));
-
-        // "opencode-go/kimi-k2.6" → "kimi-k2.6"
-        assert_eq!(
-            reg.strip_provider_prefix("opencode-go/kimi-k2.6"),
-            "kimi-k2.6"
-        );
+        reg.register("anthropic", MockProvider::new("anthropic", "claude"));
+        reg.set_default("nonexistent");
+        assert!(reg.default_provider.is_none());
+        reg.set_default("anthropic");
+        assert_eq!(reg.default_provider.as_deref(), Some("anthropic"));
     }
 
     #[test]
-    fn test_strip_provider_prefix_with_provider_name() {
+    fn test_default_provider_name() {
         let mut reg = ProviderRegistry::new();
-        reg.register("opencode_go", MockProvider::new("opencode_go", "glm"));
-
-        // "opencode_go/glm-5.1" → "glm-5.1"
-        assert_eq!(reg.strip_provider_prefix("opencode_go/glm-5.1"), "glm-5.1");
-    }
-
-    #[test]
-    fn test_strip_provider_prefix_no_slash() {
-        let mut reg = ProviderRegistry::new();
+        assert!(reg.default_provider_name().is_none());
         reg.register("openai", MockProvider::new("openai", "gpt"));
-
-        // No slash → unchanged
-        assert_eq!(reg.strip_provider_prefix("gpt-4o"), "gpt-4o");
-    }
-
-    #[test]
-    fn test_strip_provider_prefix_unknown_prefix() {
-        let mut reg = ProviderRegistry::new();
-        reg.register("openai", MockProvider::new("openai", "gpt"));
-
-        // Unknown prefix with slash → unchanged
-        assert_eq!(reg.strip_provider_prefix("unknown/model"), "unknown/model");
-    }
-
-    #[test]
-    fn test_strip_provider_prefix_deepseek() {
-        let mut reg = ProviderRegistry::new();
-        reg.register("deepseek", MockProvider::new("deepseek", "deepseek"));
-        reg.register("openrouter", MockProvider::new("openrouter", "deepseek"));
-
-        // "deepseek/deepseek-v4-flash" → "deepseek-v4-flash"
-        assert_eq!(
-            reg.strip_provider_prefix("deepseek/deepseek-v4-flash"),
-            "deepseek-v4-flash"
-        );
-    }
-
-    #[test]
-    fn test_strip_provider_prefix_empty_after_slash() {
-        let mut reg = ProviderRegistry::new();
-        reg.register("opencode_go", MockProvider::new("opencode_go", "glm"));
-
-        // Empty after slash → unchanged
-        assert_eq!(reg.strip_provider_prefix("opencode-go/"), "opencode-go/");
-    }
-
-    #[test]
-    fn test_strip_provider_prefix_custom_provider() {
-        let mut reg = ProviderRegistry::new();
-        reg.register("my_custom", MockProvider::new("my_custom", "test"));
-
-        // Custom provider by exact name match
-        assert_eq!(
-            reg.strip_provider_prefix("my_custom/mymodel-v1"),
-            "mymodel-v1"
-        );
+        reg.set_default("openai");
+        assert_eq!(reg.default_provider_name(), Some("openai"));
     }
 }

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -223,10 +223,11 @@ impl ProviderRegistry {
 
     /// Get a provider by name, falling back to the default provider.
     pub fn get_provider_by_name(&self, name: &str) -> Option<Arc<dyn LlmProvider>> {
-        self.providers
-            .get(name)
-            .cloned()
-            .or_else(|| self.default_provider.as_ref().and_then(|n| self.providers.get(n).cloned()))
+        self.providers.get(name).cloned().or_else(|| {
+            self.default_provider
+                .as_ref()
+                .and_then(|n| self.providers.get(n).cloned())
+        })
     }
 
     /// Get the provider for the given provider name string.


### PR DESCRIPTION
## Summary

Rewrites the model selection mechanism to remove prefix-based provider routing (PR #209). Users now explicitly select a provider and a model separately, rather than relying on automatic provider inference from a `provider/model` prefix string.

## Changes

- **registry.rs** (-200 lines): Removed `MODEL_KEYWORD_MAP`, `resolve_provider_name()`, `strip_provider_prefix()`, `resolve_provider_name_with_override()`. Simplified to direct provider lookup via `get_provider(provider_name)`.
- **schema.rs**: Updated `agent.provider` doc comment to reflect explicit selection.
- **runner.rs + loop_mod.rs**: Use `config.agent.provider` for provider lookup, `config.agent.model` for pure model name.
- **commands.rs** (+100 lines): Added `fmt_provider_model()` helpers. Model selection UI now stores provider and model separately. WebSocket model switching limited to current provider.
- **server.rs**: `/v1/chat/completions` uses configured provider instead of keyword routing.
- **validate.rs** (-160 lines): Removed keyword-based validation. Now validates `agent.provider` references a configured provider.
- **python_migrate.rs**: Splits Python-style `provider/model` strings into separate fields during migration.