### PR TITLE
release: bump version to 0.5.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION
## v0.5.7

### Changes
- **refactor: explicit provider/model selection** — Removed `provider/model` prefix-based routing. Users now explicitly select provider and model separately (#210)
- Net change: -193 lines
- `MODEL_KEYWORD_MAP`, `resolve_provider_name()`, `strip_provider_prefix()` removed
- Config now has separate `agent.provider` and `agent.model` fields