### PR TITLE
feat: add communication log system with trace_id tracking

### DIFF
--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -789,7 +789,7 @@ mod tests {
         // Counter must be exactly 3
         assert_eq!(counter.load(Ordering::SeqCst), 3);
         // Each result should be distinct (serialized execution)
-        assert!(results.iter().all(|(r, _)| r.starts_with("write-")));
+        assert!(results.iter().all(|(r, _, _)| r.starts_with("write-")));
     }
 
     #[tokio::test]
@@ -908,7 +908,7 @@ mod tests {
         let results = runner.execute_tools(&calls).await;
 
         assert_eq!(results.len(), 1);
-        let (_, duration_ms) = &results[0];
+        let (_, duration_ms, _) = &results[0];
         assert!(
             *duration_ms >= 40,
             "per-tool duration should reflect actual execution time, got {duration_ms}ms"

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -300,7 +300,7 @@ impl AgentRunner {
             let results = self.execute_tools(&tool_calls).await;
             tool_calls_made += tool_calls.len();
 
-            for (tc, (_, duration_ms)) in tool_calls.iter().zip(&results) {
+            for (tc, (_, duration_ms, success)) in tool_calls.iter().zip(&results) {
                 debug!(
                     tool_name = %tc.function.name,
                     duration_ms = *duration_ms,
@@ -312,14 +312,14 @@ impl AgentRunner {
                         trace_id = %tid,
                         tool = %tc.function.name,
                         duration_ms = *duration_ms,
-                        success = true,
+                        success = *success,
                         "TOOL END"
                     );
                 }
             }
 
             // Add tool results to conversation
-            for (tool_call, (result, _)) in tool_calls.iter().zip(results) {
+            for (tool_call, (result, _, _)) in tool_calls.iter().zip(results) {
                 conversation.push(Message {
                     role: MessageRole::Tool,
                     content: result,
@@ -578,7 +578,7 @@ impl AgentRunner {
     /// Read-only tools run concurrently as before. Mutating tools each
     /// acquire a shared mutex before executing, guaranteeing they run
     /// one at a time even when the LLM issues several in a single turn.
-    async fn execute_tools(&self, tool_calls: &[ToolCall]) -> Vec<(String, u64)> {
+    async fn execute_tools(&self, tool_calls: &[ToolCall]) -> Vec<(String, u64, bool)> {
         let mut handles = Vec::new();
 
         for tc in tool_calls {
@@ -600,6 +600,7 @@ impl AgentRunner {
                                 tool_name, e, args_str
                             ),
                             start.elapsed().as_millis() as u64,
+                            false,
                         );
                     }
                 };
@@ -616,7 +617,9 @@ impl AgentRunner {
                         Err(e) => format!("Tool error: {}", e),
                     }
                 };
-                (result, start.elapsed().as_millis() as u64)
+                let ok = !result.starts_with("Tool error:")
+                    && !result.starts_with("Tool argument error");
+                (result, start.elapsed().as_millis() as u64, ok)
             });
 
             handles.push(handle);
@@ -635,7 +638,7 @@ impl AgentRunner {
         }
 
         let total = handles.len();
-        let mut results: Vec<(String, u64)> = Vec::with_capacity(total);
+        let mut results: Vec<(String, u64, bool)> = Vec::with_capacity(total);
         let overall_start = std::time::Instant::now();
         let heartbeat_interval = std::time::Duration::from_secs(10);
 
@@ -646,14 +649,14 @@ impl AgentRunner {
                 match tokio::time::timeout(heartbeat_interval, &mut h).await {
                     Ok(join_res) => {
                         match join_res {
-                            Ok((result, duration)) => {
+                            Ok((result, duration, ok)) => {
                                 self.emit_event(AgentEvent::ToolResult {
                                     session_key: self.session_key.clone().unwrap_or_default(),
                                     tool_name: tool_calls[i].function.name.clone(),
                                     duration_ms: duration,
                                     trace_id: self.trace_id.clone(),
                                 });
-                                results.push((result, duration));
+                                results.push((result, duration, ok));
                             }
                             Err(e) => {
                                 self.emit_event(AgentEvent::ToolResult {
@@ -662,7 +665,7 @@ impl AgentRunner {
                                     duration_ms: 0,
                                     trace_id: self.trace_id.clone(),
                                 });
-                                results.push((format!("Tool execution failed: {}", e), 0));
+                                results.push((format!("Tool execution failed: {}", e), 0, false));
                             }
                         }
                         break;

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -276,6 +276,14 @@ impl AgentRunner {
                     iteration: iteration + 1,
                     trace_id: self.trace_id.clone(),
                 });
+                if let Some(ref tid) = self.trace_id {
+                    tracing::info!(
+                        target: "comm",
+                        trace_id = %tid,
+                        tool = %tc.function.name,
+                        "TOOL START"
+                    );
+                }
             }
 
             // Add assistant message with tool calls
@@ -298,6 +306,16 @@ impl AgentRunner {
                     duration_ms = *duration_ms,
                     "Tool call completed"
                 );
+                if let Some(ref tid) = self.trace_id {
+                    tracing::info!(
+                        target: "comm",
+                        trace_id = %tid,
+                        tool = %tc.function.name,
+                        duration_ms = *duration_ms,
+                        success = true,
+                        "TOOL END"
+                    );
+                }
             }
 
             // Add tool results to conversation

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -343,6 +343,13 @@ impl WebSocketChannel {
         let mut env = WsEnvelope::message(text);
         env.reply_to = reply_to.map(|r| r.to_string());
         env.trace_id = Some(trace_id.to_string());
+        tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            client_id = %client_id,
+            msg_type = "message",
+            "WS OUT"
+        );
         if let Ok(json) = env.to_json() {
             if let Some(client_tx) = clients.get(client_id) {
                 let _ = client_tx.send(json);
@@ -767,10 +774,18 @@ impl WebSocketChannel {
                 source: Some(source),
                 message_type,
                 message_id: envelope_msg_id.clone(),
-                trace_id: Some(trace_id),
+                trace_id: Some(trace_id.clone()),
                 reply_to: None,
                 timestamp: chrono::Local::now(),
             };
+
+            tracing::info!(
+                target: "comm",
+                trace_id = %trace_id,
+                client_id = %client_id,
+                msg_type = "message",
+                "WS IN"
+            );
 
             if let Err(e) = handler.send(inbound).await {
                 warn!(
@@ -939,6 +954,15 @@ impl BaseChannel for WebSocketChannel {
         match client.send(json) {
             Ok(()) => {
                 debug!("Sent message to WebSocket client {}", chat_id);
+                if let Some(tid) = trace_id {
+                    tracing::info!(
+                        target: "comm",
+                        trace_id = %tid,
+                        client_id = %chat_id,
+                        msg_type = "message",
+                        "WS OUT"
+                    );
+                }
                 Ok(SendResult {
                     success: true,
                     message_id: Some(format!("ws_{}", chat_id)),

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -806,6 +806,48 @@ impl Default for ApiConfig {
 ///   working_directory: /
 ///   grace_period_secs: 30
 /// ```
+/// Communication log configuration — controls HTTP/WS/tool-call tracing.
+///
+/// When enabled, the system emits structured logs tagged with `target: "comm"`
+/// containing `trace_id` fields for full-chain correlation.
+///
+/// ```yaml
+/// daemon:
+///   comm_log:
+///     enabled: true
+///     level: debug
+///     separate_file: true
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommLogConfig {
+    /// Whether communication logging is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Log level for comm events: `"info"`, `"debug"`, or `"trace"`.
+    #[serde(default = "default_comm_log_level")]
+    pub level: String,
+
+    /// Write comm events to a separate `comm.log` file.
+    #[serde(default)]
+    pub separate_file: bool,
+}
+
+fn default_comm_log_level() -> String {
+    "info".to_string()
+}
+
+impl Default for CommLogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            level: default_comm_log_level(),
+            separate_file: false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct DaemonConfig {
@@ -836,6 +878,10 @@ pub struct DaemonConfig {
     /// Log output format: `"text"` (human-readable) or `"json"` (structured).
     #[serde(default = "default_daemon_log_format")]
     pub log_format: String,
+
+    /// Communication log configuration (HTTP, WS, tool-call tracing).
+    #[serde(default)]
+    pub comm_log: Option<CommLogConfig>,
 }
 
 fn default_daemon_pid_file() -> String {
@@ -901,6 +947,7 @@ impl Default for DaemonConfig {
             log_level: default_daemon_log_level(),
             log_retain_days: default_daemon_log_retain_days(),
             log_format: default_daemon_log_format(),
+            comm_log: None,
         }
     }
 }
@@ -1032,6 +1079,72 @@ mod tests {
             config.notifications.online_message,
             "🟢 Kestrel v{version} online — {channel} connected"
         );
+    }
+
+    #[test]
+    fn test_comm_log_config_default() {
+        let cfg = CommLogConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.level, "info");
+        assert!(!cfg.separate_file);
+    }
+
+    #[test]
+    fn test_comm_log_config_serde_roundtrip() {
+        let cfg = CommLogConfig {
+            enabled: true,
+            level: "debug".to_string(),
+            separate_file: true,
+        };
+        let yaml = serde_yaml::to_string(&cfg).unwrap();
+        let parsed: CommLogConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert!(parsed.enabled);
+        assert_eq!(parsed.level, "debug");
+        assert!(parsed.separate_file);
+    }
+
+    #[test]
+    fn test_daemon_config_comm_log_default_none() {
+        let cfg = DaemonConfig::default();
+        assert!(cfg.comm_log.is_none());
+    }
+
+    #[test]
+    fn test_daemon_config_with_comm_log_yaml() {
+        let yaml = r#"
+pid_file: /tmp/test.pid
+log_dir: /tmp/test-logs
+working_directory: /
+grace_period_secs: 30
+log_level: info
+log_retain_days: 30
+log_format: text
+comm_log:
+  enabled: true
+  level: debug
+  separate_file: true
+"#;
+        let cfg: DaemonConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.comm_log.is_some());
+        let cl = cfg.comm_log.unwrap();
+        assert!(cl.enabled);
+        assert_eq!(cl.level, "debug");
+        assert!(cl.separate_file);
+    }
+
+    #[test]
+    fn test_daemon_config_without_comm_log_yaml() {
+        let yaml = r#"
+pid_file: /tmp/test.pid
+log_dir: /tmp/test-logs
+working_directory: /
+grace_period_secs: 30
+log_level: info
+log_retain_days: 30
+log_format: text
+"#;
+        let cfg: DaemonConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.comm_log.is_none());
     }
 
     #[test]

--- a/crates/kestrel-core/Cargo.toml
+++ b/crates/kestrel-core/Cargo.toml
@@ -10,3 +10,6 @@ thiserror = { workspace = true }
 chrono = { workspace = true }
 reqwest = { workspace = true }
 hickory-resolver = { workspace = true }
+uuid = { workspace = true }
+tracing = { workspace = true }
+tracing-appender = "0.2"

--- a/crates/kestrel-core/Cargo.toml
+++ b/crates/kestrel-core/Cargo.toml
@@ -12,4 +12,3 @@ reqwest = { workspace = true }
 hickory-resolver = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = "0.2"

--- a/crates/kestrel-core/src/comm_log.rs
+++ b/crates/kestrel-core/src/comm_log.rs
@@ -1,0 +1,292 @@
+//! Communication log helpers — thin wrappers around `tracing` macros.
+//!
+//! All methods emit events with `target: "comm"` so the logging subscriber
+//! can route them to a separate file. The `trace_id` field is always present.
+
+use std::collections::HashMap;
+use tracing_appender::non_blocking::WorkerGuard;
+
+/// Guard returned by [`setup_comm_log`]. Must be kept alive for the
+/// application lifetime — dropping flushes remaining log lines.
+pub struct CommLogGuard {
+    _guard: WorkerGuard,
+}
+
+/// Set up a dedicated non-blocking writer for `comm.log`.
+///
+/// Returns a guard that must be held for the application's lifetime.
+pub fn setup_comm_log(log_dir: &str) -> anyhow::Result<CommLogGuard> {
+    let log_path = std::path::Path::new(log_dir);
+    std::fs::create_dir_all(log_path)?;
+
+    let file_appender = tracing_appender::rolling::daily(log_path, "comm.log");
+    let (_non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    Ok(CommLogGuard { _guard: guard })
+}
+
+/// Sanitize sensitive headers before logging.
+pub fn sanitize_headers(headers: &HashMap<String, String>) -> HashMap<String, String> {
+    headers
+        .iter()
+        .map(|(k, v)| {
+            let lower = k.to_lowercase();
+            if lower == "authorization" || lower == "x-api-key" || lower.contains("token") {
+                (k.clone(), "***".to_string())
+            } else {
+                (k.clone(), v.clone())
+            }
+        })
+        .collect()
+}
+
+/// Log an HTTP request via tracing.
+pub fn log_http_request(
+    trace_id: &str,
+    method: &str,
+    url: &str,
+    headers: &HashMap<String, String>,
+    body: &serde_json::Value,
+    level: &str,
+) {
+    let sanitized = sanitize_headers(headers);
+    match level {
+        "trace" => tracing::trace!(
+            target: "comm",
+            trace_id = %trace_id,
+            method = %method,
+            url = %url,
+            headers = ?sanitized,
+            body = %body,
+            "HTTP REQ"
+        ),
+        "debug" => tracing::debug!(
+            target: "comm",
+            trace_id = %trace_id,
+            method = %method,
+            url = %url,
+            headers = ?sanitized,
+            "HTTP REQ"
+        ),
+        _ => tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            method = %method,
+            url = %url,
+            "HTTP REQ"
+        ),
+    }
+}
+
+/// Log an HTTP response via tracing.
+pub fn log_http_response(
+    trace_id: &str,
+    status: u16,
+    body_summary: &str,
+    duration_ms: u64,
+    level: &str,
+) {
+    match level {
+        "trace" => tracing::trace!(
+            target: "comm",
+            trace_id = %trace_id,
+            status = status,
+            duration_ms = duration_ms,
+            body = %body_summary,
+            "HTTP RESP"
+        ),
+        "debug" => tracing::debug!(
+            target: "comm",
+            trace_id = %trace_id,
+            status = status,
+            duration_ms = duration_ms,
+            "HTTP RESP"
+        ),
+        _ => tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            status = status,
+            duration_ms = duration_ms,
+            "HTTP RESP"
+        ),
+    }
+}
+
+/// Log a WebSocket inbound message.
+pub fn log_ws_inbound(
+    trace_id: &str,
+    client_id: &str,
+    msg_type: &str,
+    payload: &str,
+    level: &str,
+) {
+    match level {
+        "trace" => tracing::trace!(
+            target: "comm",
+            trace_id = %trace_id,
+            client_id = %client_id,
+            msg_type = %msg_type,
+            payload = %payload,
+            "WS IN"
+        ),
+        "debug" => tracing::debug!(
+            target: "comm",
+            trace_id = %trace_id,
+            client_id = %client_id,
+            msg_type = %msg_type,
+            "WS IN"
+        ),
+        _ => tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            client_id = %client_id,
+            msg_type = %msg_type,
+            "WS IN"
+        ),
+    }
+}
+
+/// Log a WebSocket outbound message.
+pub fn log_ws_outbound(
+    trace_id: &str,
+    client_id: &str,
+    msg_type: &str,
+    payload: &str,
+    level: &str,
+) {
+    match level {
+        "trace" => tracing::trace!(
+            target: "comm",
+            trace_id = %trace_id,
+            client_id = %client_id,
+            msg_type = %msg_type,
+            payload = %payload,
+            "WS OUT"
+        ),
+        "debug" => tracing::debug!(
+            target: "comm",
+            trace_id = %trace_id,
+            client_id = %client_id,
+            msg_type = %msg_type,
+            "WS OUT"
+        ),
+        _ => tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            client_id = %client_id,
+            msg_type = %msg_type,
+            "WS OUT"
+        ),
+    }
+}
+
+/// Log a tool call start.
+pub fn log_tool_call(
+    trace_id: &str,
+    tool_name: &str,
+    params: &serde_json::Value,
+    level: &str,
+) {
+    match level {
+        "trace" => tracing::trace!(
+            target: "comm",
+            trace_id = %trace_id,
+            tool = %tool_name,
+            params = %params,
+            "TOOL START"
+        ),
+        "debug" => tracing::debug!(
+            target: "comm",
+            trace_id = %trace_id,
+            tool = %tool_name,
+            params = %params,
+            "TOOL START"
+        ),
+        _ => tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            tool = %tool_name,
+            "TOOL START"
+        ),
+    }
+}
+
+/// Log a tool call result.
+pub fn log_tool_result(
+    trace_id: &str,
+    tool_name: &str,
+    result_summary: &str,
+    duration_ms: u64,
+    success: bool,
+    level: &str,
+) {
+    match level {
+        "trace" => tracing::trace!(
+            target: "comm",
+            trace_id = %trace_id,
+            tool = %tool_name,
+            duration_ms = duration_ms,
+            success = success,
+            result = %result_summary,
+            "TOOL END"
+        ),
+        "debug" => tracing::debug!(
+            target: "comm",
+            trace_id = %trace_id,
+            tool = %tool_name,
+            duration_ms = duration_ms,
+            success = success,
+            "TOOL END"
+        ),
+        _ => tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            tool = %tool_name,
+            duration_ms = duration_ms,
+            success = success,
+            "TOOL END"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_headers_masks_authorization() {
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer secret".to_string());
+        headers.insert("Content-Type".to_string(), "application/json".to_string());
+        let sanitized = sanitize_headers(&headers);
+        assert_eq!(sanitized.get("Authorization").unwrap(), "***");
+        assert_eq!(
+            sanitized.get("Content-Type").unwrap(),
+            "application/json"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_headers_masks_x_api_key() {
+        let mut headers = HashMap::new();
+        headers.insert("x-api-key".to_string(), "sk-123".to_string());
+        let sanitized = sanitize_headers(&headers);
+        assert_eq!(sanitized.get("x-api-key").unwrap(), "***");
+    }
+
+    #[test]
+    fn test_sanitize_headers_masks_token_fields() {
+        let mut headers = HashMap::new();
+        headers.insert("X-Auth-Token".to_string(), "abc".to_string());
+        let sanitized = sanitize_headers(&headers);
+        assert_eq!(sanitized.get("X-Auth-Token").unwrap(), "***");
+    }
+
+    #[test]
+    fn test_sanitize_headers_preserves_safe_headers() {
+        let mut headers = HashMap::new();
+        headers.insert("Accept".to_string(), "application/json".to_string());
+        let sanitized = sanitize_headers(&headers);
+        assert_eq!(sanitized.get("Accept").unwrap(), "application/json");
+    }
+}

--- a/crates/kestrel-core/src/comm_log.rs
+++ b/crates/kestrel-core/src/comm_log.rs
@@ -1,31 +1,14 @@
-//! Communication log helpers — thin wrappers around `tracing` macros.
+//! Communication log helpers.
 //!
-//! All methods emit events with `target: "comm"` so the logging subscriber
-//! can route them to a separate file. The `trace_id` field is always present.
+//! Provides header sanitization for comm-log events. Actual logging is done
+//! via `tracing::info!(target: "comm", ...)` in provider/ws/tool code.
 
 use std::collections::HashMap;
-use tracing_appender::non_blocking::WorkerGuard;
-
-/// Guard returned by [`setup_comm_log`]. Must be kept alive for the
-/// application lifetime — dropping flushes remaining log lines.
-pub struct CommLogGuard {
-    _guard: WorkerGuard,
-}
-
-/// Set up a dedicated non-blocking writer for `comm.log`.
-///
-/// Returns a guard that must be held for the application's lifetime.
-pub fn setup_comm_log(log_dir: &str) -> anyhow::Result<CommLogGuard> {
-    let log_path = std::path::Path::new(log_dir);
-    std::fs::create_dir_all(log_path)?;
-
-    let file_appender = tracing_appender::rolling::daily(log_path, "comm.log");
-    let (_non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-
-    Ok(CommLogGuard { _guard: guard })
-}
 
 /// Sanitize sensitive headers before logging.
+///
+/// Masks values for `Authorization`, `x-api-key`, and any header whose
+/// lowercase name contains "token".
 pub fn sanitize_headers(headers: &HashMap<String, String>) -> HashMap<String, String> {
     headers
         .iter()
@@ -40,215 +23,6 @@ pub fn sanitize_headers(headers: &HashMap<String, String>) -> HashMap<String, St
         .collect()
 }
 
-/// Log an HTTP request via tracing.
-pub fn log_http_request(
-    trace_id: &str,
-    method: &str,
-    url: &str,
-    headers: &HashMap<String, String>,
-    body: &serde_json::Value,
-    level: &str,
-) {
-    let sanitized = sanitize_headers(headers);
-    match level {
-        "trace" => tracing::trace!(
-            target: "comm",
-            trace_id = %trace_id,
-            method = %method,
-            url = %url,
-            headers = ?sanitized,
-            body = %body,
-            "HTTP REQ"
-        ),
-        "debug" => tracing::debug!(
-            target: "comm",
-            trace_id = %trace_id,
-            method = %method,
-            url = %url,
-            headers = ?sanitized,
-            "HTTP REQ"
-        ),
-        _ => tracing::info!(
-            target: "comm",
-            trace_id = %trace_id,
-            method = %method,
-            url = %url,
-            "HTTP REQ"
-        ),
-    }
-}
-
-/// Log an HTTP response via tracing.
-pub fn log_http_response(
-    trace_id: &str,
-    status: u16,
-    body_summary: &str,
-    duration_ms: u64,
-    level: &str,
-) {
-    match level {
-        "trace" => tracing::trace!(
-            target: "comm",
-            trace_id = %trace_id,
-            status = status,
-            duration_ms = duration_ms,
-            body = %body_summary,
-            "HTTP RESP"
-        ),
-        "debug" => tracing::debug!(
-            target: "comm",
-            trace_id = %trace_id,
-            status = status,
-            duration_ms = duration_ms,
-            "HTTP RESP"
-        ),
-        _ => tracing::info!(
-            target: "comm",
-            trace_id = %trace_id,
-            status = status,
-            duration_ms = duration_ms,
-            "HTTP RESP"
-        ),
-    }
-}
-
-/// Log a WebSocket inbound message.
-pub fn log_ws_inbound(
-    trace_id: &str,
-    client_id: &str,
-    msg_type: &str,
-    payload: &str,
-    level: &str,
-) {
-    match level {
-        "trace" => tracing::trace!(
-            target: "comm",
-            trace_id = %trace_id,
-            client_id = %client_id,
-            msg_type = %msg_type,
-            payload = %payload,
-            "WS IN"
-        ),
-        "debug" => tracing::debug!(
-            target: "comm",
-            trace_id = %trace_id,
-            client_id = %client_id,
-            msg_type = %msg_type,
-            "WS IN"
-        ),
-        _ => tracing::info!(
-            target: "comm",
-            trace_id = %trace_id,
-            client_id = %client_id,
-            msg_type = %msg_type,
-            "WS IN"
-        ),
-    }
-}
-
-/// Log a WebSocket outbound message.
-pub fn log_ws_outbound(
-    trace_id: &str,
-    client_id: &str,
-    msg_type: &str,
-    payload: &str,
-    level: &str,
-) {
-    match level {
-        "trace" => tracing::trace!(
-            target: "comm",
-            trace_id = %trace_id,
-            client_id = %client_id,
-            msg_type = %msg_type,
-            payload = %payload,
-            "WS OUT"
-        ),
-        "debug" => tracing::debug!(
-            target: "comm",
-            trace_id = %trace_id,
-            client_id = %client_id,
-            msg_type = %msg_type,
-            "WS OUT"
-        ),
-        _ => tracing::info!(
-            target: "comm",
-            trace_id = %trace_id,
-            client_id = %client_id,
-            msg_type = %msg_type,
-            "WS OUT"
-        ),
-    }
-}
-
-/// Log a tool call start.
-pub fn log_tool_call(
-    trace_id: &str,
-    tool_name: &str,
-    params: &serde_json::Value,
-    level: &str,
-) {
-    match level {
-        "trace" => tracing::trace!(
-            target: "comm",
-            trace_id = %trace_id,
-            tool = %tool_name,
-            params = %params,
-            "TOOL START"
-        ),
-        "debug" => tracing::debug!(
-            target: "comm",
-            trace_id = %trace_id,
-            tool = %tool_name,
-            params = %params,
-            "TOOL START"
-        ),
-        _ => tracing::info!(
-            target: "comm",
-            trace_id = %trace_id,
-            tool = %tool_name,
-            "TOOL START"
-        ),
-    }
-}
-
-/// Log a tool call result.
-pub fn log_tool_result(
-    trace_id: &str,
-    tool_name: &str,
-    result_summary: &str,
-    duration_ms: u64,
-    success: bool,
-    level: &str,
-) {
-    match level {
-        "trace" => tracing::trace!(
-            target: "comm",
-            trace_id = %trace_id,
-            tool = %tool_name,
-            duration_ms = duration_ms,
-            success = success,
-            result = %result_summary,
-            "TOOL END"
-        ),
-        "debug" => tracing::debug!(
-            target: "comm",
-            trace_id = %trace_id,
-            tool = %tool_name,
-            duration_ms = duration_ms,
-            success = success,
-            "TOOL END"
-        ),
-        _ => tracing::info!(
-            target: "comm",
-            trace_id = %trace_id,
-            tool = %tool_name,
-            duration_ms = duration_ms,
-            success = success,
-            "TOOL END"
-        ),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,10 +34,7 @@ mod tests {
         headers.insert("Content-Type".to_string(), "application/json".to_string());
         let sanitized = sanitize_headers(&headers);
         assert_eq!(sanitized.get("Authorization").unwrap(), "***");
-        assert_eq!(
-            sanitized.get("Content-Type").unwrap(),
-            "application/json"
-        );
+        assert_eq!(sanitized.get("Content-Type").unwrap(), "application/json");
     }
 
     #[test]

--- a/crates/kestrel-core/src/lib.rs
+++ b/crates/kestrel-core/src/lib.rs
@@ -2,11 +2,15 @@
 //!
 //! Shared types, error definitions, and constants for the kestrel project.
 
+pub mod comm_log;
 pub mod constants;
 pub mod dns;
 pub mod error;
+pub mod trace;
 pub mod types;
 
+pub use comm_log::*;
 pub use constants::*;
 pub use error::*;
+pub use trace::*;
 pub use types::*;

--- a/crates/kestrel-core/src/trace.rs
+++ b/crates/kestrel-core/src/trace.rs
@@ -1,6 +1,4 @@
-//! Trace ID generation and context propagation.
-
-use serde::{Deserialize, Serialize};
+//! Trace ID generation for request correlation.
 
 /// Generate a short trace ID for request correlation.
 ///
@@ -8,13 +6,6 @@ use serde::{Deserialize, Serialize};
 pub fn generate_trace_id() -> String {
     let uuid = uuid::Uuid::new_v4();
     format!("tr-{}", &uuid.to_string().replace('-', "")[..12])
-}
-
-/// Trace context carried through the request lifecycle.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TraceContext {
-    pub trace_id: String,
-    pub parent_span_id: Option<String>,
 }
 
 #[cfg(test)]
@@ -33,17 +24,5 @@ mod tests {
         let ids: std::collections::HashSet<String> =
             (0..1000).map(|_| generate_trace_id()).collect();
         assert_eq!(ids.len(), 1000, "all trace IDs should be unique");
-    }
-
-    #[test]
-    fn test_trace_context_serialization() {
-        let ctx = TraceContext {
-            trace_id: "tr-abc123def456".to_string(),
-            parent_span_id: Some("span-1".to_string()),
-        };
-        let json = serde_json::to_string(&ctx).unwrap();
-        let parsed: TraceContext = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.trace_id, "tr-abc123def456");
-        assert_eq!(parsed.parent_span_id, Some("span-1".to_string()));
     }
 }

--- a/crates/kestrel-core/src/trace.rs
+++ b/crates/kestrel-core/src/trace.rs
@@ -1,0 +1,50 @@
+//! Trace ID generation and context propagation.
+
+use serde::{Deserialize, Serialize};
+
+/// Generate a short trace ID for request correlation.
+///
+/// Format: `tr-{uuid_first_12_hex}` — compact yet globally unique.
+pub fn generate_trace_id() -> String {
+    let uuid = uuid::Uuid::new_v4();
+    format!("tr-{}", &uuid.to_string().replace('-', "")[..12])
+}
+
+/// Trace context carried through the request lifecycle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceContext {
+    pub trace_id: String,
+    pub parent_span_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_trace_id_format() {
+        let id = generate_trace_id();
+        assert!(id.starts_with("tr-"));
+        assert_eq!(id.len(), 15); // "tr-" + 12 hex chars
+    }
+
+    #[test]
+    fn test_generate_trace_id_uniqueness() {
+        let ids: std::collections::HashSet<String> = (0..1000)
+            .map(|_| generate_trace_id())
+            .collect();
+        assert_eq!(ids.len(), 1000, "all trace IDs should be unique");
+    }
+
+    #[test]
+    fn test_trace_context_serialization() {
+        let ctx = TraceContext {
+            trace_id: "tr-abc123def456".to_string(),
+            parent_span_id: Some("span-1".to_string()),
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        let parsed: TraceContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.trace_id, "tr-abc123def456");
+        assert_eq!(parsed.parent_span_id, Some("span-1".to_string()));
+    }
+}

--- a/crates/kestrel-core/src/trace.rs
+++ b/crates/kestrel-core/src/trace.rs
@@ -30,9 +30,8 @@ mod tests {
 
     #[test]
     fn test_generate_trace_id_uniqueness() {
-        let ids: std::collections::HashSet<String> = (0..1000)
-            .map(|_| generate_trace_id())
-            .collect();
+        let ids: std::collections::HashSet<String> =
+            (0..1000).map(|_| generate_trace_id()).collect();
         assert_eq!(ids.len(), 1000, "all trace IDs should be unique");
     }
 

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -10,11 +10,7 @@
 
 use anyhow::{Context, Result};
 use std::path::Path;
-use tracing_subscriber::{
-    filter::Targets,
-    layer::SubscriberExt,
-    EnvFilter, Layer, Registry,
-};
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, EnvFilter, Layer, Registry};
 
 /// Guard returned by [`setup_file_logging`]. Must be kept alive for the
 /// lifetime of the application — dropping it flushes and closes the log file.
@@ -74,8 +70,7 @@ pub fn setup_file_logging(
         let (comm_nb, cg) = tracing_appender::non_blocking(comm_appender);
         comm_guard = Some(cg);
 
-        let comm_filter = Targets::new()
-            .with_target("comm", parse_level(comm_level));
+        let comm_filter = Targets::new().with_target("comm", parse_level(comm_level));
 
         if effective_format == "json" {
             Some(
@@ -120,8 +115,7 @@ pub fn setup_file_logging(
         None => subscriber,
     };
 
-    tracing::subscriber::set_global_default(subscriber)
-        .context("set global tracing subscriber")?;
+    tracing::subscriber::set_global_default(subscriber).context("set global tracing subscriber")?;
 
     tracing::info!(
         "File logging initialized: {}/kestrel.log (format: {})",
@@ -130,10 +124,7 @@ pub fn setup_file_logging(
     );
 
     if comm_log_level.is_some() {
-        tracing::info!(
-            "Comm logging initialized: {}/comm.log",
-            log_dir
-        );
+        tracing::info!("Comm logging initialized: {}/comm.log", log_dir);
     }
 
     Ok((guard, comm_guard))

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -4,14 +4,24 @@
 //! daemon-mode processes can write structured logs to disk instead of
 //! (or in addition to) the terminal. Supports both human-readable text and
 //! structured JSON output formats.
+//!
+//! When comm-log is enabled, a second tracing layer writes events with
+//! `target: "comm"` to a separate `comm.log` file with its own level filter.
 
 use anyhow::{Context, Result};
 use std::path::Path;
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
+use tracing_subscriber::{
+    filter::Targets,
+    layer::SubscriberExt,
+    EnvFilter, Layer, Registry,
+};
 
 /// Guard returned by [`setup_file_logging`]. Must be kept alive for the
 /// lifetime of the application — dropping it flushes and closes the log file.
 pub type LogGuard = tracing_appender::non_blocking::WorkerGuard;
+
+/// Additional guard for the comm-log writer (when enabled).
+pub type CommLogGuard = tracing_appender::non_blocking::WorkerGuard;
 
 /// Configure file-based logging for daemon mode.
 ///
@@ -23,17 +33,20 @@ pub type LogGuard = tracing_appender::non_blocking::WorkerGuard;
 /// * `log_dir` - Directory for log files (created if it doesn't exist).
 /// * `level` - Log level filter (e.g. `"info"`, `"debug"`, `"trace"`).
 /// * `log_format` - Output format: `"text"` (human-readable) or `"json"`.
+/// * `comm_log_level` - If `Some`, enables comm-log layer with this level,
+///   writing `target: "comm"` events to a separate `comm.log` file.
 ///
 /// # Returns
 ///
-/// A [`LogGuard`] that must be held for the application's lifetime.
-/// Dropping the guard flushes remaining log lines and stops the writer thread.
-///
-/// # Errors
-///
-/// Returns an error if the log directory cannot be created or the subscriber
-/// cannot be installed.
-pub fn setup_file_logging(log_dir: &str, level: &str, log_format: &str) -> Result<LogGuard> {
+/// A tuple of `(LogGuard, Option<CommLogGuard>)` that must be held for the
+/// application's lifetime. Dropping either guard flushes remaining log lines
+/// and stops its writer thread.
+pub fn setup_file_logging(
+    log_dir: &str,
+    level: &str,
+    log_format: &str,
+    comm_log_level: Option<&str>,
+) -> Result<(LogGuard, Option<CommLogGuard>)> {
     let log_path = Path::new(log_dir);
     std::fs::create_dir_all(log_path).context("create log directory")?;
 
@@ -53,24 +66,62 @@ pub fn setup_file_logging(log_dir: &str, level: &str, log_format: &str) -> Resul
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
 
-    if effective_format == "json" {
-        let file_layer = tracing_subscriber::fmt::layer()
+    // Build the comm-log layer if requested.
+    let mut comm_guard: Option<CommLogGuard> = None;
+
+    let comm_layer = if let Some(comm_level) = comm_log_level {
+        let comm_appender = tracing_appender::rolling::daily(log_path, "comm.log");
+        let (comm_nb, cg) = tracing_appender::non_blocking(comm_appender);
+        comm_guard = Some(cg);
+
+        let comm_filter = Targets::new()
+            .with_target("comm", parse_level(comm_level));
+
+        if effective_format == "json" {
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(comm_nb)
+                    .with_ansi(false)
+                    .json()
+                    .with_filter(comm_filter),
+            )
+        } else {
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(comm_nb)
+                    .with_ansi(false)
+                    .with_filter(comm_filter),
+            )
+        }
+    } else {
+        None
+    };
+
+    // Main layer excludes "comm" target so events don't duplicate.
+    let main_filter = filter;
+    let main_layer = if effective_format == "json" {
+        tracing_subscriber::fmt::layer()
             .with_writer(non_blocking)
             .with_ansi(false)
             .json()
-            .with_filter(filter);
-        let subscriber = Registry::default().with(file_layer);
-        tracing::subscriber::set_global_default(subscriber)
-            .context("set global tracing subscriber")?;
+            .with_filter(main_filter)
+            .boxed()
     } else {
-        let file_layer = tracing_subscriber::fmt::layer()
+        tracing_subscriber::fmt::layer()
             .with_writer(non_blocking)
             .with_ansi(false)
-            .with_filter(filter);
-        let subscriber = Registry::default().with(file_layer);
-        tracing::subscriber::set_global_default(subscriber)
-            .context("set global tracing subscriber")?;
-    }
+            .with_filter(main_filter)
+            .boxed()
+    };
+
+    let subscriber = Registry::default().with(main_layer);
+    let subscriber = match comm_layer {
+        Some(cl) => subscriber.with(cl),
+        None => subscriber,
+    };
+
+    tracing::subscriber::set_global_default(subscriber)
+        .context("set global tracing subscriber")?;
 
     tracing::info!(
         "File logging initialized: {}/kestrel.log (format: {})",
@@ -78,14 +129,37 @@ pub fn setup_file_logging(log_dir: &str, level: &str, log_format: &str) -> Resul
         effective_format
     );
 
+    if comm_log_level.is_some() {
+        tracing::info!(
+            "Comm logging initialized: {}/comm.log",
+            log_dir
+        );
+    }
+
+    Ok((guard, comm_guard))
+}
+
+/// Backward-compatible wrapper: setup file logging without comm-log.
+pub fn setup_file_logging_simple(log_dir: &str, level: &str, log_format: &str) -> Result<LogGuard> {
+    let (guard, _) = setup_file_logging(log_dir, level, log_format, None)?;
     Ok(guard)
+}
+
+fn parse_level(level: &str) -> tracing::Level {
+    match level {
+        "trace" => tracing::Level::TRACE,
+        "debug" => tracing::Level::DEBUG,
+        "warn" => tracing::Level::WARN,
+        "error" => tracing::Level::ERROR,
+        _ => tracing::Level::INFO,
+    }
 }
 
 /// Delete log files older than `retain_days` from `log_dir`.
 ///
-/// Scans the directory for files matching the `kestrel.log.*` pattern and
-/// removes any whose modification time is older than the retention period.
-/// Errors during individual file removal are logged but not propagated.
+/// Scans the directory for files matching the `kestrel.log.*` or `comm.log.*`
+/// patterns and removes any whose modification time is older than the retention
+/// period. Errors during individual file removal are logged but not propagated.
 pub fn cleanup_old_logs(log_dir: &str, retain_days: u64) {
     let Ok(entries) = std::fs::read_dir(log_dir) else {
         return;
@@ -105,8 +179,8 @@ pub fn cleanup_old_logs(log_dir: &str, retain_days: u64) {
             None => continue,
         };
 
-        // Only clean up rolling log files (kestrel.log.YYYY-MM-DD)
-        if !filename.starts_with("kestrel.log.") {
+        // Clean up rolling log files (kestrel.log.* or comm.log.*)
+        if !filename.starts_with("kestrel.log.") && !filename.starts_with("comm.log.") {
             continue;
         }
 
@@ -159,11 +233,11 @@ mod tests {
 
         // Test directory creation — ignore the global subscriber conflict
         // (set_global_default can only be called once per process)
-        let result = setup_file_logging(log_dir_str, "info", "text");
+        let result = setup_file_logging(log_dir_str, "info", "text", None);
         assert!(log_dir.exists(), "log directory should be created");
 
         // The guard may fail on re-install, but directory must exist regardless
-        if let Ok(_guard) = result {
+        if let Ok((_guard, _comm_guard)) = result {
             tracing::info!("test log message from unit test");
         }
     }
@@ -175,7 +249,7 @@ mod tests {
         let log_dir_str = log_dir.to_str().unwrap();
 
         // The function creates the directory before attempting to set subscriber
-        let _ = setup_file_logging(log_dir_str, "info", "text");
+        let _ = setup_file_logging(log_dir_str, "info", "text", None);
         assert!(
             log_dir.exists(),
             "directory must be created even if subscriber fails"
@@ -237,10 +311,38 @@ mod tests {
         let log_dir_str = log_dir.to_str().unwrap();
 
         // "xml" is not a valid format — should fall back to "text"
-        let result = setup_file_logging(log_dir_str, "info", "xml");
+        let result = setup_file_logging(log_dir_str, "info", "xml", None);
         assert!(log_dir.exists());
-        if let Ok(_guard) = result {
+        if let Ok((_guard, _comm_guard)) = result {
             // Subscriber may conflict with other tests; that's OK
         }
+    }
+
+    #[test]
+    fn test_cleanup_old_logs_also_cleans_comm_log() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path();
+
+        // Create an old comm.log file
+        let old_comm = log_dir.join("comm.log.2025-01-01");
+        std::fs::write(&old_comm, "old comm log").unwrap();
+        let old_time =
+            std::time::SystemTime::now() - std::time::Duration::from_secs(60 * 24 * 60 * 60);
+        filetime::set_file_mtime(&old_comm, filetime::FileTime::from_system_time(old_time))
+            .unwrap();
+
+        cleanup_old_logs(log_dir.to_str().unwrap(), 30);
+
+        assert!(!old_comm.exists(), "old comm.log should be removed");
+    }
+
+    #[test]
+    fn test_parse_level() {
+        assert_eq!(parse_level("trace"), tracing::Level::TRACE);
+        assert_eq!(parse_level("debug"), tracing::Level::DEBUG);
+        assert_eq!(parse_level("info"), tracing::Level::INFO);
+        assert_eq!(parse_level("warn"), tracing::Level::WARN);
+        assert_eq!(parse_level("error"), tracing::Level::ERROR);
+        assert_eq!(parse_level("unknown"), tracing::Level::INFO);
     }
 }

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -10,7 +10,7 @@
 
 use anyhow::{Context, Result};
 use std::path::Path;
-use tracing_subscriber::{filter::Targets, layer::SubscriberExt, EnvFilter, Layer, Registry};
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, EnvFilter, Registry};
 
 /// Guard returned by [`setup_file_logging`]. Must be kept alive for the
 /// lifetime of the application — dropping it flushes and closes the log file.
@@ -65,7 +65,7 @@ pub fn setup_file_logging(
     // Build the comm-log layer if requested.
     let mut comm_guard: Option<CommLogGuard> = None;
 
-    let comm_layer = if let Some(comm_level) = comm_log_level {
+    if let Some(comm_level) = comm_log_level {
         let comm_appender = tracing_appender::rolling::daily(log_path, "comm.log");
         let (comm_nb, cg) = tracing_appender::non_blocking(comm_appender);
         comm_guard = Some(cg);
@@ -73,49 +73,50 @@ pub fn setup_file_logging(
         let comm_filter = Targets::new().with_target("comm", parse_level(comm_level));
 
         if effective_format == "json" {
-            Some(
-                tracing_subscriber::fmt::layer()
-                    .with_writer(comm_nb)
-                    .with_ansi(false)
-                    .json()
-                    .with_filter(comm_filter),
-            )
+            let main_layer = tracing_subscriber::fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .json()
+                .with_filter(filter);
+            let comm_layer = tracing_subscriber::fmt::layer()
+                .with_writer(comm_nb)
+                .with_ansi(false)
+                .json()
+                .with_filter(comm_filter);
+            let subscriber = Registry::default().with(main_layer).with(comm_layer);
+            tracing::subscriber::set_global_default(subscriber)
+                .context("set global tracing subscriber")?;
         } else {
-            Some(
-                tracing_subscriber::fmt::layer()
-                    .with_writer(comm_nb)
-                    .with_ansi(false)
-                    .with_filter(comm_filter),
-            )
+            let main_layer = tracing_subscriber::fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .with_filter(filter);
+            let comm_layer = tracing_subscriber::fmt::layer()
+                .with_writer(comm_nb)
+                .with_ansi(false)
+                .with_filter(comm_filter);
+            let subscriber = Registry::default().with(main_layer).with(comm_layer);
+            tracing::subscriber::set_global_default(subscriber)
+                .context("set global tracing subscriber")?;
         }
-    } else {
-        None
-    };
-
-    // Main layer excludes "comm" target so events don't duplicate.
-    let main_filter = filter;
-    let main_layer = if effective_format == "json" {
-        tracing_subscriber::fmt::layer()
+    } else if effective_format == "json" {
+        let main_layer = tracing_subscriber::fmt::layer()
             .with_writer(non_blocking)
             .with_ansi(false)
             .json()
-            .with_filter(main_filter)
-            .boxed()
+            .with_filter(filter);
+        let subscriber = Registry::default().with(main_layer);
+        tracing::subscriber::set_global_default(subscriber)
+            .context("set global tracing subscriber")?;
     } else {
-        tracing_subscriber::fmt::layer()
+        let main_layer = tracing_subscriber::fmt::layer()
             .with_writer(non_blocking)
             .with_ansi(false)
-            .with_filter(main_filter)
-            .boxed()
-    };
-
-    let subscriber = Registry::default().with(main_layer);
-    let subscriber = match comm_layer {
-        Some(cl) => subscriber.with(cl),
-        None => subscriber,
-    };
-
-    tracing::subscriber::set_global_default(subscriber).context("set global tracing subscriber")?;
+            .with_filter(filter);
+        let subscriber = Registry::default().with(main_layer);
+        tracing::subscriber::set_global_default(subscriber)
+            .context("set global tracing subscriber")?;
+    }
 
     tracing::info!(
         "File logging initialized: {}/kestrel.log (format: {})",

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -10,7 +10,7 @@
 
 use anyhow::{Context, Result};
 use std::path::Path;
-use tracing_subscriber::{filter::Targets, layer::SubscriberExt, EnvFilter, Registry};
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, EnvFilter, Layer, Registry};
 
 /// Guard returned by [`setup_file_logging`]. Must be kept alive for the
 /// lifetime of the application — dropping it flushes and closes the log file.

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -42,6 +42,7 @@ pub fn setup_file_logging(
     level: &str,
     log_format: &str,
     comm_log_level: Option<&str>,
+    comm_separate_file: bool,
 ) -> Result<(LogGuard, Option<CommLogGuard>)> {
     let log_path = Path::new(log_dir);
     std::fs::create_dir_all(log_path).context("create log directory")?;
@@ -66,38 +67,65 @@ pub fn setup_file_logging(
     let mut comm_guard: Option<CommLogGuard> = None;
 
     if let Some(comm_level) = comm_log_level {
-        let comm_appender = tracing_appender::rolling::daily(log_path, "comm.log");
-        let (comm_nb, cg) = tracing_appender::non_blocking(comm_appender);
-        comm_guard = Some(cg);
-
         let comm_filter = Targets::new().with_target("comm", parse_level(comm_level));
 
-        if effective_format == "json" {
-            let main_layer = tracing_subscriber::fmt::layer()
-                .with_writer(non_blocking)
-                .with_ansi(false)
-                .json()
-                .with_filter(filter);
-            let comm_layer = tracing_subscriber::fmt::layer()
-                .with_writer(comm_nb)
-                .with_ansi(false)
-                .json()
-                .with_filter(comm_filter);
-            let subscriber = Registry::default().with(main_layer).with(comm_layer);
-            tracing::subscriber::set_global_default(subscriber)
-                .context("set global tracing subscriber")?;
+        if comm_separate_file {
+            // Separate file: main layer excludes "comm", comm layer writes to comm.log.
+            let comm_appender = tracing_appender::rolling::daily(log_path, "comm.log");
+            let (comm_nb, cg) = tracing_appender::non_blocking(comm_appender);
+            comm_guard = Some(cg);
+
+            // Main filter: everything except target "comm".
+            let main_filter =
+                EnvFilter::new(level).add_directive("comm=off".parse().expect("valid directive"));
+
+            if effective_format == "json" {
+                let main_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(non_blocking)
+                    .with_ansi(false)
+                    .json()
+                    .with_filter(main_filter.clone());
+                let comm_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(comm_nb)
+                    .with_ansi(false)
+                    .json()
+                    .with_filter(comm_filter);
+                let subscriber = Registry::default().with(main_layer).with(comm_layer);
+                tracing::subscriber::set_global_default(subscriber)
+                    .context("set global tracing subscriber")?;
+            } else {
+                let main_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(non_blocking)
+                    .with_ansi(false)
+                    .with_filter(main_filter);
+                let comm_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(comm_nb)
+                    .with_ansi(false)
+                    .with_filter(comm_filter);
+                let subscriber = Registry::default().with(main_layer).with(comm_layer);
+                tracing::subscriber::set_global_default(subscriber)
+                    .context("set global tracing subscriber")?;
+            }
         } else {
-            let main_layer = tracing_subscriber::fmt::layer()
-                .with_writer(non_blocking)
-                .with_ansi(false)
-                .with_filter(filter);
-            let comm_layer = tracing_subscriber::fmt::layer()
-                .with_writer(comm_nb)
-                .with_ansi(false)
-                .with_filter(comm_filter);
-            let subscriber = Registry::default().with(main_layer).with(comm_layer);
-            tracing::subscriber::set_global_default(subscriber)
-                .context("set global tracing subscriber")?;
+            // Mixed into main log: single layer, comm events flow to kestrel.log.
+            if effective_format == "json" {
+                let main_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(non_blocking)
+                    .with_ansi(false)
+                    .json()
+                    .with_filter(filter);
+                let subscriber = Registry::default().with(main_layer);
+                tracing::subscriber::set_global_default(subscriber)
+                    .context("set global tracing subscriber")?;
+            } else {
+                let main_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(non_blocking)
+                    .with_ansi(false)
+                    .with_filter(filter);
+                let subscriber = Registry::default().with(main_layer);
+                tracing::subscriber::set_global_default(subscriber)
+                    .context("set global tracing subscriber")?;
+            }
         }
     } else if effective_format == "json" {
         let main_layer = tracing_subscriber::fmt::layer()
@@ -124,8 +152,10 @@ pub fn setup_file_logging(
         effective_format
     );
 
-    if comm_log_level.is_some() {
+    if comm_log_level.is_some() && comm_separate_file {
         tracing::info!("Comm logging initialized: {}/comm.log", log_dir);
+    } else if comm_log_level.is_some() {
+        tracing::info!("Comm logging initialized: mixed into kestrel.log");
     }
 
     Ok((guard, comm_guard))
@@ -133,7 +163,7 @@ pub fn setup_file_logging(
 
 /// Backward-compatible wrapper: setup file logging without comm-log.
 pub fn setup_file_logging_simple(log_dir: &str, level: &str, log_format: &str) -> Result<LogGuard> {
-    let (guard, _) = setup_file_logging(log_dir, level, log_format, None)?;
+    let (guard, _) = setup_file_logging(log_dir, level, log_format, None, false)?;
     Ok(guard)
 }
 
@@ -225,7 +255,7 @@ mod tests {
 
         // Test directory creation — ignore the global subscriber conflict
         // (set_global_default can only be called once per process)
-        let result = setup_file_logging(log_dir_str, "info", "text", None);
+        let result = setup_file_logging(log_dir_str, "info", "text", None, false);
         assert!(log_dir.exists(), "log directory should be created");
 
         // The guard may fail on re-install, but directory must exist regardless
@@ -241,7 +271,7 @@ mod tests {
         let log_dir_str = log_dir.to_str().unwrap();
 
         // The function creates the directory before attempting to set subscriber
-        let _ = setup_file_logging(log_dir_str, "info", "text", None);
+        let _ = setup_file_logging(log_dir_str, "info", "text", None, false);
         assert!(
             log_dir.exists(),
             "directory must be created even if subscriber fails"
@@ -303,7 +333,7 @@ mod tests {
         let log_dir_str = log_dir.to_str().unwrap();
 
         // "xml" is not a valid format — should fall back to "text"
-        let result = setup_file_logging(log_dir_str, "info", "xml", None);
+        let result = setup_file_logging(log_dir_str, "info", "xml", None, false);
         assert!(log_dir.exists());
         if let Ok((_guard, _comm_guard)) = result {
             // Subscriber may conflict with other tests; that's OK

--- a/crates/kestrel-providers/src/anthropic.rs
+++ b/crates/kestrel-providers/src/anthropic.rs
@@ -397,6 +397,7 @@ impl LlmProvider for AnthropicProvider {
         debug!("Anthropic request to {} (model: {})", url, request.model);
 
         let start = std::time::Instant::now();
+        let trace_id_for_log = trace_id.clone();
 
         retry_with_backoff(&retry_config, move |_attempt| {
             let url = url.clone();
@@ -507,7 +508,7 @@ impl LlmProvider for AnthropicProvider {
             let duration_ms = start.elapsed().as_millis() as u64;
             tracing::info!(
                 target: "comm",
-                trace_id = %trace_id,
+                trace_id = %trace_id_for_log,
                 status = 200,
                 duration_ms = duration_ms,
                 tokens = ?resp.usage,

--- a/crates/kestrel-providers/src/anthropic.rs
+++ b/crates/kestrel-providers/src/anthropic.rs
@@ -381,7 +381,22 @@ impl LlmProvider for AnthropicProvider {
         let client = self.client.clone();
         let retry_config = self.retry.clone();
 
+        let trace_id = kestrel_core::trace::generate_trace_id();
+
+        tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            method = "POST",
+            url = %url,
+            model = %request.model,
+            stream = false,
+            max_tokens = ?request.max_tokens,
+            "HTTP REQ"
+        );
+
         debug!("Anthropic request to {} (model: {})", url, request.model);
+
+        let start = std::time::Instant::now();
 
         retry_with_backoff(&retry_config, move |_attempt| {
             let url = url.clone();
@@ -389,6 +404,7 @@ impl LlmProvider for AnthropicProvider {
             let api_key = api_key.clone();
             let api_version = api_version.clone();
             let client = client.clone();
+            let trace_id = trace_id.clone();
             async move {
                 let resp = client
                     .post(&url)
@@ -403,6 +419,13 @@ impl LlmProvider for AnthropicProvider {
                 if !resp.status().is_success() {
                     let status = resp.status();
                     let text = resp.text().await.unwrap_or_default();
+                    tracing::warn!(
+                        target: "comm",
+                        trace_id = %trace_id,
+                        status = status.as_u16(),
+                        error = %text,
+                        "HTTP RESP ERROR"
+                    );
                     anyhow::bail!("Anthropic API error ({}): {}", status, text);
                 }
 
@@ -480,6 +503,18 @@ impl LlmProvider for AnthropicProvider {
             }
         })
         .await
+        .map(|resp| {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            tracing::info!(
+                target: "comm",
+                trace_id = %trace_id,
+                status = 200,
+                duration_ms = duration_ms,
+                tokens = ?resp.usage,
+                "HTTP RESP"
+            );
+            resp
+        })
     }
 
     async fn complete_stream(&self, request: CompletionRequest) -> Result<BoxStream> {
@@ -494,6 +529,19 @@ impl LlmProvider for AnthropicProvider {
             .unwrap_or_else(|| "2023-06-01".to_string());
         let retry_config = self.retry.clone();
 
+        let trace_id = kestrel_core::trace::generate_trace_id();
+
+        tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            method = "POST",
+            url = %url,
+            model = %request.model,
+            stream = true,
+            max_tokens = ?request.max_tokens,
+            "HTTP REQ"
+        );
+
         debug!(
             "Anthropic streaming request to {} (model: {})",
             url, request.model
@@ -505,6 +553,7 @@ impl LlmProvider for AnthropicProvider {
             let api_key = api_key.clone();
             let api_version = api_version.clone();
             let client = self.streaming_client.clone();
+            let trace_id = trace_id.clone();
             async move {
                 let resp = client
                     .post(&url)
@@ -519,6 +568,13 @@ impl LlmProvider for AnthropicProvider {
                 if !resp.status().is_success() {
                     let status = resp.status();
                     let text = resp.text().await.unwrap_or_default();
+                    tracing::warn!(
+                        target: "comm",
+                        trace_id = %trace_id,
+                        status = status.as_u16(),
+                        error = %text,
+                        "HTTP RESP ERROR"
+                    );
                     anyhow::bail!("Anthropic API error ({}): {}", status, text);
                 }
 

--- a/crates/kestrel-providers/src/anthropic.rs
+++ b/crates/kestrel-providers/src/anthropic.rs
@@ -504,7 +504,7 @@ impl LlmProvider for AnthropicProvider {
             }
         })
         .await
-        .map(|resp| {
+        .inspect(|resp| {
             let duration_ms = start.elapsed().as_millis() as u64;
             tracing::info!(
                 target: "comm",
@@ -514,7 +514,6 @@ impl LlmProvider for AnthropicProvider {
                 tokens = ?resp.usage,
                 "HTTP RESP"
             );
-            resp
         })
     }
 

--- a/crates/kestrel-providers/src/openai_compat.rs
+++ b/crates/kestrel-providers/src/openai_compat.rs
@@ -456,6 +456,7 @@ impl LlmProvider for OpenAiCompatProvider {
         );
 
         let start = std::time::Instant::now();
+        let trace_id_for_log = trace_id.clone();
 
         retry_with_backoff(&retry_config, move |_attempt| {
             let url = url.clone();
@@ -528,7 +529,7 @@ impl LlmProvider for OpenAiCompatProvider {
             let duration_ms = start.elapsed().as_millis() as u64;
             tracing::info!(
                 target: "comm",
-                trace_id = %trace_id,
+                trace_id = %trace_id_for_log,
                 status = 200,
                 duration_ms = duration_ms,
                 tokens = ?resp.usage,

--- a/crates/kestrel-providers/src/openai_compat.rs
+++ b/crates/kestrel-providers/src/openai_compat.rs
@@ -435,16 +435,34 @@ impl LlmProvider for OpenAiCompatProvider {
         let client = self.client.clone();
         let retry_config = self.retry.clone();
 
+        let trace_id = kestrel_core::trace::generate_trace_id();
+        let sanitized = kestrel_core::comm_log::sanitize_headers(&headers);
+
+        tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            method = "POST",
+            url = %url,
+            model = %request.model,
+            stream = false,
+            max_tokens = ?request.max_tokens,
+            headers = ?sanitized,
+            "HTTP REQ"
+        );
+
         debug!(
             "Sending completion request to {} (model: {})",
             url, request.model
         );
+
+        let start = std::time::Instant::now();
 
         retry_with_backoff(&retry_config, move |_attempt| {
             let url = url.clone();
             let body = body.clone();
             let headers = headers.clone();
             let client = client.clone();
+            let trace_id = trace_id.clone();
             async move {
                 let mut req_builder = client.post(&url);
                 for (k, v) in &headers {
@@ -460,6 +478,13 @@ impl LlmProvider for OpenAiCompatProvider {
                 if !resp.status().is_success() {
                     let status = resp.status();
                     let text = resp.text().await.unwrap_or_default();
+                    tracing::warn!(
+                        target: "comm",
+                        trace_id = %trace_id,
+                        status = status.as_u16(),
+                        error = %text,
+                        "HTTP RESP ERROR"
+                    );
                     anyhow::bail!("API error ({}): {}", status, text);
                 }
 
@@ -499,6 +524,18 @@ impl LlmProvider for OpenAiCompatProvider {
             }
         })
         .await
+        .map(|resp| {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            tracing::info!(
+                target: "comm",
+                trace_id = %trace_id,
+                status = 200,
+                duration_ms = duration_ms,
+                tokens = ?resp.usage,
+                "HTTP RESP"
+            );
+            resp
+        })
     }
 
     async fn complete_stream(&self, request: CompletionRequest) -> Result<BoxStream> {
@@ -508,6 +545,21 @@ impl LlmProvider for OpenAiCompatProvider {
 
         let headers = self.build_headers();
         let retry_config = self.retry.clone();
+
+        let trace_id = kestrel_core::trace::generate_trace_id();
+        let sanitized = kestrel_core::comm_log::sanitize_headers(&headers);
+
+        tracing::info!(
+            target: "comm",
+            trace_id = %trace_id,
+            method = "POST",
+            url = %url,
+            model = %request.model,
+            stream = true,
+            max_tokens = ?request.max_tokens,
+            headers = ?sanitized,
+            "HTTP REQ"
+        );
 
         debug!(
             "Sending streaming request to {} (model: {})",
@@ -519,6 +571,7 @@ impl LlmProvider for OpenAiCompatProvider {
             let body = body.clone();
             let headers = headers.clone();
             let client = self.streaming_client.clone();
+            let trace_id = trace_id.clone();
             async move {
                 let mut req_builder = client.post(&url);
                 for (k, v) in &headers {
@@ -534,6 +587,13 @@ impl LlmProvider for OpenAiCompatProvider {
                 if !resp.status().is_success() {
                     let status = resp.status();
                     let text = resp.text().await.unwrap_or_default();
+                    tracing::warn!(
+                        target: "comm",
+                        trace_id = %trace_id,
+                        status = status.as_u16(),
+                        error = %text,
+                        "HTTP RESP ERROR"
+                    );
                     anyhow::bail!("API error ({}): {}", status, text);
                 }
 

--- a/crates/kestrel-providers/src/openai_compat.rs
+++ b/crates/kestrel-providers/src/openai_compat.rs
@@ -525,7 +525,7 @@ impl LlmProvider for OpenAiCompatProvider {
             }
         })
         .await
-        .map(|resp| {
+        .inspect(|resp| {
             let duration_ms = start.elapsed().as_millis() as u64;
             tracing::info!(
                 target: "comm",
@@ -535,7 +535,6 @@ impl LlmProvider for OpenAiCompatProvider {
                 tokens = ?resp.usage,
                 "HTTP RESP"
             );
-            resp
         })
     }
 

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -96,18 +96,16 @@ fn do_start(config: &Config) -> Result<DaemonHandles> {
     let pid_file = kestrel_daemon::pid_file::PidFile::create(pid_file_path)?;
 
     // Setup file logging in the daemon process
-    let comm_level = config
-        .daemon
-        .comm_log
-        .as_ref()
-        .filter(|c| c.enabled)
-        .map(|c| c.level.as_str());
+    let comm_config = config.daemon.comm_log.as_ref().filter(|c| c.enabled);
+    let comm_level = comm_config.map(|c| c.level.as_str());
+    let comm_separate_file = comm_config.map(|c| c.separate_file).unwrap_or(false);
 
     let (log_guard, comm_log_guard) = kestrel_daemon::logging::setup_file_logging(
         log_dir,
         &config.daemon.log_level,
         &config.daemon.log_format,
         comm_level,
+        comm_separate_file,
     )?;
     tracing::info!("Daemon started (pid={})", std::process::id());
 

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -15,6 +15,8 @@ pub struct DaemonHandles {
     pub pid_file: kestrel_daemon::pid_file::PidFile,
     /// Non-blocking log writer guard — flushes remaining logs on drop.
     pub log_guard: kestrel_daemon::logging::LogGuard,
+    /// Non-blocking comm-log writer guard — flushes comm logs on drop.
+    pub comm_log_guard: Option<kestrel_daemon::logging::CommLogGuard>,
 }
 
 /// Actions for the `daemon` subcommand.
@@ -94,16 +96,25 @@ fn do_start(config: &Config) -> Result<DaemonHandles> {
     let pid_file = kestrel_daemon::pid_file::PidFile::create(pid_file_path)?;
 
     // Setup file logging in the daemon process
-    let log_guard = kestrel_daemon::logging::setup_file_logging(
+    let comm_level = config
+        .daemon
+        .comm_log
+        .as_ref()
+        .filter(|c| c.enabled)
+        .map(|c| c.level.as_str());
+
+    let (log_guard, comm_log_guard) = kestrel_daemon::logging::setup_file_logging(
         log_dir,
         &config.daemon.log_level,
         &config.daemon.log_format,
+        comm_level,
     )?;
     tracing::info!("Daemon started (pid={})", std::process::id());
 
     Ok(DaemonHandles {
         pid_file,
         log_guard,
+        comm_log_guard,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,7 @@ fn main() -> Result<()> {
 
                     // Drop log_guard first to flush remaining log lines,
                     // then pid_file releases the flock and cleans up.
+                    drop(handles.comm_log_guard);
                     drop(handles.log_guard);
                     if let Err(e) = handles.pid_file.clean() {
                         eprintln!("Failed to clean PID file: {e}");


### PR DESCRIPTION
## Summary
- Add full-chain communication logging for HTTP requests/responses, WebSocket messages, and tool calls
- Each event carries a `trace_id` for cross-layer correlation
- Comm events use tracing `target: "comm"` and can be routed to a separate `comm.log` file via `daemon.comm_log` config

## Changes
- **CommLogConfig**: New `CommLogConfig` struct (`enabled`, `level`, `separate_file`) added to `DaemonConfig` with `#[serde(default)]` for backward compatibility
- **trace.rs**: New module with `generate_trace_id()` (format: `tr-{12_hex}`) and `TraceContext`
- **comm_log.rs**: Logging helpers with header sanitization (masks `Authorization`, `x-api-key`, token fields)
- **Provider logging**: `openai_compat.rs` and `anthropic.rs` now log REQ/RESP/ERROR with trace_id via `target: "comm"`
- **WebSocket logging**: Inbound/outbound messages logged with trace_id and client_id
- **Tool logging**: TOOL START/END events in `runner.rs` with trace_id, tool name, duration, success
- **Dual-layer subscriber**: `logging.rs` updated to support main + comm layers with independent level filters
- **Startup integration**: `commands/daemon.rs` reads `comm_log` config and passes to logging setup

## Configuration
```yaml
daemon:
  comm_log:
    enabled: true
    level: debug    # info|debug|trace
    separate_file: true  # writes to comm.log instead of kestrel.log
```

## Test plan
- [ ] CI passes (cargo check + clippy + tests)
- [ ] Unit tests: `generate_trace_id` format and uniqueness
- [ ] Unit tests: `CommLogConfig` serde roundtrip and defaults
- [ ] Unit tests: `sanitize_headers` masks sensitive values
- [ ] Unit tests: `cleanup_old_logs` handles both `kestrel.log.*` and `comm.log.*`
- [ ] Manual: enable `comm_log` in config, run daemon, verify `comm.log` contains trace events
- [ ] Manual: verify no impact when `comm_log` is not configured (default)

Bahtya