### PR TITLE
feat: improve Telegram /models menu UX — collapse on select, paginate large lists

### DIFF
--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -16,7 +16,7 @@ use parking_lot::RwLock;
 use tokio::sync::OnceCell;
 
 use crate::platforms::telegram::{
-    InlineKeyboardBuilder, InlineKeyboardButton, InlineKeyboardMarkup,
+    InlineKeyboardBuilder, InlineKeyboardMarkup,
 };
 
 /// Fallback model names for cycling when dynamic discovery is unavailable.
@@ -1864,27 +1864,9 @@ pub async fn handle_models_provider_detail(provider: &str, page: usize) -> Comma
 
     // Navigation row: pagination | back
     if total_pages > 1 {
-        // Pagination buttons
-        let mut nav_row = Vec::new();
-        if page > 0 {
-            nav_row.push(InlineKeyboardButton {
-                text: "◀ Prev".to_string(),
-                callback_data: Some(format!("models:ppage:{}|{}", provider, page - 1)),
-                url: None,
-            });
-        }
-        nav_row.push(InlineKeyboardButton {
-            text: format!("{}/{}", page + 1, total_pages),
-            callback_data: Some(format!("models:ppage:{}|{}", provider, page)),
-            url: None,
+        let nav_row = InlineKeyboardBuilder::pagination_row(page, total_pages, |p| {
+            format!("models:ppage:{}|{}", provider, p)
         });
-        if page + 1 < total_pages {
-            nav_row.push(InlineKeyboardButton {
-                text: "Next ▶".to_string(),
-                callback_data: Some(format!("models:ppage:{}|{}", provider, page + 1)),
-                url: None,
-            });
-        }
         kb = kb.push_row(nav_row);
     }
 

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -15,7 +15,9 @@ use std::sync::{Arc, LazyLock};
 use parking_lot::RwLock;
 use tokio::sync::OnceCell;
 
-use crate::platforms::telegram::{InlineKeyboardBuilder, InlineKeyboardButton, InlineKeyboardMarkup};
+use crate::platforms::telegram::{
+    InlineKeyboardBuilder, InlineKeyboardButton, InlineKeyboardMarkup,
+};
 
 /// Fallback model names for cycling when dynamic discovery is unavailable.
 const MODEL_CYCLE: &[&str] = &[
@@ -1829,7 +1831,7 @@ pub async fn handle_models_provider_detail(provider: &str, page: usize) -> Comma
     }
 
     let total = models.len();
-    let total_pages = (total + MODELS_PER_PAGE - 1) / MODELS_PER_PAGE;
+    let total_pages = total.div_ceil(MODELS_PER_PAGE);
     let page = page.min(total_pages.saturating_sub(1));
     let start = page * MODELS_PER_PAGE;
     let end = (start + MODELS_PER_PAGE).min(total);
@@ -3161,7 +3163,7 @@ model = "gpt-4o"
         assert!(resp.text.contains("gpt-4o"));
         assert!(resp.text.contains("opencode_go"));
         assert!(resp.text.contains("kimi-k2.6"));
-        assert!(resp.keyboard.is_some());
+        assert!(resp.keyboard.is_none());
     }
 
     #[test]

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, LazyLock};
 use parking_lot::RwLock;
 use tokio::sync::OnceCell;
 
