### PR TITLE
feat: add config import/export with AES-256-GCM encryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ dashmap = "6"
 # DNS
 hickory-resolver = { version = "0.25", features = ["tokio"] }
 
+# Crypto
+aes-gcm = "0.10"
+argon2 = "0.5"
+
 # Misc
 uuid = { version = "1", features = ["v4"] }
 regex = "1"
@@ -126,6 +130,8 @@ chrono = { workspace = true }
 parking_lot = { workspace = true }
 async-trait = { workspace = true }
 toml = { workspace = true }
+reqwest = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/kestrel-config/Cargo.toml
+++ b/crates/kestrel-config/Cargo.toml
@@ -16,7 +16,6 @@ tracing = { workspace = true }
 ipnet = "2"
 aes-gcm = { workspace = true }
 argon2 = { workspace = true }
-rand = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kestrel-config/Cargo.toml
+++ b/crates/kestrel-config/Cargo.toml
@@ -14,6 +14,9 @@ regex = { workspace = true }
 dirs = "5"
 tracing = { workspace = true }
 ipnet = "2"
+aes-gcm = { workspace = true }
+argon2 = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kestrel-config/src/crypto.rs
+++ b/crates/kestrel-config/src/crypto.rs
@@ -1,11 +1,10 @@
 //! AES-256-GCM encryption/decryption with Argon2 key derivation.
 
+use aes_gcm::aead::rand_core::RngCore;
 use aes_gcm::aead::{Aead, KeyInit, OsRng};
-use aes_gcm::{Aes256Gcm, AeadCore, Nonce};
+use aes_gcm::{AeadCore, Aes256Gcm, Nonce};
 use anyhow::{Context, Result};
-use argon2::password_hash::SaltString;
 use argon2::Argon2;
-use rand::RngCore;
 
 const SALT_LEN: usize = 16;
 const NONCE_LEN: usize = 12;
@@ -16,7 +15,7 @@ fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
     let mut key = [0u8; 32];
     argon2
         .hash_password_into(password.as_bytes(), salt, &mut key)
-        .context("Argon2 key derivation failed")?;
+        .map_err(|e| anyhow::anyhow!("Argon2 key derivation failed: {e}"))?;
     Ok(key)
 }
 
@@ -28,8 +27,8 @@ pub fn encrypt(plaintext: &str, password: &str) -> Result<Vec<u8>> {
     OsRng.fill_bytes(&mut salt);
 
     let key = derive_key(password, &salt)?;
-    let cipher = Aes256Gcm::new_from_slice(&key)
-        .map_err(|e| anyhow::anyhow!("AES key init failed: {e}"))?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key).map_err(|e| anyhow::anyhow!("AES key init failed: {e}"))?;
 
     let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
     let ciphertext = cipher
@@ -55,8 +54,8 @@ pub fn decrypt(data: &[u8], password: &str) -> Result<String> {
     let (nonce_bytes, ciphertext) = rest.split_at(NONCE_LEN);
 
     let key = derive_key(password, salt)?;
-    let cipher = Aes256Gcm::new_from_slice(&key)
-        .map_err(|e| anyhow::anyhow!("AES key init failed: {e}"))?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key).map_err(|e| anyhow::anyhow!("AES key init failed: {e}"))?;
 
     let nonce = Nonce::from_slice(nonce_bytes);
     let plaintext = cipher

--- a/crates/kestrel-config/src/crypto.rs
+++ b/crates/kestrel-config/src/crypto.rs
@@ -1,0 +1,91 @@
+//! AES-256-GCM encryption/decryption with Argon2 key derivation.
+
+use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, AeadCore, Nonce};
+use anyhow::{Context, Result};
+use argon2::password_hash::SaltString;
+use argon2::Argon2;
+use rand::RngCore;
+
+const SALT_LEN: usize = 16;
+const NONCE_LEN: usize = 12;
+
+/// Derive a 32-byte AES key from a password and salt using Argon2id.
+fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
+    let argon2 = Argon2::default();
+    let mut key = [0u8; 32];
+    argon2
+        .hash_password_into(password.as_bytes(), salt, &mut key)
+        .context("Argon2 key derivation failed")?;
+    Ok(key)
+}
+
+/// Encrypt plaintext using AES-256-GCM with a password-derived key.
+///
+/// Binary format: `salt (16 bytes) || nonce (12 bytes) || ciphertext+tag`.
+pub fn encrypt(plaintext: &str, password: &str) -> Result<Vec<u8>> {
+    let mut salt = [0u8; SALT_LEN];
+    OsRng.fill_bytes(&mut salt);
+
+    let key = derive_key(password, &salt)?;
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|e| anyhow::anyhow!("AES key init failed: {e}"))?;
+
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Encryption failed: {e}"))?;
+
+    let mut out = Vec::with_capacity(SALT_LEN + NONCE_LEN + ciphertext.len());
+    out.extend_from_slice(&salt);
+    out.extend_from_slice(&nonce);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+/// Decrypt ciphertext produced by [`encrypt`].
+///
+/// Expects binary format: `salt (16 bytes) || nonce (12 bytes) || ciphertext+tag`.
+pub fn decrypt(data: &[u8], password: &str) -> Result<String> {
+    if data.len() < SALT_LEN + NONCE_LEN + 1 {
+        anyhow::bail!("Encrypted data too short");
+    }
+
+    let (salt, rest) = data.split_at(SALT_LEN);
+    let (nonce_bytes, ciphertext) = rest.split_at(NONCE_LEN);
+
+    let key = derive_key(password, salt)?;
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|e| anyhow::anyhow!("AES key init failed: {e}"))?;
+
+    let nonce = Nonce::from_slice(nonce_bytes);
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| anyhow::anyhow!("Decryption failed — wrong password or corrupted data"))?;
+
+    String::from_utf8(plaintext).context("Decrypted data is not valid UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let msg = "hello kestrel config";
+        let encrypted = encrypt(msg, "hunter2").unwrap();
+        let decrypted = decrypt(&encrypted, "hunter2").unwrap();
+        assert_eq!(decrypted, msg);
+    }
+
+    #[test]
+    fn wrong_password_fails() {
+        let encrypted = encrypt("secret", "correct").unwrap();
+        assert!(decrypt(&encrypted, "wrong").is_err());
+    }
+
+    #[test]
+    fn truncated_data_fails() {
+        assert!(decrypt(&[0u8; 10], "pw").is_err());
+    }
+}

