### PR TITLE
feat: add kestrel doctor diagnostic command

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -213,7 +213,13 @@ async fn check_providers(config: &Config, errors: &mut usize, warnings: &mut usi
         match tokio::time::timeout(Duration::from_secs(30), provider.complete(req)).await {
             Ok(Ok(resp)) => {
                 let elapsed = start.elapsed();
-                let content_preview: String = content_preview.chars().take(30).collect();
+                let content_preview: String = resp
+                    .content
+                    .as_deref()
+                    .unwrap_or("(no content)")
+                    .chars()
+                    .take(30)
+                    .collect();
                 println!("pass ({:.1}s) — {}", elapsed.as_secs_f64(), content_preview);
             }
             Ok(Err(e)) => {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -139,10 +139,7 @@ fn check_websocket(config: &Config, errors: &mut usize, warnings: &mut usize) {
             print!("  Port {} (disabled): ", default_addr);
             match default_addr.parse::<std::net::SocketAddr>() {
                 Ok(sock_addr) => {
-                    match TcpStream::connect_timeout(
-                        &sock_addr,
-                        Duration::from_secs(3),
-                    ) {
+                    match TcpStream::connect_timeout(&sock_addr, Duration::from_secs(3)) {
                         Ok(_) => println!("listening (but disabled in config)"),
                         Err(_) => println!("nothing listening"),
                     }
@@ -216,14 +213,8 @@ async fn check_providers(config: &Config, errors: &mut usize, warnings: &mut usi
         match tokio::time::timeout(Duration::from_secs(30), provider.complete(req)).await {
             Ok(Ok(resp)) => {
                 let elapsed = start.elapsed();
-                let content_preview = resp.content.as_deref().unwrap_or("(empty)");
-                let content_preview: String =
-                    content_preview.chars().take(30).collect();
-                println!(
-                    "pass ({:.1}s) — {}",
-                    elapsed.as_secs_f64(),
-                    content_preview
-                );
+                let content_preview: String = content_preview.chars().take(30).collect();
+                println!("pass ({:.1}s) — {}", elapsed.as_secs_f64(), content_preview);
             }
             Ok(Err(e)) => {
                 *errors += 1;
@@ -288,22 +279,15 @@ async fn check_telegram(config: &Config, errors: &mut usize, _warnings: &mut usi
                         // Try to extract bot username from response
                         if let Ok(val) = serde_json::from_str::<serde_json::Value>(&body) {
                             let username = val.pointer("/result/username");
-                            let username = username
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("unknown");
-                            println!(
-                                "pass ({:.1}s) — bot @{}",
-                                elapsed.as_secs_f64(),
-                                username
-                            );
+                            let username = username.and_then(|v| v.as_str()).unwrap_or("unknown");
+                            println!("pass ({:.1}s) — bot @{}", elapsed.as_secs_f64(), username);
                         } else {
                             println!("pass ({:.1}s)", elapsed.as_secs_f64());
                         }
                     }
-                    Err(_) => println!(
-                        "pass ({:.1}s) — could not read body",
-                        elapsed.as_secs_f64()
-                    ),
+                    Err(_) => {
+                        println!("pass ({:.1}s) — could not read body", elapsed.as_secs_f64())
+                    }
                 }
             } else {
                 *errors += 1;
@@ -329,9 +313,7 @@ async fn check_telegram(config: &Config, errors: &mut usize, _warnings: &mut usi
     println!();
 }
 
-fn build_telegram_http_client(
-    proxy: Option<&str>,
-) -> Result<reqwest::Client> {
+fn build_telegram_http_client(proxy: Option<&str>) -> Result<reqwest::Client> {
     let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .dns_resolver(kestrel_core::dns::build_dns_resolver());

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use kestrel_config::paths::get_config_path;
 use kestrel_config::schema::Config;
 use kestrel_config::validate;
-use kestrel_providers::{CompletionRequest, LlmProvider, ProviderRegistry};
+use kestrel_providers::{CompletionRequest, ProviderRegistry};
 use std::net::TcpStream;
 use std::time::{Duration, Instant};
 
@@ -63,7 +63,10 @@ fn check_config_file(config: &Config, errors: &mut usize, warnings: &mut usize) 
                 }
             } else {
                 *warnings += 1;
-                println!("  Config file:    not found at {} (using defaults)", path.display());
+                println!(
+                    "  Config file:    not found at {} (using defaults)",
+                    path.display()
+                );
             }
         }
         Err(e) => {
@@ -83,7 +86,15 @@ fn check_config_file(config: &Config, errors: &mut usize, warnings: &mut usize) 
         println!("  Schema:         pass");
     } else {
         for f in report.findings() {
-            println!("  Schema {:?}: [{}] {} — {}", f.severity, f.path, f.message, if f.severity == validate::Severity::Error { "FAIL" } else { "WARN" });
+            let label = if f.severity == validate::Severity::Error {
+                "FAIL"
+            } else {
+                "WARN"
+            };
+            println!(
+                "  Schema {:?}: [{}] {} — {}",
+                f.severity, f.path, f.message, label
+            );
         }
     }
 
@@ -127,11 +138,15 @@ fn check_websocket(config: &Config, errors: &mut usize, warnings: &mut usize) {
                 .unwrap_or("127.0.0.1:8090");
             print!("  Port {} (disabled): ", default_addr);
             match default_addr.parse::<std::net::SocketAddr>() {
-                Ok(sock_addr) => match TcpStream::connect_timeout(&sock_addr, Duration::from_secs(3))
-                {
-                    Ok(_) => println!("listening (but disabled in config)"),
-                    Err(_) => println!("nothing listening"),
-                },
+                Ok(sock_addr) => {
+                    match TcpStream::connect_timeout(
+                        &sock_addr,
+                        Duration::from_secs(3),
+                    ) {
+                        Ok(_) => println!("listening (but disabled in config)"),
+                        Err(_) => println!("nothing listening"),
+                    }
+                }
                 Err(_) => println!("invalid address"),
             }
         }
@@ -201,13 +216,9 @@ async fn check_providers(config: &Config, errors: &mut usize, warnings: &mut usi
         match tokio::time::timeout(Duration::from_secs(30), provider.complete(req)).await {
             Ok(Ok(resp)) => {
                 let elapsed = start.elapsed();
-                let content_preview = resp
-                    .content
-                    .as_deref()
-                    .unwrap_or("(empty)")
-                    .chars()
-                    .take(30)
-                    .collect::<String>();
+                let content_preview = resp.content.as_deref().unwrap_or("(empty)");
+                let content_preview: String =
+                    content_preview.chars().take(30).collect();
                 println!(
                     "pass ({:.1}s) — {}",
                     elapsed.as_secs_f64(),
@@ -235,7 +246,7 @@ async fn check_providers(config: &Config, errors: &mut usize, warnings: &mut usi
 // 4. Telegram API health
 // ---------------------------------------------------------------------------
 
-async fn check_telegram(config: &Config, errors: &mut usize, warnings: &mut usize) {
+async fn check_telegram(config: &Config, errors: &mut usize, _warnings: &mut usize) {
     println!("[4/4] Telegram API health");
 
     let tg = match &config.channels.telegram {
@@ -276,8 +287,8 @@ async fn check_telegram(config: &Config, errors: &mut usize, warnings: &mut usiz
                     Ok(body) => {
                         // Try to extract bot username from response
                         if let Ok(val) = serde_json::from_str::<serde_json::Value>(&body) {
-                            let username = val
-                                .pointer("/result/username")
+                            let username = val.pointer("/result/username");
+                            let username = username
                                 .and_then(|v| v.as_str())
                                 .unwrap_or("unknown");
                             println!(
@@ -289,7 +300,10 @@ async fn check_telegram(config: &Config, errors: &mut usize, warnings: &mut usiz
                             println!("pass ({:.1}s)", elapsed.as_secs_f64());
                         }
                     }
-                    Err(_) => println!("pass ({:.1}s) — could not read body", elapsed.as_secs_f64()),
+                    Err(_) => println!(
+                        "pass ({:.1}s) — could not read body",
+                        elapsed.as_secs_f64()
+                    ),
                 }
             } else {
                 *errors += 1;

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,0 +1,333 @@
+//! Doctor command — comprehensive system diagnostics.
+
+use anyhow::Result;
+use kestrel_config::paths::get_config_path;
+use kestrel_config::schema::Config;
+use kestrel_config::validate;
+use kestrel_providers::{CompletionRequest, LlmProvider, ProviderRegistry};
+use std::net::TcpStream;
+use std::time::{Duration, Instant};
+
+/// Run all diagnostic checks.
+pub async fn run(config: &Config) -> Result<()> {
+    println!("=== Kestrel Doctor ===\n");
+
+    let mut errors = 0usize;
+    let mut warnings = 0usize;
+
+    check_config_file(config, &mut errors, &mut warnings);
+    check_websocket(config, &mut errors, &mut warnings);
+    check_providers(config, &mut errors, &mut warnings).await;
+    check_telegram(config, &mut errors, &mut warnings).await;
+
+    println!("\n--- Summary ---");
+    if errors == 0 && warnings == 0 {
+        println!("All checks passed.");
+    } else {
+        if errors > 0 {
+            println!("{} error(s) found.", errors);
+        }
+        if warnings > 0 {
+            println!("{} warning(s) found.", warnings);
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 1. Config file validation
+// ---------------------------------------------------------------------------
+
+fn check_config_file(config: &Config, errors: &mut usize, warnings: &mut usize) {
+    println!("[1/4] Config file validation");
+
+    // Check that config file exists
+    match get_config_path() {
+        Ok(path) => {
+            if path.exists() {
+                println!("  Config path:    {}", path.display());
+                // Try to re-parse the raw file
+                match std::fs::read_to_string(&path) {
+                    Ok(raw) => match toml::from_str::<Config>(&raw) {
+                        Ok(_) => println!("  Parse:          pass"),
+                        Err(e) => {
+                            *errors += 1;
+                            println!("  Parse:          FAIL — {}", e);
+                        }
+                    },
+                    Err(e) => {
+                        *errors += 1;
+                        println!("  Read:           FAIL — {}", e);
+                    }
+                }
+            } else {
+                *warnings += 1;
+                println!("  Config file:    not found at {} (using defaults)", path.display());
+            }
+        }
+        Err(e) => {
+            *errors += 1;
+            println!("  Config path:    FAIL — {}", e);
+        }
+    }
+
+    // Schema validation
+    let report = validate::validate(config);
+    let err_count = report.errors().len();
+    let warn_count = report.warnings().len();
+    *errors += err_count;
+    *warnings += warn_count;
+
+    if report.is_empty() {
+        println!("  Schema:         pass");
+    } else {
+        for f in report.findings() {
+            println!("  Schema {:?}: [{}] {} — {}", f.severity, f.path, f.message, if f.severity == validate::Severity::Error { "FAIL" } else { "WARN" });
+        }
+    }
+
+    println!();
+}
+
+// ---------------------------------------------------------------------------
+// 2. WebSocket port health
+// ---------------------------------------------------------------------------
+
+fn check_websocket(config: &Config, errors: &mut usize, warnings: &mut usize) {
+    println!("[2/4] WebSocket port health");
+
+    match &config.channels.websocket {
+        Some(ws) if ws.enabled => {
+            let addr = &ws.listen_addr;
+            match addr.parse::<std::net::SocketAddr>() {
+                Ok(sock_addr) => {
+                    print!("  Port {}: ", addr);
+                    match TcpStream::connect_timeout(&sock_addr, Duration::from_secs(5)) {
+                        Ok(_) => println!("listening"),
+                        Err(e) => {
+                            *errors += 1;
+                            println!("FAIL — {}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    *warnings += 1;
+                    println!("  Port {}: FAIL — invalid address: {}", addr, e);
+                }
+            }
+        }
+        _ => {
+            // WebSocket not configured or disabled — check if anything is listening anyway
+            let default_addr = config
+                .channels
+                .websocket
+                .as_ref()
+                .map(|ws| ws.listen_addr.as_str())
+                .unwrap_or("127.0.0.1:8090");
+            print!("  Port {} (disabled): ", default_addr);
+            match default_addr.parse::<std::net::SocketAddr>() {
+                Ok(sock_addr) => match TcpStream::connect_timeout(&sock_addr, Duration::from_secs(3))
+                {
+                    Ok(_) => println!("listening (but disabled in config)"),
+                    Err(_) => println!("nothing listening"),
+                },
+                Err(_) => println!("invalid address"),
+            }
+        }
+    }
+
+    println!();
+}
+
+// ---------------------------------------------------------------------------
+// 3. Provider model availability
+// ---------------------------------------------------------------------------
+
+async fn check_providers(config: &Config, errors: &mut usize, warnings: &mut usize) {
+    println!("[3/4] Provider model availability");
+
+    let registry = match ProviderRegistry::from_config(config) {
+        Ok(r) => r,
+        Err(e) => {
+            *errors += 1;
+            println!("  Registry:       FAIL — {}", e);
+            println!();
+            return;
+        }
+    };
+
+    let names = registry.provider_names();
+    if names.is_empty() {
+        *warnings += 1;
+        println!("  No providers configured.");
+        println!();
+        return;
+    }
+
+    for name in &names {
+        let provider = match registry.get_provider(name) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let model = provider.default_model();
+        let model_display = if model.is_empty() {
+            config.agent.model.as_str()
+        } else {
+            model
+        };
+
+        print!("  {} ({}): ", name, model_display);
+
+        let req = CompletionRequest {
+            model: model_display.to_string(),
+            messages: vec![kestrel_core::Message {
+                role: kestrel_core::MessageRole::User,
+                content: "hi".to_string(),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+                reasoning_content: None,
+            }],
+            tools: None,
+            max_tokens: Some(5),
+            temperature: Some(0.0),
+            stream: false,
+            reasoning_effort: None,
+        };
+
+        let start = Instant::now();
+        match tokio::time::timeout(Duration::from_secs(30), provider.complete(req)).await {
+            Ok(Ok(resp)) => {
+                let elapsed = start.elapsed();
+                let content_preview = resp
+                    .content
+                    .as_deref()
+                    .unwrap_or("(empty)")
+                    .chars()
+                    .take(30)
+                    .collect::<String>();
+                println!(
+                    "pass ({:.1}s) — {}",
+                    elapsed.as_secs_f64(),
+                    content_preview
+                );
+            }
+            Ok(Err(e)) => {
+                *errors += 1;
+                // Extract a concise error message
+                let msg = format!("{}", e);
+                let short = msg.lines().next().unwrap_or(&msg);
+                println!("FAIL — {}", short);
+            }
+            Err(_) => {
+                *errors += 1;
+                println!("FAIL — timeout (30s)");
+            }
+        }
+    }
+
+    println!();
+}
+
+// ---------------------------------------------------------------------------
+// 4. Telegram API health
+// ---------------------------------------------------------------------------
+
+async fn check_telegram(config: &Config, errors: &mut usize, warnings: &mut usize) {
+    println!("[4/4] Telegram API health");
+
+    let tg = match &config.channels.telegram {
+        Some(tg) if tg.enabled && !tg.token.is_empty() => tg,
+        Some(tg) if !tg.token.is_empty() => {
+            println!("  Telegram disabled in config — skipping");
+            println!();
+            return;
+        }
+        _ => {
+            println!("  Not configured — skipping");
+            println!();
+            return;
+        }
+    };
+
+    let url = format!("https://api.telegram.org/bot{}/getMe", tg.token);
+
+    let client = build_telegram_http_client(tg.proxy.as_deref());
+    let client = match client {
+        Ok(c) => c,
+        Err(e) => {
+            *errors += 1;
+            println!("  HTTP client:    FAIL — {}", e);
+            println!();
+            return;
+        }
+    };
+
+    print!("  getMe:          ");
+    let start = Instant::now();
+    match tokio::time::timeout(Duration::from_secs(15), client.get(&url).send()).await {
+        Ok(Ok(resp)) => {
+            let elapsed = start.elapsed();
+            let status = resp.status();
+            if status.is_success() {
+                match resp.text().await {
+                    Ok(body) => {
+                        // Try to extract bot username from response
+                        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&body) {
+                            let username = val
+                                .pointer("/result/username")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown");
+                            println!(
+                                "pass ({:.1}s) — bot @{}",
+                                elapsed.as_secs_f64(),
+                                username
+                            );
+                        } else {
+                            println!("pass ({:.1}s)", elapsed.as_secs_f64());
+                        }
+                    }
+                    Err(_) => println!("pass ({:.1}s) — could not read body", elapsed.as_secs_f64()),
+                }
+            } else {
+                *errors += 1;
+                if status.as_u16() == 401 {
+                    println!("FAIL — unauthorized (invalid bot token)");
+                } else {
+                    println!("FAIL — HTTP {}", status);
+                }
+            }
+        }
+        Ok(Err(e)) => {
+            *errors += 1;
+            let msg = format!("{}", e);
+            let short = msg.lines().next().unwrap_or(&msg);
+            println!("FAIL — {}", short);
+        }
+        Err(_) => {
+            *errors += 1;
+            println!("FAIL — timeout (15s)");
+        }
+    }
+
+    println!();
+}
+
+fn build_telegram_http_client(
+    proxy: Option<&str>,
+) -> Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .dns_resolver(kestrel_core::dns::build_dns_resolver());
+
+    if let Some(proxy_url) = proxy {
+        if !proxy_url.is_empty() {
+            let proxy = reqwest::Proxy::all(proxy_url)?;
+            builder = builder.proxy(proxy);
+        }
+    }
+
+    Ok(builder.build()?)
+}

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -5,6 +5,7 @@ use kestrel_config::paths::get_config_path;
 use kestrel_config::schema::Config;
 use kestrel_config::validate;
 use kestrel_providers::{CompletionRequest, ProviderRegistry};
+use std::io::Write;
 use std::net::TcpStream;
 use std::time::{Duration, Instant};
 
@@ -30,6 +31,10 @@ pub async fn run(config: &Config) -> Result<()> {
         if warnings > 0 {
             println!("{} warning(s) found.", warnings);
         }
+    }
+
+    if errors > 0 {
+        std::process::exit(1);
     }
 
     Ok(())
@@ -114,6 +119,7 @@ fn check_websocket(config: &Config, errors: &mut usize, warnings: &mut usize) {
             match addr.parse::<std::net::SocketAddr>() {
                 Ok(sock_addr) => {
                     print!("  Port {}: ", addr);
+                    let _ = std::io::stdout().flush();
                     match TcpStream::connect_timeout(&sock_addr, Duration::from_secs(5)) {
                         Ok(_) => println!("listening"),
                         Err(e) => {
@@ -137,6 +143,7 @@ fn check_websocket(config: &Config, errors: &mut usize, warnings: &mut usize) {
                 .map(|ws| ws.listen_addr.as_str())
                 .unwrap_or("127.0.0.1:8090");
             print!("  Port {} (disabled): ", default_addr);
+            let _ = std::io::stdout().flush();
             match default_addr.parse::<std::net::SocketAddr>() {
                 Ok(sock_addr) => {
                     match TcpStream::connect_timeout(&sock_addr, Duration::from_secs(3)) {
@@ -191,6 +198,7 @@ async fn check_providers(config: &Config, errors: &mut usize, warnings: &mut usi
         };
 
         print!("  {} ({}): ", name, model_display);
+        let _ = std::io::stdout().flush();
 
         let req = CompletionRequest {
             model: model_display.to_string(),
@@ -248,8 +256,14 @@ async fn check_telegram(config: &Config, errors: &mut usize, _warnings: &mut usi
 
     let tg = match &config.channels.telegram {
         Some(tg) if tg.enabled && !tg.token.is_empty() => tg,
-        Some(tg) if !tg.token.is_empty() => {
+        Some(tg) if !tg.enabled && !tg.token.is_empty() => {
             println!("  Telegram disabled in config — skipping");
+            println!();
+            return;
+        }
+        Some(tg) if tg.token.is_empty() => {
+            *errors += 1;
+            println!("  Token:          FAIL — empty bot token");
             println!();
             return;
         }
@@ -274,6 +288,7 @@ async fn check_telegram(config: &Config, errors: &mut usize, _warnings: &mut usi
     };
 
     print!("  getMe:          ");
+    let _ = std::io::stdout().flush();
     let start = Instant::now();
     match tokio::time::timeout(Duration::from_secs(15), client.get(&url).send()).await {
         Ok(Ok(resp)) => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod agent;
 pub mod config;
 pub mod cron;
 pub mod daemon;
+pub mod doctor;
 pub mod gateway;
 pub mod health;
 pub mod heartbeat;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,9 @@ enum Commands {
     /// Show current configuration and status.
     Status,
 
+    /// Run comprehensive system diagnostics.
+    Doctor,
+
     /// Daemon management commands (Unix only).
     Daemon {
         #[command(subcommand)]
@@ -226,6 +229,10 @@ fn main() -> Result<()> {
         Commands::Setup => unreachable!("setup is handled before config loading"),
         Commands::Status => {
             commands::status::run(&config)?;
+        }
+        Commands::Doctor => {
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(commands::doctor::run(&config))?;
         }
         Commands::Daemon { subcommand } => {
             let action = match subcommand {


### PR DESCRIPTION
## Summary
- Add `kestrel doctor` CLI subcommand that runs a suite of diagnostic checks against the current configuration and environment
- 4 checks: config file validation (parse + schema), WebSocket port health, LLM provider connectivity (sends a minimal completion request to each configured provider), and Telegram Bot API health (`getMe` with proxy support)

## Details
- `src/commands/doctor.rs` — single new file (~330 lines) containing all checks
- Prints a structured report with pass/fail per check, error/warning counts, and a final summary
- Uses existing `kestrel_config` / `kestrel_providers` / `kestrel_core` crates; no new dependencies

## Test plan
- [ ] CI passes (`cargo check` / `cargo clippy` / `cargo test`)
- [ ] `kestrel doctor` prints all 4 sections and exits 0 on a healthy config
- [ ] `kestrel doctor` reports errors for misconfigured providers / missing config

Bahtya