### PR TITLE
feat: migrate kestrel-config from YAML to TOML format

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ cargo build --release
 
 ```bash
 kestrel setup
-# Edit ~/.kestrel/config.yaml with your API keys
+# Edit ~/.kestrel/config.toml with your API keys
 ```
 
 ### Run
@@ -180,120 +180,126 @@ Environment variable `KESTREL_HOME` overrides the default config directory
 
 ## Configuration
 
-```yaml
-# ~/.kestrel/config.yaml
+```toml
+# ~/.kestrel/config.toml
 
-providers:
-  openai:
-    api_key: ${OPENAI_API_KEY}
-    model: gpt-4o
-    base_url: https://api.openai.com/v1   # optional: point to any OpenAI-compatible API
-  anthropic:
-    api_key: ${ANTHROPIC_API_KEY}
-    model: claude-sonnet-4-6
-  openrouter:
-    api_key: ${OPENROUTER_API_KEY}
-    model: anthropic/claude-sonnet-4-6
-  ollama:
-    base_url: http://localhost:11434/v1
-    model: llama3
-  deepseek:
-    api_key: ${DEEPSEEK_API_KEY}
-    model: deepseek-chat
-  groq:
-    api_key: ${GROQ_API_KEY}
-    model: llama-3.3-70b-versatile
-  gemini:
-    api_key: ${GEMINI_API_KEY}
-    model: gemini-2.0-flash
-  # no_proxy: true              # skip proxy for domestic APIs (e.g. ZAI, Qwen)
+[providers.openai]
+api_key = "${OPENAI_API_KEY}"
+model = "gpt-4o"
+# base_url = "https://api.openai.com/v1"   # optional: point to any OpenAI-compatible API
 
-channels:
-  telegram:
-    token: ${TELEGRAM_BOT_TOKEN}
-    allowed_users: ["123456789"]         # optional: restrict to user IDs
-    admin_users: ["123456789"]           # optional: admin user IDs
-    enabled: true
-    streaming: false                     # telegram doesn't support token-by-token
-    proxy: ""                            # optional: http/socks5 proxy URL
-  discord:
-    token: ${DISCORD_BOT_TOKEN}
-    allowed_guilds: ["111222333"]        # optional: restrict to guild IDs
-    enabled: true
-  websocket:
-    enabled: true
-    listen_addr: "127.0.0.1:8090"
-    auth:
-      required: true
-      token: "my-secret"
-    max_clients: 100
-    max_message_size: 1048576
+[providers.anthropic]
+api_key = "${ANTHROPIC_API_KEY}"
+model = "claude-sonnet-4-6"
 
-agent:
-  model: gpt-4o
-  temperature: 0.7
-  max_tokens: 4096
-  max_iterations: 50                    # tool loop limit
-  streaming: true
-  tool_timeout: 120                     # seconds per tool execution
-  system_prompt: "You are a helpful AI assistant."  # optional override
-  workspace: /tmp/workspace             # optional: default working directory
+[providers.openrouter]
+api_key = "${OPENROUTER_API_KEY}"
+model = "anthropic/claude-sonnet-4-6"
 
-dream:                                  # memory consolidation
-  enabled: true
-  interval_secs: 7200                   # consolidate every 2h
-  model: gpt-4o-mini                    # optional: use cheaper model
+[providers.ollama]
+base_url = "http://localhost:11434/v1"
+model = "llama3"
 
-heartbeat:
-  enabled: false
-  interval_secs: 1800
+[providers.deepseek]
+api_key = "${DEEPSEEK_API_KEY}"
+model = "deepseek-chat"
 
-cron:
-  enabled: false
-  state_file: ~/.kestrel/cron_state.json
-  tick_secs: 60
+[providers.groq]
+api_key = "${GROQ_API_KEY}"
+model = "llama-3.3-70b-versatile"
 
-security:
-  block_private_ips: true               # block RFC1918 by default
-  ssrf_whitelist: []                    # allowed IP ranges for outbound
-  blocked_networks: []                  # additional blocked ranges
+[providers.gemini]
+api_key = "${GEMINI_API_KEY}"
+model = "gemini-2.0-flash"
+# no_proxy = true              # skip proxy for domestic APIs (e.g. ZAI, Qwen)
 
-api:
-  host: 0.0.0.0
-  port: 8080
-  allowed_origins: ["*"]                # CORS origins
-  max_body_size: 10485760               # 10 MB
+[channels.telegram]
+token = "${TELEGRAM_BOT_TOKEN}"
+allowed_users = ["123456789"]         # optional: restrict to user IDs
+admin_users = ["123456789"]           # optional: admin user IDs
+enabled = true
+streaming = false                     # telegram doesn't support token-by-token
+# proxy = ""                          # optional: http/socks5 proxy URL
 
-daemon:
-  pid_file: ~/.kestrel/kestrel.pid
-  log_dir: ~/.kestrel/logs
-  working_directory: /
-  grace_period_secs: 30
+[channels.discord]
+token = "${DISCORD_BOT_TOKEN}"
+allowed_guilds = ["111222333"]        # optional: restrict to guild IDs
+enabled = true
+
+[channels.websocket]
+enabled = true
+listen_addr = "127.0.0.1:8090"
+max_clients = 100
+max_message_size = 1048576
+
+[channels.websocket.auth]
+required = true
+token = "my-secret"
+
+[agent]
+model = "gpt-4o"
+temperature = 0.7
+max_tokens = 4096
+max_iterations = 50                    # tool loop limit
+streaming = true
+tool_timeout = 120                     # seconds per tool execution
+# system_prompt = "You are a helpful AI assistant."  # optional override
+# workspace = "/tmp/workspace"                       # optional: default working directory
+
+[dream]                                 # memory consolidation
+enabled = true
+interval_secs = 7200                    # consolidate every 2h
+# model = "gpt-4o-mini"                # optional: use cheaper model
+
+[heartbeat]
+enabled = false
+interval_secs = 1800
+
+[cron]
+enabled = false
+# state_file = "~/.kestrel/cron_state.json"
+tick_secs = 60
+
+[security]
+block_private_ips = true                # block RFC1918 by default
+ssrf_whitelist = []                     # allowed IP ranges for outbound
+blocked_networks = []                   # additional blocked ranges
+
+[api]
+host = "0.0.0.0"
+port = 8080
+allowed_origins = ["*"]                 # CORS origins
+max_body_size = 10485760                # 10 MB
+
+[daemon]
+# pid_file = "~/.kestrel/kestrel.pid"
+# log_dir = "~/.kestrel/logs"
+# working_directory = "/"
+grace_period_secs = 30
 
 # optional: custom system prompt additions
-custom_instructions: "Always respond in English."
+# custom_instructions = "Always respond in English."
 
 # optional: agent identity
-name: "Kestrel"
+# name = "Kestrel"
 
 # optional: MCP tool servers
-# mcp_servers:
-#   filesystem:
-#     transport: stdio
-#     command: "mcp-filesystem"
-#     args: ["--root", "/data"]
+# [mcp_servers.filesystem]
+# transport = "stdio"
+# command = "mcp-filesystem"
+# args = ["--root", "/data"]
 
 # optional: custom provider endpoints
-# custom_providers:
-#   - name: my_provider
-#     base_url: https://my-api.com/v1
-#     api_key: key123
-#     model_patterns: ["my-model"]
+# [[custom_providers]]
+# name = "my_provider"
+# base_url = "https://my-api.com/v1"
+# api_key = "key123"
+# model_patterns = ["my-model"]
 
