### PR TITLE
chore: bump version to 0.5.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION
Updates workspace version from 0.5.7 to 0.5.8 to match the v0.5.8 release tag.