--- a/crates/kestrel-config/src/lib.rs
+++ b/crates/kestrel-config/src/lib.rs
@@ -3,6 +3,7 @@
 //! Configuration loading and schema for kestrel.
 //! Uses TOML format for the config file (`config.toml`).
 
+pub mod crypto;
 pub mod loader;
 pub mod migration;
 pub mod paths;

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,6 +1,6 @@
-//! Config subcommand — validate config.toml schema and migrate from Python.
+//! Config subcommand — validate, migrate, import, and export.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use kestrel_config::Config;
 use std::path::Path;
 use tracing::info;
@@ -88,5 +88,60 @@ pub fn migrate(from: &Path, dry_run: bool) -> Result<()> {
         println!("Migration complete.");
     }
 
+    Ok(())
+}
+
+/// Import encrypted config from a URL, decrypt, validate, and save.
+pub async fn import(url: &str, password: &str) -> Result<()> {
+    info!("Downloading encrypted config from: {url}");
+
+    let response = reqwest::get(url)
+        .await
+        .with_context(|| format!("Failed to download from {url}"))?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("HTTP {} from {}", response.status(), url);
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .context("Failed to read response body")?;
+
+    info!("Downloaded {} bytes, decrypting...", bytes.len());
+
+    let toml_str = kestrel_config::crypto::decrypt(&bytes, password)
+        .context("Decryption failed — wrong password or corrupted data")?;
+
+    // Validate TOML by parsing into Config
+    let config: Config = toml::from_str(&toml_str).context("Decrypted data is not valid TOML")?;
+
+    // Run schema validation
+    let report = kestrel_config::validate(&config);
+    if !report.errors().is_empty() {
+        println!("Decrypted config has validation errors:");
+        for e in report.errors() {
+            println!("  {}", e);
+        }
+        anyhow::bail!("Import aborted — config has validation errors");
+    }
+
+    let config_path = kestrel_config::paths::get_config_path()?;
+    println!("Saving config to: {}", config_path.display());
+    kestrel_config::loader::save_config(&config, &config_path)?;
+
+    println!("Import complete.");
+    Ok(())
+}
+
+/// Export current config: encrypt with password and write to file.
+pub fn export(config: &Config, password: &str, output: &Path) -> Result<()> {
+    let toml_str = toml::to_string(config)?;
+    let encrypted = kestrel_config::crypto::encrypt(&toml_str, password)?;
+
+    std::fs::write(output, &encrypted)
+        .with_context(|| format!("Failed to write to {}", output.display()))?;
+
+    println!("Exported encrypted config to: {}", output.display());
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,27 @@ enum ConfigSubcommand {
         #[arg(long)]
         dry_run: bool,
     },
+
+    /// Import encrypted config from a URL.
+    Import {
+        /// URL to download the encrypted config file from.
+        url: String,
+
+        /// Password for decryption.
+        #[arg(long)]
+        password: String,
+    },
+
+    /// Export current config as an encrypted file.
+    Export {
+        /// Password for encryption.
+        #[arg(long)]
+        password: String,
+
+        /// Output file path.
+        #[arg(short, long, default_value = "config.toml.enc")]
+        output: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -193,6 +214,13 @@ fn main() -> Result<()> {
             }
             ConfigSubcommand::Migrate { from, dry_run } => {
                 commands::config::migrate(&from, dry_run)?;
+            }
+            ConfigSubcommand::Import { url, password } => {
+                let rt = tokio::runtime::Runtime::new()?;
+                rt.block_on(commands::config::import(&url, &password))?;
+            }
+            ConfigSubcommand::Export { password, output } => {
+                commands::config::export(&config, &password, &output)?;
             }
         },
         Commands::Setup => unreachable!("setup is handled before config loading"),


### PR DESCRIPTION
Closes #TBD

## 功能
- `kestrel config import <url> --password <pw>` — 从 URL 下载加密配置，解密后导入
- `kestrel config export --password <pw> [-o output]` — 导出当前配置并加密

## 实现
- 新增 `crates/kestrel-config/src/crypto.rs`：Argon2id 密钥派生 + AES-256-GCM 加解密
- 二进制格式：`salt(16) || nonce(12) || ciphertext+tag`
- 导入时验证 TOML 格式 + schema 校验
- 单元测试覆盖：往返、错误密码、截断数据