-notifications:
-  online_notify: true
-  # notify_chat_id: "-1001234567890"    # which chat receives the ping
-  online_message: "Kestrel v{version} online — {channel} connected"
+[notifications]
+online_notify = true
+# notify_chat_id = "-1001234567890"     # which chat receives the ping
+online_message = "Kestrel v{version} online — {channel} connected"
 ```
 
 Environment variables in values (`${VAR}`) are expanded at load time.
@@ -309,7 +315,7 @@ Environment variables in values (`${VAR}`) are expanded at load time.
 | `health` | Show health check status |
 | `cron list` | List all cron jobs |
 | `cron status` | Show status of a specific cron job |
-| `config validate` | Validate the config.yaml schema |
+| `config validate` | Validate the config.toml schema |
 | `config migrate` | Migrate Python kestrel config to kestrel format |
 | `setup` | Interactive configuration wizard |
 | `status` | Show current configuration and system status |

--- a/crates/kestrel-agent/Cargo.toml
+++ b/crates/kestrel-agent/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+toml = { workspace = true }
 futures = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/kestrel-agent/src/heartbeat.rs
+++ b/crates/kestrel-agent/src/heartbeat.rs
@@ -1335,7 +1335,7 @@ mod tests {
     async fn test_deep_config_missing_model() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("config.toml");
-        std::fs::write(&config_path, "agent:\n  max_iterations: 10\n").unwrap();
+        std::fs::write(&config_path, "[agent]\nmax_iterations = 10\n").unwrap();
 
         let check = DeepConfigStoreHealthCheck::new(config_path, dir.path().to_path_buf());
         let result = check.report_health().await;

--- a/crates/kestrel-agent/src/heartbeat.rs
+++ b/crates/kestrel-agent/src/heartbeat.rs
@@ -655,7 +655,7 @@ impl HealthCheck for ReadinessCheck {
 ///
 /// In addition to file readability and data-dir writability (handled by
 /// [`ConfigStoreHealthCheck`]), this check optionally:
-/// - Parses the YAML config and reports parse errors
+/// - Parses the TOML config and reports parse errors
 /// - Validates that critical keys (`agent.model`) are present
 pub struct DeepConfigStoreHealthCheck {
     config_path: std::path::PathBuf,
@@ -685,8 +685,8 @@ impl HealthCheck for DeepConfigStoreHealthCheck {
         if self.config_path.exists() {
             match std::fs::read_to_string(&self.config_path) {
                 Ok(content) => {
-                    // 2. YAML parse validation
-                    match serde_yaml::from_str::<serde_yaml::Value>(&content) {
+                    // 2. TOML parse validation
+                    match toml::from_str::<toml::Value>(&content) {
                         Ok(parsed) => {
                             // 3. Check critical key: agent.model
                             if let Some(agent) = parsed.get("agent") {
@@ -699,7 +699,7 @@ impl HealthCheck for DeepConfigStoreHealthCheck {
                             // If no agent section at all, that's acceptable (defaults)
                         }
                         Err(e) => {
-                            issues.push(format!("config YAML parse error: {}", e));
+                            issues.push(format!("config TOML parse error: {}", e));
                         }
                     }
                 }
@@ -1080,8 +1080,8 @@ mod tests {
     #[tokio::test]
     async fn test_config_store_healthy() {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, "agent:\n  model: test\n").unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[agent]\nmodel = \"test\"\n").unwrap();
 
         let check = ConfigStoreHealthCheck::new(config_path, dir.path().to_path_buf());
         let result = check.report_health().await;
@@ -1094,7 +1094,7 @@ mod tests {
     #[tokio::test]
     async fn test_config_store_healthy_no_config_file() {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("nonexistent.yaml");
+        let config_path = dir.path().join("nonexistent.toml");
 
         let check = ConfigStoreHealthCheck::new(config_path, dir.path().to_path_buf());
         let result = check.report_health().await;
@@ -1106,7 +1106,7 @@ mod tests {
     #[tokio::test]
     async fn test_config_store_unreadable_config() {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.yaml");
+        let config_path = dir.path().join("config.toml");
         std::fs::write(&config_path, "test").unwrap();
         std::fs::set_permissions(
             &config_path,
@@ -1143,7 +1143,7 @@ mod tests {
         )
         .unwrap();
 
-        let check = ConfigStoreHealthCheck::new(dir.path().join("config.yaml"), data_dir.clone());
+        let check = ConfigStoreHealthCheck::new(dir.path().join("config.toml"), data_dir.clone());
         let result = check.report_health().await;
 
         // On some systems running as root, the permission restriction doesn't apply
@@ -1164,7 +1164,7 @@ mod tests {
     async fn test_config_store_name() {
         let dir = tempfile::tempdir().unwrap();
         let check =
-            ConfigStoreHealthCheck::new(dir.path().join("config.yaml"), dir.path().to_path_buf());
+            ConfigStoreHealthCheck::new(dir.path().join("config.toml"), dir.path().to_path_buf());
         assert_eq!(check.component_name(), "config_store");
     }
 
@@ -1319,10 +1319,10 @@ mod tests {
     // === DeepConfigStoreHealthCheck ===
 
     #[tokio::test]
-    async fn test_deep_config_valid_yaml() {
+    async fn test_deep_config_valid_toml() {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, "agent:\n  model: gpt-4\n").unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[agent]\nmodel = \"gpt-4\"\n").unwrap();
 
         let check = DeepConfigStoreHealthCheck::new(config_path, dir.path().to_path_buf());
         let result = check.report_health().await;
@@ -1334,7 +1334,7 @@ mod tests {
     #[tokio::test]
     async fn test_deep_config_missing_model() {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.yaml");
+        let config_path = dir.path().join("config.toml");
         std::fs::write(&config_path, "agent:\n  max_iterations: 10\n").unwrap();
 
         let check = DeepConfigStoreHealthCheck::new(config_path, dir.path().to_path_buf());
@@ -1346,10 +1346,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_deep_config_invalid_yaml() {
+    async fn test_deep_config_invalid_toml() {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, "agent:\n  model: [broken\n").unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[agent\nmodel = [broken\n").unwrap();
 
         let check = DeepConfigStoreHealthCheck::new(config_path, dir.path().to_path_buf());
         let result = check.report_health().await;
@@ -1361,7 +1361,7 @@ mod tests {
     #[tokio::test]
     async fn test_deep_config_no_file() {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("nonexistent.yaml");
+        let config_path = dir.path().join("nonexistent.toml");
 
         let check = DeepConfigStoreHealthCheck::new(config_path, dir.path().to_path_buf());
         let result = check.report_health().await;
@@ -1382,7 +1382,7 @@ mod tests {
         .unwrap();
 
         let check =
-            DeepConfigStoreHealthCheck::new(dir.path().join("config.yaml"), data_dir.clone());
+            DeepConfigStoreHealthCheck::new(dir.path().join("config.toml"), data_dir.clone());
         let result = check.report_health().await;
 
         assert!(matches!(
@@ -1402,7 +1402,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing_dir = dir.path().join("does_not_exist");
 
-        let check = DeepConfigStoreHealthCheck::new(dir.path().join("config.yaml"), missing_dir);
+        let check = DeepConfigStoreHealthCheck::new(dir.path().join("config.toml"), missing_dir);
         let result = check.report_health().await;
 
         assert_eq!(result.status, CheckStatus::Unhealthy);
@@ -1413,7 +1413,7 @@ mod tests {
     async fn test_deep_config_name() {
         let dir = tempfile::tempdir().unwrap();
         let check = DeepConfigStoreHealthCheck::new(
-            dir.path().join("config.yaml"),
+            dir.path().join("config.toml"),
             dir.path().to_path_buf(),
         );
         assert_eq!(check.component_name(), "config_store");
@@ -1436,7 +1436,7 @@ mod tests {
         let tool_check = ToolRegistryHealthCheck::new(kestrel_tools::ToolRegistry::new());
         let agent_check = AgentLoopHealthCheck::new(Arc::new(parking_lot::RwLock::new(None)), 60);
         let config_check =
-            ConfigStoreHealthCheck::new(dir.path().join("config.yaml"), dir.path().to_path_buf());
+            ConfigStoreHealthCheck::new(dir.path().join("config.toml"), dir.path().to_path_buf());
 
         let checks: Vec<&dyn HealthCheck> = vec![
             &provider_check,

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -461,7 +461,7 @@ fn handle_help() -> String {
         "/status   - Show bot status, channels, and config summary"
     );
     let _ = writeln!(out, "/skill    - List, view, and search registered skills");
-    let _ = writeln!(out, "/validate - Validate config.yaml and show results");
+    let _ = writeln!(out, "/validate - Validate config.toml and show results");
     let _ = writeln!(out, "/settings - Toggle preferences (notifications, model)");
     let _ = writeln!(out, "/models   - Browse and select models from providers");
     let _ = writeln!(out, "/history  - Browse recent conversation history");
@@ -695,7 +695,7 @@ async fn ws_models_provider_list() -> String {
     let models = catalog.list_all_models().await;
 
     if models.is_empty() {
-        return "No models discovered. Configure a provider (e.g. opencode_go) in config.yaml."
+        return "No models discovered. Configure a provider (e.g. opencode_go) in config.toml."
             .to_string();
     }
 
@@ -895,7 +895,7 @@ async fn ws_settings_models_list(arg: &str) -> String {
 
     let models = catalog.list_all_models().await;
     if models.is_empty() {
-        return "No models discovered. Configure a provider (e.g. opencode_go) in config.yaml."
+        return "No models discovered. Configure a provider (e.g. opencode_go) in config.toml."
             .to_string();
     }
 
@@ -1456,7 +1456,7 @@ fn handle_validate() -> String {
             return format!(
                 "Failed to load configuration.\n\n\
                  Error: {e}\n\n\
-                 Create one at ~/.kestrel/config.yaml or run `kestrel setup`."
+                 Create one at ~/.kestrel/config.toml or run `kestrel setup`."
             );
         }
     };
@@ -1780,7 +1780,7 @@ pub async fn handle_models_provider_list() -> CommandResponse {
 
     if models.is_empty() {
         return CommandResponse::text(
-            "No models discovered. Configure a provider (e.g. opencode_go) in config.yaml.",
+            "No models discovered. Configure a provider (e.g. opencode_go) in config.toml.",
         );
     }
 
@@ -2108,17 +2108,17 @@ mod tests {
 
     // -- helpers -------------------------------------------------------------
 
-    /// Helper: create a temp dir with a config.yaml and set KESTREL_HOME.
+    /// Helper: create a temp dir with a config.toml and set KESTREL_HOME.
     struct TestHome {
         _dir: tempfile::TempDir,
         _env: EnvVarGuard,
     }
 
-    fn with_temp_config(yaml: &str) -> TestHome {
+    fn with_temp_config(toml_str: &str) -> TestHome {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.yaml");
+        let config_path = dir.path().join("config.toml");
         let mut f = std::fs::File::create(&config_path).unwrap();
-        f.write_all(yaml.as_bytes()).unwrap();
+        f.write_all(toml_str.as_bytes()).unwrap();
         let env = EnvVarGuard::set("KESTREL_HOME", dir.path());
         TestHome {
             _dir: dir,
@@ -2152,15 +2152,14 @@ mod tests {
 
     #[test]
     fn test_handle_validate_valid_config() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test123"
-channels:
-  telegram:
-    token: "123456:ABC"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test123"
+
+[channels.telegram]
+token = "123456:ABC"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         // With a valid provider and channel, the config should be valid or
         // at least parseable.
@@ -2173,50 +2172,49 @@ channels:
     #[test]
     fn test_handle_validate_invalid_config() {
         // Empty agent model triggers an error.
-        let yaml = r#"
-agent:
-  model: ""
+        let toml_str = r#"
+[agent]
+model = ""
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         assert!(result.contains("error(s)") || result.contains("[ERROR]"));
     }
 
     #[test]
     fn test_handle_validate_summary_shows_name() {
-        let yaml = r#"
-name: "testbot"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+name = "testbot"
+
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         assert!(result.contains("Name: testbot"));
     }
 
     #[test]
     fn test_handle_validate_summary_shows_unnamed() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         assert!(result.contains("Name: unnamed"));
     }
 
     #[test]
     fn test_handle_validate_summary_shows_providers() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
-  anthropic:
-    api_key: "sk-ant-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
+
+[providers.anthropic]
+api_key = "sk-ant-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         assert!(result.contains("openai"));
         assert!(result.contains("anthropic"));
@@ -2224,14 +2222,14 @@ providers:
 
     #[test]
     fn test_handle_validate_summary_shows_channels() {
-        let yaml = r#"
-channels:
-  telegram:
-    token: "123:ABC"
-  discord:
-    token: "discord-token"
+        let toml_str = r#"
+[channels.telegram]
+token = "123:ABC"
+
+[channels.discord]
+token = "discord-token"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         assert!(result.contains("telegram (enabled)"));
         assert!(result.contains("discord (enabled)"));
@@ -2239,35 +2237,33 @@ channels:
 
     #[test]
     fn test_handle_validate_summary_channels_disabled() {
-        let yaml = r#"
-channels:
-  telegram:
-    token: "123:ABC"
-    enabled: false
+        let toml_str = r#"
+[channels.telegram]
+token = "123:ABC"
+enabled = false
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         assert!(result.contains("telegram (disabled)"));
     }
 
     #[test]
     fn test_handle_validate_no_providers() {
-        let yaml = r#"
+        let toml_str = r#"
 # empty config
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         assert!(result.contains("Providers: (none)") || result.contains("error"));
     }
 
     #[test]
     fn test_handle_validate_no_channels() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_validate();
         assert!(result.contains("Channels: (none)") || result.contains("Channel"));
     }
@@ -2309,23 +2305,22 @@ providers:
 
     #[test]
     fn test_handle_status_no_key() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: ""
+        let toml_str = r#"
+[providers.openai]
+api_key = ""
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_status();
         assert!(result.contains("openai: no key"));
     }
 
     #[test]
     fn test_handle_status_heartbeat_disabled() {
-        let yaml = r#"
-heartbeat:
-  enabled: false
+        let toml_str = r#"
+[heartbeat]
+enabled = false
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_status();
         assert!(result.contains("Heartbeat: disabled"));
     }
@@ -2377,7 +2372,7 @@ heartbeat:
 
     #[test]
     fn test_handle_menu_callback_status() {
-        let _dir = with_temp_config("providers:\n  openai:\n    api_key: sk-test\n");
+        let _dir = with_temp_config("[providers.openai]\napi_key = \"sk-test\"\n");
         let (text, kb) = handle_menu_callback("status");
         assert!(text.contains("Agent:"));
         assert!(kb.is_some());
@@ -2393,7 +2388,7 @@ heartbeat:
 
     #[test]
     fn test_handle_menu_callback_validate() {
-        let _dir = with_temp_config("providers:\n  openai:\n    api_key: sk-test\n");
+        let _dir = with_temp_config("[providers.openai]\napi_key = \"sk-test\"\n");
         let (text, kb) = handle_menu_callback("validate");
         assert!(text.contains("Configuration"));
         assert!(kb.is_some());
@@ -2417,12 +2412,11 @@ heartbeat:
 
     #[test]
     fn test_handle_settings_has_keyboard() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let r = handle_settings();
         assert!(r.text.contains("Settings"));
         assert!(r.text.contains("Model:"));
@@ -2431,12 +2425,11 @@ providers:
 
     #[tokio::test]
     async fn test_try_handle_command_settings() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let r = expect_response(try_handle_command("/settings").await.unwrap());
         assert!(r.text.contains("Settings"));
         assert!(r.keyboard.is_some());
@@ -2444,12 +2437,11 @@ providers:
 
     #[test]
     fn test_settings_keyboard_buttons() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let r = handle_settings();
         let kb = r.keyboard.unwrap();
         // Should have the row with models picker + streaming toggle.
@@ -2464,12 +2456,11 @@ providers:
 
     #[test]
     fn test_handle_settings_single_page() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let resp = handle_settings_callback(0);
         // Page 0 contains Name, Model, Streaming, Max tokens, Temperature.
         assert!(resp.text.contains("Model:"));
@@ -2495,27 +2486,27 @@ providers:
 
     #[test]
     fn test_handle_settings_shows_name() {
-        let yaml = r#"
-name: "mybot"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+name = "mybot"
+
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let resp = handle_settings_callback(0);
         assert!(resp.text.contains("mybot"));
     }
 
     #[test]
     fn test_handle_settings_shows_providers() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
-  anthropic:
-    api_key: "sk-ant-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
+
+[providers.anthropic]
+api_key = "sk-ant-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         // Providers are on page 1 (index 5+ out of 7 settings with page size 5).
         let resp = handle_settings_callback(1);
         assert!(resp.text.contains("openai"));
@@ -2524,9 +2515,8 @@ providers:
 
     #[test]
     fn test_handle_settings_no_providers() {
-        let yaml = "# empty\n";
-        let _dir = with_temp_config(yaml);
-        // Providers on page 1.
+        let toml_str = "# empty\n";
+        let _dir = with_temp_config(toml_str);
         let resp = handle_settings_callback(1);
         assert!(resp.text.contains("(none)") || resp.text.contains("Providers:"));
     }
@@ -2862,14 +2852,14 @@ providers:
     #[test]
     fn test_handle_callback_settings_model_switch() {
         let dir = tempfile::tempdir().unwrap();
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
-  streaming: true
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
+streaming = true
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, yaml).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
 
         let resp = handle_callback("settings:model:switch").unwrap();
         assert!(resp.text.contains("Model:"));
@@ -2880,14 +2870,14 @@ agent:
     #[test]
     fn test_handle_callback_settings_streaming_toggle() {
         let dir = tempfile::tempdir().unwrap();
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
-  streaming: true
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
+streaming = true
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, yaml).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
 
         let resp = handle_callback("settings:streaming:toggle").unwrap();
         assert!(resp.text.contains("Streaming: off"));
@@ -2949,12 +2939,11 @@ agent:
 
     #[tokio::test]
     async fn test_ws_settings_shows_current() {
-        let yaml = r#"
-providers:
-  openai:
-    api_key: "sk-test"
+        let toml_str = r#"
+[providers.openai]
+api_key = "sk-test"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_ws_settings("/settings").await;
         assert!(result.contains("Settings"));
         assert!(result.contains("Model:"));
@@ -2966,11 +2955,11 @@ providers:
 
     #[tokio::test]
     async fn test_ws_settings_model_show_current() {
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = handle_ws_settings("/settings model").await;
         assert!(result.contains("gpt-4o"));
     }
@@ -2978,13 +2967,13 @@ agent:
     #[tokio::test]
     async fn test_ws_settings_model_next_cycles() {
         let dir = tempfile::tempdir().unwrap();
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, yaml).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
 
         let result = handle_ws_settings("/settings model next").await;
         assert!(result.contains("Model switched to:"));
@@ -2994,13 +2983,13 @@ agent:
     #[tokio::test]
     async fn test_ws_settings_model_set_by_name() {
         let dir = tempfile::tempdir().unwrap();
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, yaml).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
 
         let result = handle_ws_settings("/settings model my-custom-model").await;
         assert!(result.contains("gpt-4o"));
@@ -3010,14 +2999,14 @@ agent:
     #[tokio::test]
     async fn test_ws_settings_streaming_toggle() {
         let dir = tempfile::tempdir().unwrap();
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
-  streaming: true
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
+streaming = true
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, yaml).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
 
         let result = handle_ws_settings("/settings streaming").await;
         assert!(result.contains("Streaming: off"));
@@ -3036,16 +3025,16 @@ agent:
 
     #[test]
     fn test_ws_settings_gateway_shows_config() {
-        let yaml = r#"
-api:
-  host: "0.0.0.0"
-  port: 9090
-channels:
-  websocket:
-    enabled: true
-    listen_addr: "0.0.0.0:9091"
+        let toml_str = r#"
+[api]
+host = "0.0.0.0"
+port = 9090
+
+[channels.websocket]
+enabled = true
+listen_addr = "0.0.0.0:9091"
 "#;
-        let _dir = with_temp_config(yaml);
+        let _dir = with_temp_config(toml_str);
         let result = ws_settings_gateway();
         assert!(result.contains("Gateway settings"));
         assert!(result.contains("API host: 0.0.0.0"));
@@ -3070,14 +3059,14 @@ channels:
     #[test]
     fn test_ws_settings_timeout_set_valid() {
         let dir = tempfile::tempdir().unwrap();
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
-  tool_timeout: 120
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
+tool_timeout = 120
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, yaml).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
 
         let result = ws_settings_timeout("tool_timeout 300");
         assert!(result.contains("tool_timeout: 120s → 300s"));
@@ -3125,13 +3114,13 @@ agent:
     #[test]
     fn test_handle_models_select_sets_model() {
         let dir = tempfile::tempdir().unwrap();
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, yaml).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
 
         let resp = handle_models_select("opencode_go/kimi-k2.6");
         assert!(resp.text.contains("Model changed"));
@@ -3151,13 +3140,13 @@ agent:
     #[test]
     fn test_handle_models_callback_select() {
         let dir = tempfile::tempdir().unwrap();
-        let yaml = r#"
-agent:
-  model: "gpt-4o"
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
-        let config_path = dir.path().join("config.yaml");
-        std::fs::write(&config_path, yaml).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
 
         let resp = handle_models_callback("select", Some("openai/gpt-4o-mini")).unwrap();
         assert!(resp.text.contains("Model changed"));

--- a/crates/kestrel-channels/tests/proxy_client.rs
+++ b/crates/kestrel-channels/tests/proxy_client.rs
@@ -16,21 +16,20 @@ use kestrel_core::Platform;
 #[test]
 fn test_expand_env_vars_telegram_token() {
     std::env::set_var("TEST_TG_TOKEN", "123456:ABC-DEF");
-    let input = "token: ${TEST_TG_TOKEN}";
+    let input = "token = ${TEST_TG_TOKEN}";
     let expanded = expand_env_vars(input);
-    assert_eq!(expanded, "token: 123456:ABC-DEF");
+    assert_eq!(expanded, "token = 123456:ABC-DEF");
     std::env::remove_var("TEST_TG_TOKEN");
 }
 
 #[test]
-fn test_expand_env_vars_with_default_in_yaml() {
-    let yaml = r#"
-channels:
-  telegram:
-    token: ${NONEXISTENT_TG_TOKEN:-default_token}
-    enabled: true
+fn test_expand_env_vars_with_default_in_toml() {
+    let toml_str = r#"
+[channels.telegram]
+token = "${NONEXISTENT_TG_TOKEN:-default_token}"
+enabled = true
 "#;
-    let expanded = expand_env_vars(yaml);
+    let expanded = expand_env_vars(toml_str);
     assert!(expanded.contains("default_token"));
     assert!(!expanded.contains("${"));
 }
@@ -39,9 +38,9 @@ channels:
 fn test_expand_env_vars_multiple_in_one_line() {
     std::env::set_var("TEST_HOST", "api.example.com");
     std::env::set_var("TEST_PORT", "8080");
-    let input = "url: https://${TEST_HOST}:${TEST_PORT}/v1";
+    let input = "url = \"https://${TEST_HOST}:${TEST_PORT}/v1\"";
     let expanded = expand_env_vars(input);
-    assert_eq!(expanded, "url: https://api.example.com:8080/v1");
+    assert_eq!(expanded, "url = \"https://api.example.com:8080/v1\"");
     std::env::remove_var("TEST_HOST");
     std::env::remove_var("TEST_PORT");
 }
@@ -49,24 +48,25 @@ fn test_expand_env_vars_multiple_in_one_line() {
 #[test]
 fn test_load_config_from_file_with_env_vars() {
     let tmp = tempfile::tempdir().unwrap();
-    let config_path = tmp.path().join("config.yaml");
+    let config_path = tmp.path().join("config.toml");
 
     std::env::set_var("TEST_KESTREL_TG_TOKEN", "999888:XYZ");
     std::env::set_var("TEST_KESTREL_OPENAI_KEY", "sk-test-key-12345");
 
-    let yaml_content = r#"
-_config_version: 4
-providers:
-  openai:
-    api_key: ${TEST_KESTREL_OPENAI_KEY}
-channels:
-  telegram:
-    token: ${TEST_KESTREL_TG_TOKEN}
-    enabled: true
-agent:
-  model: gpt-4o
+    let toml_content = r#"
+_config_version = 4
+
+[providers.openai]
+api_key = "${TEST_KESTREL_OPENAI_KEY}"
+
+[channels.telegram]
+token = "${TEST_KESTREL_TG_TOKEN}"
+enabled = true
+
+[agent]
+model = "gpt-4o"
 "#;
-    std::fs::write(&config_path, yaml_content).unwrap();
+    std::fs::write(&config_path, toml_content).unwrap();
 
     let config = load_config(Some(&config_path)).unwrap();
     assert_eq!(

--- a/crates/kestrel-config/Cargo.toml
+++ b/crates/kestrel-config/Cargo.toml
@@ -8,6 +8,7 @@ kestrel-core = { path = "../kestrel-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+toml = { workspace = true }
 anyhow = { workspace = true }
 regex = { workspace = true }
 dirs = "5"

--- a/crates/kestrel-config/README.md
+++ b/crates/kestrel-config/README.md
@@ -1,15 +1,15 @@
 # kestrel-config
 
-YAML configuration loading with environment variable expansion and schema migration.
+TOML configuration loading with environment variable expansion and schema migration.
 
 Part of the [kestrel](../..) workspace.
 
 ## Overview
 
-Loads and validates the `config.yaml` that drives kestrel behavior. Supports `${VAR}`
-and `${VAR:-default}` environment variable substitution inside YAML values, and
-automatically migrates older config versions to the current schema. Maintains YAML
-compatibility with the Python kestrel config format.
+Loads and validates the `config.toml` that drives kestrel behavior. Supports `${VAR}`
+and `${VAR:-default}` environment variable substitution inside TOML values, and
+automatically migrates older config versions to the current schema. Can migrate from
+Python kestrel's JSON/YAML config format.
 
 ## Key Types
 
@@ -28,7 +28,7 @@ compatibility with the Python kestrel config format.
 ## Key Functions
 
 - `load_config(path)` -- Load from file (or default path), expand env vars, run migrations
-- `save_config(config, path)` -- Serialize config back to YAML
+- `save_config(config, path)` -- Serialize config back to TOML
 - `expand_env_vars(input)` -- Resolve `${VAR}` / `${VAR:-default}` patterns
 
 ## Usage
@@ -37,11 +37,11 @@ compatibility with the Python kestrel config format.
 use kestrel_config::load_config;
 use std::path::Path;
 
-let config = load_config(Some(Path::new("config.yaml")))?;
+let config = load_config(Some(Path::new("config.toml")))?;
 println!("Model: {}", config.agent.model);
 println!("Temperature: {}", config.agent.temperature);
 
-// Env vars in YAML are expanded:
-//   api_key: ${ANTHROPIC_API_KEY}
-//   model: ${MODEL:-gpt-4o}
+// Env vars in TOML are expanded:
+//   api_key = "${ANTHROPIC_API_KEY}"
+//   model = "${MODEL:-gpt-4o}"
 ```

