### PR TITLE
feat: add GLM Coding Plan (智谱) as built-in provider

### DIFF
--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -1166,6 +1166,9 @@ fn collect_settings(config: &Config) -> Vec<String> {
     if config.providers.opencode_go.is_some() {
         providers.push("opencode_go");
     }
+    if config.providers.glm_coding_plan.is_some() {
+        providers.push("glm_coding_plan");
+    }
     for cp in &config.custom_providers {
         providers.push(&cp.name);
     }
@@ -1555,6 +1558,9 @@ fn build_summary(config: &Config) -> String {
     if config.providers.opencode_go.is_some() {
         providers.push("opencode_go");
     }
+    if config.providers.glm_coding_plan.is_some() {
+        providers.push("glm_coding_plan");
+    }
     for cp in &config.custom_providers {
         providers.push(&cp.name);
     }
@@ -1704,6 +1710,9 @@ fn handle_status() -> String {
     }
     if let Some(ref p) = config.providers.openai_codex {
         providers.push(format_key_status("openai_codex", p.api_key.as_deref()));
+    }
+    if let Some(ref p) = config.providers.glm_coding_plan {
+        providers.push(format_key_status("glm_coding_plan", p.api_key.as_deref()));
     }
     for cp in &config.custom_providers {
         providers.push(format!("{} (custom)", cp.name));

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -1711,6 +1711,9 @@ fn handle_status() -> String {
     if let Some(ref p) = config.providers.openai_codex {
         providers.push(format_key_status("openai_codex", p.api_key.as_deref()));
     }
+    if let Some(ref p) = config.providers.opencode_go {
+        providers.push(format_key_status("opencode_go", p.api_key.as_deref()));
+    }
     if let Some(ref p) = config.providers.glm_coding_plan {
         providers.push(format_key_status("glm_coding_plan", p.api_key.as_deref()));
     }

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -170,6 +170,9 @@ pub struct ProvidersConfig {
     /// OpenCode Go provider settings (https://opencode.ai/go).
     #[serde(default)]
     pub opencode_go: Option<ProviderEntry>,
+    /// GLM Coding Plan (智谱) provider settings (https://open.bigmodel.cn).
+    #[serde(default)]
+    pub glm_coding_plan: Option<ProviderEntry>,
 }
 
 /// A generic provider entry with API key and optional base URL.

--- a/crates/kestrel-providers/src/discovery.rs
+++ b/crates/kestrel-providers/src/discovery.rs
@@ -277,6 +277,25 @@ pub fn build_catalog(config: &kestrel_config::schema::Config) -> ModelCatalog {
         }
     }
 
+    // GLM Coding Plan (智谱) — OpenAI-compatible dynamic model fetching.
+    if let Some(entry) = &config.providers.glm_coding_plan {
+        if let Some(api_key) = &entry.api_key {
+            let base_url = entry
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://open.bigmodel.cn/api/coding/paas/v4".to_string());
+            catalog.register(
+                "glm_coding_plan",
+                Arc::new(OpenAiCompatDiscovery::new(
+                    base_url,
+                    api_key.clone(),
+                    "glm_coding_plan".to_string(),
+                    entry.no_proxy.unwrap_or(false),
+                )),
+            );
+        }
+    }
+
     // Any OpenAI-compatible provider with an API key can potentially list models.
     // Register discovery for the built-in providers that expose /v1/models.
     let builtins: Vec<(&str, Option<&kestrel_config::schema::ProviderEntry>, &str)> = vec![

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -178,6 +178,24 @@ impl ProviderRegistry {
             }
         }
 
+        // Register GLM Coding Plan provider (智谱 — OpenAI-compatible endpoint)
+        if let Some(entry) = &config.providers.glm_coding_plan {
+            if let Some(api_key) = &entry.api_key {
+                let provider = OpenAiCompatProvider::new(OpenAiCompatConfig {
+                    api_key: api_key.clone(),
+                    base_url: entry
+                        .base_url
+                        .clone()
+                        .unwrap_or_else(|| "https://open.bigmodel.cn/api/coding/paas/v4".to_string()),
+                    model: entry.model.clone().unwrap_or_default(),
+                    organization: None,
+                    no_proxy: entry.no_proxy.unwrap_or(false),
+                })?;
+                registry.register("glm_coding_plan", provider);
+                info!("Registered GLM Coding Plan provider");
+            }
+        }
+
         // Register custom providers
         for custom in &config.custom_providers {
             let provider = OpenAiCompatProvider::new(OpenAiCompatConfig {

--- a/crates/kestrel-providers/src/registry.rs
+++ b/crates/kestrel-providers/src/registry.rs
@@ -183,10 +183,9 @@ impl ProviderRegistry {
             if let Some(api_key) = &entry.api_key {
                 let provider = OpenAiCompatProvider::new(OpenAiCompatConfig {
                     api_key: api_key.clone(),
-                    base_url: entry
-                        .base_url
-                        .clone()
-                        .unwrap_or_else(|| "https://open.bigmodel.cn/api/coding/paas/v4".to_string()),
+                    base_url: entry.base_url.clone().unwrap_or_else(|| {
+                        "https://open.bigmodel.cn/api/coding/paas/v4".to_string()
+                    }),
                     model: entry.model.clone().unwrap_or_default(),
                     organization: None,
                     no_proxy: entry.no_proxy.unwrap_or(false),

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -23,6 +23,7 @@ const PROVIDER_NAMES: &[&str] = &[
     "minimax",
     "github_copilot",
     "openai_codex",
+    "glm_coding_plan",
 ];
 
 const TOTAL_STEPS: usize = 5;
@@ -328,6 +329,7 @@ fn configure_provider(io: &dyn WizardIo, config: &mut Config) -> Result<()> {
         "minimax" => "MiniMax-Text-01",
         "github_copilot" => "gpt-4o",
         "openai_codex" => "codex-mini",
+        "glm_coding_plan" => "glm-5.1",
         _ => "gpt-4o",
     };
 
@@ -352,6 +354,7 @@ fn configure_provider(io: &dyn WizardIo, config: &mut Config) -> Result<()> {
         "minimax" => "https://api.minimax.chat/v1",
         "github_copilot" => "https://api.githubcopilot.com",
         "openai_codex" => "https://api.openai.com/v1",
+        "glm_coding_plan" => "https://open.bigmodel.cn/api/coding/paas/v4",
         _ => "",
     };
 
@@ -518,19 +521,126 @@ fn get_provider_entry_mut<'a>(
     config: &'a mut Config,
     provider: &str,
 ) -> Option<&'a mut ProviderEntry> {
-    provider_field!(config, provider, mut)?.as_mut()
+    match provider {
+        "anthropic" => config.providers.anthropic.as_mut(),
+        "openai" => config.providers.openai.as_mut(),
+        "openrouter" => config.providers.openrouter.as_mut(),
+        "ollama" => config.providers.ollama.as_mut(),
+        "deepseek" => config.providers.deepseek.as_mut(),
+        "gemini" => config.providers.gemini.as_mut(),
+        "groq" => config.providers.groq.as_mut(),
+        "moonshot" => config.providers.moonshot.as_mut(),
+        "minimax" => config.providers.minimax.as_mut(),
+        "github_copilot" => config.providers.github_copilot.as_mut(),
+        "openai_codex" => config.providers.openai_codex.as_mut(),
+        "opencode_go" => config.providers.opencode_go.as_mut(),
+        "glm_coding_plan" => config.providers.glm_coding_plan.as_mut(),
+        _ => None,
+    }
 }
 
 fn ensure_provider_entry(config: &mut Config, provider: &str) {
-    if let Some(field) = provider_field!(config, provider, mut) {
-        field.get_or_insert_with(ProviderEntry::default);
+    match provider {
+        "anthropic" => {
+            config
+                .providers
+                .anthropic
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "openai" => {
+            config
+                .providers
+                .openai
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "openrouter" => {
+            config
+                .providers
+                .openrouter
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "ollama" => {
+            config
+                .providers
+                .ollama
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "deepseek" => {
+            config
+                .providers
+                .deepseek
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "gemini" => {
+            config
+                .providers
+                .gemini
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "groq" => {
+            config
+                .providers
+                .groq
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "moonshot" => {
+            config
+                .providers
+                .moonshot
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "minimax" => {
+            config
+                .providers
+                .minimax
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "github_copilot" => {
+            config
+                .providers
+                .github_copilot
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "openai_codex" => {
+            config
+                .providers
+                .openai_codex
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "opencode_go" => {
+            config
+                .providers
+                .opencode_go
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        "glm_coding_plan" => {
+            config
+                .providers
+                .glm_coding_plan
+                .get_or_insert_with(ProviderEntry::default);
+        }
+        _ => {}
     }
 }
 
 fn get_provider_url<'a>(config: &'a Config, provider: &str) -> Option<&'a str> {
-    provider_field!(config, provider)?
-        .as_ref()
-        .and_then(|e| e.base_url.as_deref())
+    let entry = match provider {
+        "anthropic" => config.providers.anthropic.as_ref(),
+        "openai" => config.providers.openai.as_ref(),
+        "openrouter" => config.providers.openrouter.as_ref(),
+        "ollama" => config.providers.ollama.as_ref(),
+        "deepseek" => config.providers.deepseek.as_ref(),
+        "gemini" => config.providers.gemini.as_ref(),
+        "groq" => config.providers.groq.as_ref(),
+        "moonshot" => config.providers.moonshot.as_ref(),
+        "minimax" => config.providers.minimax.as_ref(),
+        "github_copilot" => config.providers.github_copilot.as_ref(),
+        "openai_codex" => config.providers.openai_codex.as_ref(),
+        "opencode_go" => config.providers.opencode_go.as_ref(),
+        "glm_coding_plan" => config.providers.glm_coding_plan.as_ref(),
+        _ => None,
+    };
+    entry.and_then(|e| e.base_url.as_deref())
 }
 
 fn set_provider_url(config: &mut Config, provider: &str, url: &str) {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -95,6 +95,7 @@ impl WizardIo for TermWizard<'_> {
 
 // ── Provider dispatch macro (single source of truth) ───────────
 
+#[allow(unused_macros)]
 macro_rules! provider_field {
     ($config:expr, $provider:expr, mut) => {
         match $provider {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -29,6 +29,7 @@ pub fn run(config: &Config) -> Result<()> {
         ("Ollama", config.providers.ollama.as_ref()),
         ("Gemini", config.providers.gemini.as_ref()),
         ("OpenCode Go", config.providers.opencode_go.as_ref()),
+        ("GLM Coding Plan", config.providers.glm_coding_plan.as_ref()),
     ];
     for (name, entry) in &provider_entries {
         let status = match entry {


### PR DESCRIPTION
## Summary

- Adds GLM Coding Plan (https://open.bigmodel.cn/api/coding/paas/v4) as a built-in provider alongside OpenCode Go
- Default base URL: `https://open.bigmodel.cn/api/coding/paas/v4`
- Supports dynamic model discovery via `/v1/models` endpoint
- Default model: `glm-5.1`

## Changes

- `schema.rs` — `glm_coding_plan: Option<ProviderEntry>` field
- `registry.rs` — Registered GLM provider with default base URL
- `discovery.rs` — Model discovery via `/v1/models`
- `commands.rs` — Shows in `/status`, `/settings`, `/validate`, `/models` (two-level menu: provider → model)
- `setup.rs` — Selectable in setup wizard
- `status.rs` — Visible in CLI status

## Available GLM models

glm-4.5, glm-4.5-air, glm-4.6, glm-4.7, glm-5, glm-5-turbo, glm-5.1

## Test plan

- [ ] Configure `glm_coding_plan` with API key in config.yaml
- [ ] Use `/models` to verify GLM appears in provider list
- [ ] Select GLM provider → verify model list loads via discovery
- [ ] Select a GLM model → verify it's saved to config
- [ ] CI passes (build, clippy, tests)