-use crate::platforms::telegram::{InlineKeyboardBuilder, InlineKeyboardMarkup};
+use crate::platforms::telegram::{InlineKeyboardBuilder, InlineKeyboardButton, InlineKeyboardMarkup};
 
 /// Fallback model names for cycling when dynamic discovery is unavailable.
 const MODEL_CYCLE: &[&str] = &[
@@ -1807,10 +1807,13 @@ pub async fn handle_models_provider_list() -> CommandResponse {
     CommandResponse::with_keyboard(out, kb.build())
 }
 
-/// Show models for a specific provider as an inline keyboard.
+/// Models per page for the provider detail keyboard.
+const MODELS_PER_PAGE: usize = 15;
+
+/// Show models for a specific provider as an inline keyboard (paginated).
 ///
 /// Level 2: User picks a model to set as active.
-pub async fn handle_models_provider_detail(provider: &str) -> CommandResponse {
+pub async fn handle_models_provider_detail(provider: &str, page: usize) -> CommandResponse {
     let config = match load_config(None) {
         Ok(c) => c,
         Err(e) => return CommandResponse::text(format!("Failed to load config: {e}")),
@@ -1825,12 +1828,22 @@ pub async fn handle_models_provider_detail(provider: &str) -> CommandResponse {
         return CommandResponse::text(format!("No models found for provider: {}", provider));
     }
 
+    let total = models.len();
+    let total_pages = (total + MODELS_PER_PAGE - 1) / MODELS_PER_PAGE;
+    let page = page.min(total_pages.saturating_sub(1));
+    let start = page * MODELS_PER_PAGE;
+    let end = (start + MODELS_PER_PAGE).min(total);
+    let page_models = &models[start..end];
+
     let mut out = String::new();
-    let _ = writeln!(out, "[{}] models:", provider);
+    let _ = writeln!(out, "[{}] models ({} total):", provider, total);
     let _ = writeln!(out, "Current: {}", current);
+    if total_pages > 1 {
+        let _ = writeln!(out, "Page {} of {}", page + 1, total_pages);
+    }
 
     let mut kb = InlineKeyboardBuilder::new();
-    for m in &models {
+    for m in page_models {
         let marker =
             if m.id == config.agent.model && config.agent.provider.as_deref() == Some(provider) {
                 " *"
@@ -1846,6 +1859,33 @@ pub async fn handle_models_provider_detail(provider: &str) -> CommandResponse {
         kb = kb.button(&label, &data);
         kb = kb.new_row();
     }
+
+    // Navigation row: pagination | back
+    if total_pages > 1 {
+        // Pagination buttons
+        let mut nav_row = Vec::new();
+        if page > 0 {
+            nav_row.push(InlineKeyboardButton {
+                text: "◀ Prev".to_string(),
+                callback_data: Some(format!("models:ppage:{}|{}", provider, page - 1)),
+                url: None,
+            });
+        }
+        nav_row.push(InlineKeyboardButton {
+            text: format!("{}/{}", page + 1, total_pages),
+            callback_data: Some(format!("models:ppage:{}|{}", provider, page)),
+            url: None,
+        });
+        if page + 1 < total_pages {
+            nav_row.push(InlineKeyboardButton {
+                text: "Next ▶".to_string(),
+                callback_data: Some(format!("models:ppage:{}|{}", provider, page + 1)),
+                url: None,
+            });
+        }
+        kb = kb.push_row(nav_row);
+    }
+
     kb = kb.button("<< Back to providers", "models:providers");
 
     CommandResponse::with_keyboard(out, kb.build())
@@ -1881,13 +1921,7 @@ pub fn handle_models_select(qualified_id: &str) -> CommandResponse {
     let _ = writeln!(out, "Model changed:");
     let _ = writeln!(out, "  {} -> {}/{}", old, provider, model_id);
 
-    let keyboard = InlineKeyboardBuilder::new()
-        .button("Select another model", "models:providers")
-        .new_row()
-        .button("Settings", "settings:show")
-        .build();
-
-    CommandResponse::with_keyboard(out, keyboard)
+    CommandResponse::text(out)
 }
 
 /// Handle a callback from the /models inline keyboard.

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -15,9 +15,7 @@ use std::sync::{Arc, LazyLock};
 use parking_lot::RwLock;
 use tokio::sync::OnceCell;
 
-use crate::platforms::telegram::{
-    InlineKeyboardBuilder, InlineKeyboardMarkup,
-};
+use crate::platforms::telegram::{InlineKeyboardBuilder, InlineKeyboardMarkup};
 
 /// Fallback model names for cycling when dynamic discovery is unavailable.
 const MODEL_CYCLE: &[&str] = &[

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -355,6 +355,15 @@ impl InlineKeyboardBuilder {
         builder
     }
 
+    /// Append a pre-built row of buttons, flushing any pending row first.
+    pub fn push_row(mut self, row: Vec<InlineKeyboardButton>) -> Self {
+        if !self.current_row.is_empty() {
+            self.rows.push(std::mem::take(&mut self.current_row));
+        }
+        self.rows.push(row);
+        self
+    }
+
     /// Finalise: flush any pending row and return the markup.
     pub fn build(mut self) -> InlineKeyboardMarkup {
         if !self.current_row.is_empty() {
@@ -1678,7 +1687,21 @@ impl TelegramChannel {
                         "provider" => {
                             let provider = payload.as_deref().unwrap_or("");
                             let response =
-                                crate::commands::handle_models_provider_detail(provider).await;
+                                crate::commands::handle_models_provider_detail(provider, 0).await;
+                            CallbackResponse::EditMessage {
+                                text: response.text,
+                                keyboard: response.keyboard,
+                            }
+                        }
+                        "ppage" => {
+                            let raw = payload.as_deref().unwrap_or("");
+                            let (provider, page) = raw
+                                .split_once('|')
+                                .map(|(p, n)| (p, n.parse::<usize>().unwrap_or(0)))
+                                .unwrap_or((raw, 0));
+                            let response =
+                                crate::commands::handle_models_provider_detail(provider, page)
+                                    .await;
                             CallbackResponse::EditMessage {
                                 text: response.text,
                                 keyboard: response.keyboard,
@@ -1698,7 +1721,9 @@ impl TelegramChannel {
                             let response = crate::commands::handle_models_select(qualified_id);
                             CallbackResponse::EditMessage {
                                 text: response.text,
-                                keyboard: response.keyboard,
+                                keyboard: response.keyboard.or_else(|| {
+                                    Some(InlineKeyboardBuilder::new().build())
+                                }),
                             }
                         }
                         _ => CallbackResponse::Acknowledged,

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -328,29 +328,38 @@ impl InlineKeyboardBuilder {
         )
     }
 
-    /// Build a pagination keyboard with previous/next buttons.
-    pub fn pagination(prefix: &str, page: usize, total_pages: usize) -> Self {
-        let mut builder = Self::new();
+    /// Build a single pagination button row (Prev / indicator / Next).
+    pub fn pagination_row<F>(page: usize, total_pages: usize, callback: F) -> Vec<InlineKeyboardButton>
+    where
+        F: Fn(usize) -> String,
+    {
         let mut row = Vec::new();
         if page > 0 {
             row.push(InlineKeyboardButton {
                 text: "◀ Prev".to_string(),
-                callback_data: Some(format!("{prefix}:page:{}", page - 1)),
+                callback_data: Some(callback(page - 1)),
                 url: None,
             });
         }
         row.push(InlineKeyboardButton {
             text: format!("{}/{}", page + 1, total_pages),
-            callback_data: Some(format!("{prefix}:page:{page}")),
+            callback_data: Some(callback(page)),
             url: None,
         });
         if page + 1 < total_pages {
             row.push(InlineKeyboardButton {
                 text: "Next ▶".to_string(),
-                callback_data: Some(format!("{prefix}:page:{}", page + 1)),
+                callback_data: Some(callback(page + 1)),
                 url: None,
             });
         }
+        row
+    }
+
+    /// Build a pagination keyboard with previous/next buttons.
+    pub fn pagination(prefix: &str, page: usize, total_pages: usize) -> Self {
+        let row = Self::pagination_row(page, total_pages, |p| format!("{prefix}:page:{p}"));
+        let mut builder = Self::new();
         builder.rows.push(row);
         builder
     }
@@ -1696,7 +1705,7 @@ impl TelegramChannel {
                         "ppage" => {
                             let raw = payload.as_deref().unwrap_or("");
                             let (provider, page) = raw
-                                .split_once('|')
+                                .rsplit_once('|')
                                 .map(|(p, n)| (p, n.parse::<usize>().unwrap_or(0)))
                                 .unwrap_or((raw, 0));
                             let response =

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -329,7 +329,11 @@ impl InlineKeyboardBuilder {
     }
 
     /// Build a single pagination button row (Prev / indicator / Next).
-    pub fn pagination_row<F>(page: usize, total_pages: usize, callback: F) -> Vec<InlineKeyboardButton>
+    pub fn pagination_row<F>(
+        page: usize,
+        total_pages: usize,
+        callback: F,
+    ) -> Vec<InlineKeyboardButton>
     where
         F: Fn(usize) -> String,
     {

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1721,9 +1721,9 @@ impl TelegramChannel {
                             let response = crate::commands::handle_models_select(qualified_id);
                             CallbackResponse::EditMessage {
                                 text: response.text,
-                                keyboard: response.keyboard.or_else(|| {
-                                    Some(InlineKeyboardBuilder::new().build())
-                                }),
+                                keyboard: response
+                                    .keyboard
+                                    .or_else(|| Some(InlineKeyboardBuilder::new().build())),
                             }
                         }
                         _ => CallbackResponse::Acknowledged,


### PR DESCRIPTION
## Summary
- Collapse inline keyboard after model selection in /modes menu (remove buttons, keep confirmation text)
- Add pagination for providers with >15 models (◀ Prev / X/Y / Next ▶ navigation)
- callback_data format: `models:ppage:{provider}|{page}`

## Test plan
- [ ] Verify /modes → select model → menu collapses with confirmation text
- [ ] Verify provider with >15 models shows paginated keyboard with navigation
- [ ] Verify page boundary handling (first page no prev, last page no next)