--- a/crates/kestrel-config/examples/migrate.rs
+++ b/crates/kestrel-config/examples/migrate.rs
@@ -1,26 +1,26 @@
 //! Standalone Python kestrel config migration tool.
 //!
 //! Reads a Python kestrel `config.json` (plus per-channel configs) and converts
-//! it to kestrel `config.yaml`.
+//! it to kestrel `config.toml`.
 //!
 //! # Usage
 //!
 //! ```sh
-//! # Dry run — print YAML to stdout
+//! # Dry run — print TOML to stdout
 //! cargo run -p kestrel-config --example migrate -- --from ~/.kestrel --dry-run
 //!
-//! # Write to auto-detected config path (~/.kestrel/config.yaml)
+//! # Write to auto-detected config path (~/.kestrel/config.toml)
 //! cargo run -p kestrel-config --example migrate -- --from ~/.kestrel
 //!
 //! # Write to a specific output file
-//! cargo run -p kestrel-config --example migrate -- --from ~/.kestrel --output ./config.yaml
+//! cargo run -p kestrel-config --example migrate -- --from ~/.kestrel --output ./config.toml
 //! ```
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Migrate Python kestrel config to kestrel YAML format.
+/// Migrate Python kestrel config to kestrel TOML format.
 #[derive(Parser)]
 #[command(
     name = "migrate",
@@ -31,12 +31,12 @@ struct Cli {
     #[arg(long)]
     from: PathBuf,
 
-    /// Output path for config.yaml.
-    /// Defaults to auto-detected path (~/.kestrel/config.yaml).
+    /// Output path for config.toml.
+    /// Defaults to auto-detected path (~/.kestrel/config.toml).
     #[arg(long)]
     output: Option<PathBuf>,
 
-    /// Dry run: print YAML to stdout instead of writing to file.
+    /// Dry run: print TOML to stdout instead of writing to file.
     #[arg(long)]
     dry_run: bool,
 }
@@ -65,11 +65,10 @@ fn main() -> Result<()> {
     // Print migration report to stderr so stdout stays clean for --dry-run
     print_report(&result.report);
 
-    let yaml =
-        serde_yaml::to_string(&result.config).context("Failed to serialize config to YAML")?;
+    let toml_str = toml::to_string(&result.config).context("Failed to serialize config to TOML")?;
 
     if cli.dry_run {
-        println!("{}", yaml);
+        println!("{}", toml_str);
     } else {
         let output_path = match cli.output {
             Some(ref p) => p.clone(),
@@ -80,7 +79,7 @@ fn main() -> Result<()> {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
         }
-        std::fs::write(&output_path, &yaml)
+        std::fs::write(&output_path, &toml_str)
             .with_context(|| format!("Failed to write config to {}", output_path.display()))?;
         eprintln!("\nConfig written to: {}", output_path.display());
     }

--- a/crates/kestrel-config/src/lib.rs
+++ b/crates/kestrel-config/src/lib.rs
@@ -1,7 +1,7 @@
 //! # kestrel-config
 //!
 //! Configuration loading and schema for kestrel.
-//! Maintains YAML compatibility with the Python kestrel config format.
+//! Uses TOML format for the config file (`config.toml`).
 
 pub mod loader;
 pub mod migration;

--- a/crates/kestrel-config/src/loader.rs
+++ b/crates/kestrel-config/src/loader.rs
@@ -24,8 +24,8 @@ pub fn load_config(config_path: Option<&Path>) -> Result<Config> {
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
 
         let expanded = expand_env_vars(&raw);
-        let mut config: Config = serde_yaml::from_str(&expanded)
-            .with_context(|| format!("Failed to parse config YAML: {}", path.display()))?;
+        let mut config: Config = toml::from_str(&expanded)
+            .with_context(|| format!("Failed to parse config TOML: {}", path.display()))?;
 
         migrate_config(&mut config)?;
         config
@@ -54,10 +54,10 @@ pub fn expand_env_vars(input: &str) -> String {
     .into_owned()
 }
 
-/// Save configuration to a YAML file.
+/// Save configuration to a TOML file.
 pub fn save_config(config: &Config, path: &Path) -> Result<()> {
-    let yaml = serde_yaml::to_string(config)?;
-    std::fs::write(path, yaml)
+    let toml_str = toml::to_string(config)?;
+    std::fs::write(path, toml_str)
         .with_context(|| format!("Failed to write config to {}", path.display()))?;
     Ok(())
 }
@@ -69,34 +69,34 @@ mod tests {
     #[test]
     fn test_expand_env_vars_simple() {
         std::env::set_var("TEST_KESTREL_KEY", "secret123");
-        let result = expand_env_vars("key: ${TEST_KESTREL_KEY}");
-        assert_eq!(result, "key: secret123");
+        let result = expand_env_vars("key = ${TEST_KESTREL_KEY}");
+        assert_eq!(result, "key = secret123");
     }
 
     #[test]
     fn test_expand_env_vars_with_default() {
-        let result = expand_env_vars("key: ${NONEXISTENT_VAR:-fallback}");
-        assert_eq!(result, "key: fallback");
+        let result = expand_env_vars("key = ${NONEXISTENT_VAR:-fallback}");
+        assert_eq!(result, "key = fallback");
     }
 
     #[test]
     fn test_expand_env_vars_missing_no_default() {
-        let result = expand_env_vars("key: ${NONEXISTENT_VAR_NO_DEFAULT}");
-        assert_eq!(result, "key: ");
+        let result = expand_env_vars("key = ${NONEXISTENT_VAR_NO_DEFAULT}");
+        assert_eq!(result, "key = ");
     }
 
     #[test]
     fn test_default_config_roundtrip() {
         let config = Config::default();
-        let yaml = serde_yaml::to_string(&config).unwrap();
-        let parsed: Config = serde_yaml::from_str(&yaml).unwrap();
+        let toml_str = toml::to_string(&config).unwrap();
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.agent.model, config.agent.model);
     }
 
     #[test]
     fn test_save_and_load_config() {
         let tmp = tempfile::tempdir().unwrap();
-        let config_path = tmp.path().join("config.yaml");
+        let config_path = tmp.path().join("config.toml");
 
         let config = Config::default();
         save_config(&config, &config_path).unwrap();
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn test_load_config_missing_file_returns_default() {
         let config = load_config(Some(std::path::Path::new(
-            "/tmp/nonexistent_kestrel_config_9999.yaml",
+            "/tmp/nonexistent_kestrel_config_9999.toml",
         )))
         .unwrap();
         // Should return default config
@@ -120,19 +120,19 @@ mod tests {
     #[test]
     fn test_load_config_with_env_vars() {
         let tmp = tempfile::tempdir().unwrap();
-        let config_path = tmp.path().join("config.yaml");
+        let config_path = tmp.path().join("config.toml");
 
         std::env::set_var("TEST_KESTREL_LOAD_KEY", "my-secret-key");
 
-        let yaml_content = r#"
-providers:
-  openai:
-    api_key: ${TEST_KESTREL_LOAD_KEY}
-    model: gpt-4o
-agent:
-  model: ${NONEXISTENT_MODEL:-gpt-4o}
+        let toml_content = r#"
+[providers.openai]
+api_key = "${TEST_KESTREL_LOAD_KEY}"
+model = "gpt-4o"
+
+[agent]
+model = "${NONEXISTENT_MODEL:-gpt-4o}"
 "#;
-        std::fs::write(&config_path, yaml_content).unwrap();
+        std::fs::write(&config_path, toml_content).unwrap();
 
         let config = load_config(Some(&config_path)).unwrap();
         assert_eq!(

--- a/crates/kestrel-config/src/paths.rs
+++ b/crates/kestrel-config/src/paths.rs
@@ -54,10 +54,10 @@ pub fn get_sessions_dir() -> Result<PathBuf> {
 
 /// Get the config file path.
 ///
-/// Default: `~/.kestrel/config.yaml`
+/// Default: `~/.kestrel/config.toml`
 pub fn get_config_path() -> Result<PathBuf> {
     let home = get_kestrel_home()?;
-    Ok(home.join("config.yaml"))
+    Ok(home.join("config.toml"))
 }
 
 /// Get the memory storage directory.
@@ -132,7 +132,7 @@ mod tests {
     fn test_config_path_default() {
         std::env::set_var("KESTREL_HOME", "/tmp/test-kestrel-config");
         let path = get_config_path().unwrap();
-        assert_eq!(path, PathBuf::from("/tmp/test-kestrel-config/config.yaml"));
+        assert_eq!(path, PathBuf::from("/tmp/test-kestrel-config/config.toml"));
         std::env::remove_var("KESTREL_HOME");
     }
 }

--- a/crates/kestrel-config/src/python_migrate.rs
+++ b/crates/kestrel-config/src/python_migrate.rs
@@ -1,4 +1,4 @@
-//! Python kestrel config migration to kestrel YAML format.
+//! Python kestrel config migration to kestrel TOML format.
 //!
 //! Reads Python JSON/YAML configs, converts to kestrel [`Config`],
 //! validates the result, and reports mapped/unmapped/ignored fields.
@@ -37,8 +37,8 @@ pub struct MigrationOptions {
     /// Explicit path to the Python config file (JSON or YAML).
     /// If `None`, auto-detects `config.json` then `config.yaml` in `python_home`.
     pub input_file: Option<std::path::PathBuf>,
-    /// Output path for the kestrel config.yaml.
-    /// If `None`, writes to `<KESTREL_HOME>/config.yaml`.
+    /// Output path for the kestrel config.toml.
+    /// If `None`, writes to `<KESTREL_HOME>/config.toml`.
     pub output_file: Option<std::path::PathBuf>,
     /// Whether to fill defaults before validating.
     pub fill_defaults: bool,
@@ -212,8 +212,9 @@ const KNOWN_CHANNELS: &[&str] = &[
 /// Migrate Python kestrel config directory to kestrel Config.
 ///
 /// `python_home` is the Python kestrel config directory (e.g., `~/.kestrel`).
-/// Reads `config.json` (or `config.yaml`) from that directory, plus any
-/// per-channel configs at sibling directories like `~/.kestrel-telegram/config.json`.
+/// Reads `config.json` (or `config.yaml`) from that directory (Python format),
+/// plus any per-channel configs at sibling directories like `~/.kestrel-telegram/config.json`.
+/// Outputs the result as TOML.
 ///
 /// Validates the result and optionally writes to disk (unless dry-run).
 pub fn migrate_from_python(
@@ -896,10 +897,10 @@ mod tests {
 
     #[test]
     fn test_migration_options_with_output() {
-        let opts = MigrationOptions::with_output("/tmp/test-config.yaml");
+        let opts = MigrationOptions::with_output("/tmp/test-config.toml");
         assert_eq!(
             opts.output_file.unwrap().to_str(),
-            Some("/tmp/test-config.yaml")
+            Some("/tmp/test-config.toml")
         );
     }
 
@@ -1172,17 +1173,17 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // YAML output roundtrip
+    // TOML output roundtrip
     // -------------------------------------------------------------------
 
     #[test]
-    fn test_migrate_yaml_output_valid() {
+    fn test_migrate_toml_output_valid() {
         let py = make_full_python_config();
         let mut report = MigrationReport::default();
         let config = convert_python_config(&py, &[], &mut report);
 
-        let yaml = serde_yaml::to_string(&config).unwrap();
-        let parsed: Config = serde_yaml::from_str(&yaml).unwrap();
+        let toml_str = toml::to_string(&config).unwrap();
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
 
         assert_eq!(parsed.agent.model, "claude-opus-4-5");
         assert_eq!(parsed.agent.provider, Some("openrouter".to_string()));
@@ -1503,7 +1504,7 @@ channels:
         )
         .unwrap();
 
-        let output = tmp.path().join("output.yaml");
+        let output = tmp.path().join("output.toml");
         let opts = MigrationOptions {
             dry_run: true,
             output_file: Some(output.clone()),
@@ -1532,7 +1533,7 @@ channels:
         )
         .unwrap();
 
-        let output = tmp.path().join("migrated.yaml");
+        let output = tmp.path().join("migrated.toml");
         let opts = MigrationOptions {
             dry_run: false,
             output_file: Some(output.clone()),
@@ -1541,10 +1542,10 @@ channels:
 
         migrate_from_python(&py_home, &opts).unwrap();
 
-        // Output file should exist and be valid YAML
+        // Output file should exist and be valid TOML
         assert!(output.exists());
         let content = fs::read_to_string(&output).unwrap();
-        let parsed: Config = serde_yaml::from_str(&content).unwrap();
+        let parsed: Config = toml::from_str(&content).unwrap();
         assert!(parsed.providers.openai.is_some());
     }
 

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -1,4 +1,4 @@
-//! Configuration schema matching the Python kestrel config.yaml format.
+//! Configuration schema matching the Python kestrel config.toml format.
 //!
 //! Uses serde for deserialization with `#[serde(rename_all = "snake_case")]`
 //! to maintain compatibility with the Python camelCase config keys.
@@ -799,12 +799,12 @@ impl Default for ApiConfig {
 /// signal handling, and file-based logging. Activated via `kestrel daemon start`
 /// on the CLI — there is no config-file toggle.
 ///
-/// ```yaml
-/// daemon:
-///   pid_file: ~/.kestrel/kestrel.pid
-///   log_dir: ~/.kestrel/logs
-///   working_directory: /
-///   grace_period_secs: 30
+/// ```toml
+/// [daemon]
+/// pid_file = "~/.kestrel/kestrel.pid"
+/// log_dir = "~/.kestrel/logs"
+/// working_directory = "/"
+/// grace_period_secs = 30
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1048,10 +1048,10 @@ mod tests {
     }
 
     #[test]
-    fn test_config_yaml_roundtrip() {
+    fn test_config_toml_roundtrip() {
         let config = Config::default();
-        let yaml = serde_yaml::to_string(&config).expect("serialize to yaml");
-        let parsed: Config = serde_yaml::from_str(&yaml).expect("deserialize from yaml");
+        let toml_str = toml::to_string(&config).expect("serialize to toml");
+        let parsed: Config = toml::from_str(&toml_str).expect("deserialize from toml");
         assert_eq!(parsed._config_version, config._config_version);
         assert_eq!(parsed.agent.model, config.agent.model);
         assert_eq!(parsed.agent.temperature, config.agent.temperature);
@@ -1080,9 +1080,9 @@ mod tests {
         assert!(security.ssrf_whitelist.is_empty());
         assert!(security.blocked_networks.is_empty());
 
-        // Verify that serde deserialization of empty yaml uses default_true.
-        let from_yaml: SecurityConfig = serde_yaml::from_str("{}").unwrap();
-        assert!(from_yaml.block_private_ips);
+        // Verify that serde deserialization of empty toml uses default_true.
+        let from_toml: SecurityConfig = toml::from_str("").unwrap();
+        assert!(from_toml.block_private_ips);
     }
 
     #[test]
@@ -1098,13 +1098,13 @@ mod tests {
     }
 
     #[test]
-    fn test_config_parse_minimal_yaml() {
-        let yaml = r#"
-agent:
-  model: gpt-4o-mini
-  temperature: 0.5
+    fn test_config_parse_minimal_toml() {
+        let toml_str = r#"
+[agent]
+model = "gpt-4o-mini"
+temperature = 0.5
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.agent.model, "gpt-4o-mini");
         assert!((config.agent.temperature - 0.5).abs() < f32::EPSILON);
         assert!(config.providers.anthropic.is_none());
@@ -1112,55 +1112,57 @@ agent:
     }
 
     #[test]
-    fn test_config_parse_full_yaml() {
-        let yaml = r#"
-_config_version: 4
-providers:
-  openai:
-    api_key: sk-test-123
-    base_url: https://api.openai.com/v1
-    model: gpt-4o
-  anthropic:
-    api_key: sk-ant-123
-channels:
-  telegram:
-    token: "123456:ABC"
-    allowed_users:
-      - user1
-    streaming: true
-agent:
-  model: gpt-4o
-  temperature: 0.8
-  max_tokens: 2048
-  max_iterations: 30
-  streaming: false
-  tool_timeout: 60
-dream:
-  enabled: true
-  interval_secs: 3600
-heartbeat:
-  enabled: true
-  interval_secs: 600
-security:
-  block_private_ips: true
-  ssrf_whitelist:
-    - 10.0.0.0/8
-custom_instructions: "Be helpful"
-name: "TestBot"
-workspace: "/tmp/workspace"
-mcp_servers:
-  filesystem:
-    transport: stdio
-    command: "mcp-filesystem"
-    args:
-      - "--root"
-      - "/data"
-notifications:
-  online_notify: false
-  notify_chat_id: "-1001234567890"
-  online_message: "Kestrel {version} online on {channel}"
+    fn test_config_parse_full_toml() {
+        let toml_str = r#"
+_config_version = 4
+custom_instructions = "Be helpful"
+name = "TestBot"
+workspace = "/tmp/workspace"
+
+[providers.openai]
+api_key = "sk-test-123"
+base_url = "https://api.openai.com/v1"
+model = "gpt-4o"
+
+[providers.anthropic]
+api_key = "sk-ant-123"
+
+[channels.telegram]
+token = "123456:ABC"
+allowed_users = ["user1"]
+streaming = true
+
+[agent]
+model = "gpt-4o"
+temperature = 0.8
+max_tokens = 2048
+max_iterations = 30
+streaming = false
+tool_timeout = 60
+
+[dream]
+enabled = true
+interval_secs = 3600
+
+[heartbeat]
+enabled = true
+interval_secs = 600
+
+[security]
+block_private_ips = true
+ssrf_whitelist = ["10.0.0.0/8"]
+
+[mcp_servers.filesystem]
+transport = "stdio"
+command = "mcp-filesystem"
+args = ["--root", "/data"]
+
+[notifications]
+online_notify = false
+notify_chat_id = "-1001234567890"
+online_message = "Kestrel {version} online on {channel}"
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config._config_version, Some(4));
         assert_eq!(config.agent.model, "gpt-4o");
         assert!((config.agent.temperature - 0.8).abs() < f32::EPSILON);
@@ -1218,7 +1220,7 @@ notifications:
 
     #[test]
     fn test_notifications_config_parse_defaults_when_missing() {
-        let config: Config = serde_yaml::from_str("{}").unwrap();
+        let config: Config = toml::from_str("").unwrap();
         assert!(config.notifications.online_notify);
         assert!(config.notifications.notify_chat_id.is_none());
         assert_eq!(
@@ -1229,16 +1231,15 @@ notifications:
 
     #[test]
     fn test_custom_provider_config_parse() {
-        let yaml = r#"
-custom_providers:
-  - name: my_provider
-    base_url: https://my-api.com/v1
-    api_key: key123
-    model_patterns:
-      - my-model
-    no_proxy: true
+        let toml_str = r#"
+[[custom_providers]]
+name = "my_provider"
+base_url = "https://my-api.com/v1"
+api_key = "key123"
+model_patterns = ["my-model"]
+no_proxy = true
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.custom_providers.len(), 1);
         let cp = &config.custom_providers[0];
         assert_eq!(cp.name, "my_provider");
@@ -1273,13 +1274,13 @@ custom_providers:
 
     #[test]
     fn test_cron_config_parse() {
-        let yaml = r#"
-cron:
-  enabled: true
-  state_file: /tmp/cron_state.json
-  tick_secs: 30
+        let toml_str = r#"
+[cron]
+enabled = true
+state_file = "/tmp/cron_state.json"
+tick_secs = 30
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.cron.enabled);
         assert_eq!(
             config.cron.state_file,
@@ -1289,9 +1290,8 @@ cron:
     }
 
     #[test]
-    fn test_empty_config_yaml() {
-        let yaml = "{}";
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+    fn test_empty_config_toml() {
+        let config: Config = toml::from_str("").unwrap();
         assert_eq!(config.agent.model, "gpt-4o");
         assert!(config.agent.streaming);
     }
@@ -1309,16 +1309,16 @@ cron:
 
     #[test]
     fn test_daemon_config_parse() {
-        let yaml = r#"
-daemon:
-  pid_file: /var/run/kestrel.pid
-  log_dir: /var/log/kestrel
-  working_directory: /opt
-  grace_period_secs: 60
-  log_retain_days: 7
-  log_format: json
+        let toml_str = r#"
+[daemon]
+pid_file = "/var/run/kestrel.pid"
+log_dir = "/var/log/kestrel"
+working_directory = "/opt"
+grace_period_secs = 60
+log_retain_days = 7
+log_format = "json"
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.daemon.pid_file, "/var/run/kestrel.pid");
         assert_eq!(config.daemon.log_dir, "/var/log/kestrel");
         assert_eq!(config.daemon.working_directory, "/opt");
@@ -1328,10 +1328,10 @@ daemon:
     }
 
     #[test]
-    fn test_daemon_config_yaml_roundtrip() {
+    fn test_daemon_config_toml_roundtrip() {
         let dc = DaemonConfig::default();
-        let yaml = serde_yaml::to_string(&dc).unwrap();
-        let parsed: DaemonConfig = serde_yaml::from_str(&yaml).unwrap();
+        let toml_str = toml::to_string(&dc).unwrap();
+        let parsed: DaemonConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.pid_file, dc.pid_file);
         assert_eq!(parsed.log_dir, dc.log_dir);
         assert_eq!(parsed.working_directory, dc.working_directory);
@@ -1353,18 +1353,18 @@ daemon:
 
     #[test]
     fn test_websocket_config_parse() {
-        let yaml = r#"
-channels:
-  websocket:
-    enabled: true
-    listen_addr: "0.0.0.0:9090"
-    auth:
-      required: true
-      token: "my-secret"
-    max_clients: 50
-    max_message_size: 2097152
+        let toml_str = r#"
+[channels.websocket]
+enabled = true
+listen_addr = "0.0.0.0:9090"
+max_clients = 50
+max_message_size = 2097152
+
+[channels.websocket.auth]
+required = true
+token = "my-secret"
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         let ws = config.channels.websocket.unwrap();
         assert!(ws.enabled);
         assert_eq!(ws.listen_addr, "0.0.0.0:9090");
@@ -1375,10 +1375,10 @@ channels:
     }
 
     #[test]
-    fn test_websocket_config_yaml_roundtrip() {
+    fn test_websocket_config_toml_roundtrip() {
         let wc = WebSocketConfig::default();
-        let yaml = serde_yaml::to_string(&wc).unwrap();
-        let parsed: WebSocketConfig = serde_yaml::from_str(&yaml).unwrap();
+        let toml_str = toml::to_string(&wc).unwrap();
+        let parsed: WebSocketConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.enabled, wc.enabled);
         assert_eq!(parsed.listen_addr, wc.listen_addr);
         assert_eq!(parsed.max_clients, wc.max_clients);

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -1,4 +1,4 @@
-//! Configuration validation — schema checks for config.yaml.
+//! Configuration validation — schema checks for config.toml.
 //!
 //! Validates field types, required fields, value ranges, and cross-field
 //! constraints. Returns a structured [`ValidationReport`] with warnings
@@ -237,36 +237,36 @@ pub fn validate_and_fill(config: &mut Config) -> (ValidationReport, Vec<String>)
 }
 
 // ---------------------------------------------------------------------------
-// Raw YAML env-var validation
+// Raw TOML env-var validation
 // ---------------------------------------------------------------------------
 
-/// Check raw config YAML for unresolved environment variable templates.
+/// Check raw config TOML for unresolved environment variable templates.
 ///
 /// Detects `${VAR}` patterns (without a `:-default` fallback) and warns
 /// if the referenced env var is not set. Returns a list of (path, message)
-/// findings. This should be called on the raw YAML string **before**
+/// findings. This should be called on the raw TOML string **before**
 /// [`crate::loader::expand_env_vars`] so unresolved vars are still visible.
 ///
 /// Only emits warnings (not errors) because missing env vars may be
 /// intentional (e.g., set at deploy time).
-pub fn validate_raw_env_vars(raw_yaml: &str) -> Vec<ValidationFinding> {
+pub fn validate_raw_env_vars(raw_toml: &str) -> Vec<ValidationFinding> {
     let mut findings = Vec::new();
 
     // Match ${VAR} without :-default
     let re = regex::Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
         .expect("static regex is valid");
-    for cap in re.captures_iter(raw_yaml) {
+    for cap in re.captures_iter(raw_toml) {
         let var_name = &cap[1];
         let has_default = cap.get(2).is_some();
 
         if !has_default && std::env::var(var_name).is_err() {
             // Find which line contains this variable for a useful path hint
             let full_match = cap.get(0).expect("capture group 0 always exists").as_str();
-            for (line_num, line) in raw_yaml.lines().enumerate() {
+            for (line_num, line) in raw_toml.lines().enumerate() {
                 if line.contains(full_match) {
-                    // Try to extract the YAML key from the line
+                    // Try to extract the TOML key from the line (key = value)
                     let key_hint = line
-                        .split(':')
+                        .split('=')
                         .next()
                         .map(|k| k.trim().to_string())
                         .unwrap_or_default();
@@ -2606,12 +2606,11 @@ mod tests {
     fn test_raw_env_vars_unresolved_var() {
         // Ensure THIS_VAR_DOES_NOT_EXIST is not in the environment
         std::env::remove_var("THIS_VAR_DOES_NOT_EXIST_XYZ");
-        let yaml = r#"
-providers:
-  openai:
-    api_key: ${THIS_VAR_DOES_NOT_EXIST_XYZ}
+        let toml_str = r#"
+[providers.openai]
+api_key = "${THIS_VAR_DOES_NOT_EXIST_XYZ}"
 "#;
-        let findings = validate_raw_env_vars(yaml);
+        let findings = validate_raw_env_vars(toml_str);
         assert!(!findings.is_empty());
         assert!(findings
             .iter()
@@ -2623,12 +2622,11 @@ providers:
     fn test_raw_env_vars_with_default_ok() {
         // Var with a default should NOT produce a warning
         std::env::remove_var("PROBABLY_MISSING_VAR_ABC");
-        let yaml = r#"
-providers:
-  openai:
-    api_key: ${PROBABLY_MISSING_VAR_ABC:-fallback-key}
+        let toml_str = r#"
+[providers.openai]
+api_key = "${PROBABLY_MISSING_VAR_ABC:-fallback-key}"
 "#;
-        let findings = validate_raw_env_vars(yaml);
+        let findings = validate_raw_env_vars(toml_str);
         assert!(
             findings.is_empty(),
             "Expected no findings for var with default, got: {:?}",
@@ -2640,12 +2638,11 @@ providers:
     fn test_raw_env_vars_set_in_env_ok() {
         // Var that IS set should NOT produce a warning
         std::env::set_var("KESTREL_TEST_SET_VAR", "hello");
-        let yaml = r#"
-providers:
-  openai:
-    api_key: ${KESTREL_TEST_SET_VAR}
+        let toml_str = r#"
+[providers.openai]
+api_key = "${KESTREL_TEST_SET_VAR}"
 "#;
-        let findings = validate_raw_env_vars(yaml);
+        let findings = validate_raw_env_vars(toml_str);
         std::env::remove_var("KESTREL_TEST_SET_VAR");
         assert!(
             findings.is_empty(),
@@ -2656,12 +2653,12 @@ providers:
 
     #[test]
     fn test_raw_env_vars_no_vars() {
-        let yaml = r#"
-agent:
-  model: gpt-4o
-  temperature: 0.7
+        let toml_str = r#"
+[agent]
+model = "gpt-4o"
+temperature = 0.7
 "#;
-        let findings = validate_raw_env_vars(yaml);
+        let findings = validate_raw_env_vars(toml_str);
         assert!(findings.is_empty());
     }
 
@@ -2669,15 +2666,14 @@ agent:
     fn test_raw_env_vars_multiple_unresolved() {
         std::env::remove_var("MISSING_AAA");
         std::env::remove_var("MISSING_BBB");
-        let yaml = r#"
-providers:
-  openai:
-    api_key: ${MISSING_AAA}
-channels:
-  telegram:
-    token: ${MISSING_BBB}
+        let toml_str = r#"
+[providers.openai]
+api_key = "${MISSING_AAA}"
+
+[channels.telegram]
+token = "${MISSING_BBB}"
 "#;
-        let findings = validate_raw_env_vars(yaml);
+        let findings = validate_raw_env_vars(toml_str);
         assert_eq!(findings.len(), 2);
         let names: Vec<&str> = findings
             .iter()
@@ -2691,10 +2687,10 @@ channels:
     }
 
     #[test]
-    fn test_raw_env_vars_path_is_yaml_key() {
+    fn test_raw_env_vars_path_is_toml_key() {
         std::env::remove_var("MISSING_KEY_FOR_PATH_TEST");
-        let yaml = "api_key: ${MISSING_KEY_FOR_PATH_TEST}\n";
-        let findings = validate_raw_env_vars(yaml);
+        let toml_str = "api_key = \"${MISSING_KEY_FOR_PATH_TEST}\"\n";
+        let findings = validate_raw_env_vars(toml_str);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].path, "api_key");
     }
@@ -2703,8 +2699,8 @@ channels:
     fn test_raw_env_vars_empty_default_no_warn() {
         // ${VAR:-} has an empty default, should NOT warn
         std::env::remove_var("MISSING_WITH_EMPTY_DEFAULT");
-        let yaml = "key: ${MISSING_WITH_EMPTY_DEFAULT:-}\n";
-        let findings = validate_raw_env_vars(yaml);
+        let toml_str = "key = \"${MISSING_WITH_EMPTY_DEFAULT:-}\"\n";
+        let findings = validate_raw_env_vars(toml_str);
         assert!(
             findings.is_empty(),
             "Expected no warning for var with empty default, got: {:?}",

--- a/crates/kestrel-core/src/error.rs
+++ b/crates/kestrel-core/src/error.rs
@@ -38,8 +38,8 @@ pub enum KestrelError {
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
-    #[error("YAML error: {0}")]
-    Yaml(String),
+    #[error("TOML error: {0}")]
+    Toml(String),
 
     #[error("HTTP error: {0}")]
     Http(String),
@@ -102,8 +102,8 @@ mod tests {
         let agent_err = KestrelError::Agent("agent lost".to_string());
         assert!(format!("{}", agent_err).contains("Agent error"));
 
-        let yaml_err = KestrelError::Yaml("parse fail".to_string());
-        assert!(format!("{}", yaml_err).contains("YAML error"));
+        let toml_err = KestrelError::Toml("parse fail".to_string());
+        assert!(format!("{}", toml_err).contains("TOML error"));
 
         let http_err = KestrelError::Http("503".to_string());
         assert!(format!("{}", http_err).contains("HTTP error"));

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,4 +1,4 @@
-//! Config subcommand — validate config.yaml schema and migrate from Python.
+//! Config subcommand — validate config.toml schema and migrate from Python.
 
 use anyhow::Result;
 use kestrel_config::Config;
@@ -78,9 +78,9 @@ pub fn migrate(from: &Path, dry_run: bool) -> Result<()> {
     }
 
     if dry_run {
-        println!("\n--- Generated config.yaml (dry run) ---\n");
-        let yaml = serde_yaml::to_string(&result.config)?;
-        println!("{}", yaml);
+        println!("\n--- Generated config.toml (dry run) ---\n");
+        let toml_str = toml::to_string(&result.config)?;
+        println!("{}", toml_str);
     } else {
         let config_path = kestrel_config::paths::get_config_path()?;
         println!("\nWriting config to: {}", config_path.display());

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -97,15 +97,15 @@ fn initialize_home(config_path: &Path, template: &Config) -> Result<()> {
 mod tests {
     use super::*;
 
-    fn template_yaml() -> String {
-        serde_yaml::to_string(&Config::default()).unwrap()
+    fn template_toml() -> String {
+        toml::to_string(&Config::default()).unwrap()
     }
 
     #[test]
     fn setup_keeps_existing_config_when_user_declines_overwrite() {
         let tmp = tempfile::tempdir().unwrap();
-        let config_path = tmp.path().join("config.yaml");
-        std::fs::write(&config_path, "agent:\n  model: existing-model\n").unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "[agent]\nmodel = \"existing-model\"\n").unwrap();
 
         let mut input = io::Cursor::new(b"n\n");
         let mut output = Vec::new();
@@ -114,7 +114,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(&config_path).unwrap(),
-            "agent:\n  model: existing-model\n"
+            "[agent]\nmodel = \"existing-model\"\n"
         );
         assert!(!tmp.path().join("skills").exists());
 
@@ -126,8 +126,8 @@ mod tests {
     #[test]
     fn setup_keeps_existing_config_when_user_presses_enter() {
         let tmp = tempfile::tempdir().unwrap();
-        let config_path = tmp.path().join("config.yaml");
-        std::fs::write(&config_path, "agent:\n  model: existing-model\n").unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "[agent]\nmodel = \"existing-model\"\n").unwrap();
 
         let mut input = io::Cursor::new(b"\n");
         let mut output = Vec::new();
@@ -136,7 +136,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(&config_path).unwrap(),
-            "agent:\n  model: existing-model\n"
+            "[agent]\nmodel = \"existing-model\"\n"
         );
         assert!(!tmp.path().join("sessions").exists());
 
@@ -147,8 +147,8 @@ mod tests {
     #[test]
     fn setup_overwrites_existing_config_and_creates_default_directories() {
         let tmp = tempfile::tempdir().unwrap();
-        let config_path = tmp.path().join("config.yaml");
-        std::fs::write(&config_path, "agent:\n  model: existing-model\n").unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "[agent]\nmodel = \"existing-model\"\n").unwrap();
 
         let mut input = io::Cursor::new(b"y\n");
         let mut output = Vec::new();
@@ -157,7 +157,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(&config_path).unwrap(),
-            template_yaml()
+            template_toml()
         );
         assert!(tmp.path().join("skills").is_dir());
         assert!(tmp.path().join("sessions").is_dir());
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn setup_creates_template_config_and_directories_when_config_is_missing() {
         let tmp = tempfile::tempdir().unwrap();
-        let config_path = tmp.path().join("config.yaml");
+        let config_path = tmp.path().join("config.toml");
 
         let mut input = io::Cursor::new(Vec::<u8>::new());
         let mut output = Vec::new();
@@ -179,7 +179,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(&config_path).unwrap(),
-            template_yaml()
+            template_toml()
         );
         assert!(tmp.path().join("skills").is_dir());
         assert!(tmp.path().join("sessions").is_dir());

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ enum CronSubcommand {
 
 #[derive(Subcommand)]
 enum ConfigSubcommand {
-    /// Validate the config.yaml schema.
+    /// Validate the config.toml schema.
     Validate,
 
     /// Migrate Python kestrel config to kestrel format.


### PR DESCRIPTION
## Summary
- Replace `serde_yaml` with `toml` for kestrel's own config file format
- Default config path changes from `~/.kestrel/config.yaml` to `~/.kestrel/config.toml`
- Python kestrel migration still reads JSON/YAML but outputs TOML
- All tests, docs, and error types updated across 6 crates (18 files)

## Test plan
- [ ] CI passes (build + test)
- [ ] Verify `kestrel setup` writes `config.toml`
- [ ] Verify `kestrel config validate` works with TOML config
- [ ] Verify Python migration outputs valid TOML

Bahtya