### PR TITLE
feat: add Feishu (Lark) channel support with webhook and setup

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"3a67e6c8-1e35-4384-be3e-704285471714","pid":2019776,"acquiredAt":1777221650783}
+{"sessionId":"312edcd4-f169-4f76-9fca-8186fc3d11ea","pid":79326,"procStart":"8400162","acquiredAt":1778055411342}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -727,18 +727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,7 +750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1045,36 +1033,11 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "idna",
  "ipnet",
  "jni",
  "rand 0.10.1",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1104,27 +1067,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.4",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -1132,7 +1074,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni",
@@ -1827,7 +1769,7 @@ name = "kestrel-core"
 version = "0.6.0"
 dependencies = [
  "chrono",
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "reqwest",
  "serde",
  "serde_json",
@@ -2346,7 +2288,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2832,7 +2774,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "hickory-resolver 0.25.2",
  "http",
  "http-body",
  "http-body-util",
@@ -2841,7 +2782,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2926,7 +2866,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3177,7 +3117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3431,7 +3371,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4165,7 +4105,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +133,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -305,6 +367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +421,19 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -438,7 +523,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -518,6 +613,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +633,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -570,6 +679,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-as-inner"
@@ -821,6 +936,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1229,6 +1354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,12 +1491,15 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "chrono",
  "clap",
+ "console",
+ "dialoguer",
  "futures",
  "kestrel-agent",
  "kestrel-api",
@@ -1381,7 +1518,9 @@ dependencies = [
  "kestrel-skill",
  "kestrel-test-utils",
  "kestrel-tools",
+ "owo-colors",
  "parking_lot",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1394,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1423,13 +1562,14 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "kestrel-api"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1439,6 +1579,7 @@ dependencies = [
  "http-body-util",
  "kestrel-agent",
  "kestrel-bus",
+ "kestrel-channels",
  "kestrel-config",
  "kestrel-core",
  "kestrel-heartbeat",
@@ -1460,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1472,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1500,9 +1641,11 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
+ "argon2",
  "clap",
  "dirs",
  "ipnet",
@@ -1512,12 +1655,13 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "toml",
  "tracing",
 ]
 
 [[package]]
 name = "kestrel-core"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1525,11 +1669,13 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "kestrel-cron"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1548,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1567,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1591,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1612,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1634,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1655,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1668,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1686,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1705,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1721,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2072,6 +2218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2274,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2180,6 +2349,18 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2335,7 +2516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2345,7 +2526,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2708,6 +2898,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3422,10 +3618,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -140,7 +140,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -353,6 +353,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +434,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +457,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +477,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -934,6 +974,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -993,6 +1034,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto 0.26.1",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,11 +1073,31 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
  "tracing",
  "url",
 ]
@@ -1025,14 +1110,40 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1389,6 +1500,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1465,6 +1579,55 @@ dependencies = [
  "phf",
  "regex",
  "rustc-hash",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1664,7 +1827,7 @@ name = "kestrel-core"
 version = "0.6.0"
 dependencies = [
  "chrono",
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -1839,7 +2002,7 @@ dependencies = [
  "dirs",
  "kestrel-core",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "tempfile",
@@ -2123,6 +2286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,7 +2526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2390,6 +2559,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -2462,7 +2642,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2520,6 +2700,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2737,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2635,7 +2832,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "http",
  "http-body",
  "http-body-util",
@@ -2709,6 +2906,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2886,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2920,6 +3126,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3011,6 +3233,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3567,7 +3810,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = "2"
 anyhow = "1"
 
 # HTTP
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "socks", "rustls-tls-webpki-roots", "hickory-dns"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "socks", "rustls-tls-webpki-roots"] }
 axum = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ parking_lot = "0.12"
 dashmap = "6"
 
 # DNS
-hickory-resolver = { version = "0.25", features = ["tokio"] }
+hickory-resolver = { version = "0.26", features = ["tokio"] }
 
 # Crypto
 aes-gcm = "0.10"

--- a/crates/kestrel-api/Cargo.toml
+++ b/crates/kestrel-api/Cargo.toml
@@ -12,6 +12,7 @@ kestrel-agent = { path = "../kestrel-agent" }
 kestrel-providers = { path = "../kestrel-providers" }
 kestrel-tools = { path = "../kestrel-tools" }
 kestrel-heartbeat = { path = "../kestrel-heartbeat" }
+kestrel-channels = { path = "../kestrel-channels" }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/kestrel-api/src/server.rs
+++ b/crates/kestrel-api/src/server.rs
@@ -992,11 +992,19 @@ async fn feishu_webhook(
                         warn!("Feishu webhook: failed to forward message: {e}");
                     }
                 }
-                (StatusCode::OK, [(CONTENT_TYPE, "application/json")], "{}".to_string())
+                (
+                    StatusCode::OK,
+                    [(CONTENT_TYPE, "application/json")],
+                    "{}".to_string(),
+                )
             }
             WebhookResult::Ignored => {
                 debug!("Feishu webhook: ignored event");
-                (StatusCode::OK, [(CONTENT_TYPE, "application/json")], "{}".to_string())
+                (
+                    StatusCode::OK,
+                    [(CONTENT_TYPE, "application/json")],
+                    "{}".to_string(),
+                )
             }
         },
         Err(e) => {

--- a/crates/kestrel-api/src/server.rs
+++ b/crates/kestrel-api/src/server.rs
@@ -162,7 +162,8 @@ impl ApiServer {
         let public_routes = Router::new()
             .route("/v1/models", get(list_models))
             .route("/health", get(health))
-            .route("/ready", get(ready));
+            .route("/ready", get(ready))
+            .route("/feishu/webhook", post(feishu_webhook));
 
         let protected_routes = Router::new()
             .route("/v1/chat/completions", post(chat_completions))
@@ -957,6 +958,55 @@ async fn ready(State(state): State<AppState>) -> impl IntoResponse {
                 "reason": "No health checks run yet",
             })),
         ),
+    }
+}
+
+// ─── Feishu Webhook ──────────────────────────────────────────
+
+/// Handle incoming Feishu webhook events.
+///
+/// Feishu sends two types of requests:
+/// - **URL verification**: responds with the challenge token for initial setup.
+/// - **Event callback**: extracts messages and forwards them to the message bus.
+async fn feishu_webhook(
+    State(state): State<AppState>,
+    body: axum::body::Bytes,
+) -> impl IntoResponse {
+    use kestrel_channels::{parse_webhook, WebhookResult};
+
+    match parse_webhook(&body) {
+        Ok(result) => match result {
+            WebhookResult::Challenge(json_str) => {
+                info!("Feishu webhook: URL verification challenge");
+                (
+                    StatusCode::OK,
+                    [(CONTENT_TYPE, "application/json")],
+                    json_str,
+                )
+            }
+            WebhookResult::Messages(messages) => {
+                let tx = state.bus.inbound_sender();
+                for msg in messages {
+                    debug!("Feishu webhook: forwarding message from {}", msg.chat_id);
+                    if let Err(e) = tx.send(msg).await {
+                        warn!("Feishu webhook: failed to forward message: {e}");
+                    }
+                }
+                (StatusCode::OK, [(CONTENT_TYPE, "application/json")], "{}".to_string())
+            }
+            WebhookResult::Ignored => {
+                debug!("Feishu webhook: ignored event");
+                (StatusCode::OK, [(CONTENT_TYPE, "application/json")], "{}".to_string())
+            }
+        },
+        Err(e) => {
+            warn!("Feishu webhook: parse error: {e}");
+            (
+                StatusCode::BAD_REQUEST,
+                [(CONTENT_TYPE, "application/json")],
+                format!("{{\"error\":\"{e}\"}}"),
+            )
+        }
     }
 }
 

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -1668,6 +1668,19 @@ fn handle_status() -> String {
         };
         channels.push(format!("discord: {}", state));
     }
+    if let Some(ref fs) = config.channels.feishu {
+        let state = if fs.enabled {
+            if std::env::var("FEISHU_APP_ID").is_ok() && std::env::var("FEISHU_APP_SECRET").is_ok()
+            {
+                "connected"
+            } else {
+                "configured (no credentials)"
+            }
+        } else {
+            "disabled"
+        };
+        channels.push(format!("feishu: {}", state));
+    }
     if channels.is_empty() {
         channels.push("(none)".to_string());
     }

--- a/crates/kestrel-channels/src/lib.rs
+++ b/crates/kestrel-channels/src/lib.rs
@@ -16,12 +16,12 @@ pub use commands::{
     SETTINGS_PER_PAGE,
 };
 pub use manager::ChannelManager;
+pub use platforms::feishu::{parse_webhook, FeishuChannel, WebhookResult};
 pub use platforms::telegram::{
     CallbackAction, CallbackContext, CallbackResponse, CallbackRouter, InlineKeyboardBuilder,
     InlineKeyboardButton, InlineKeyboardMarkup,
 };
 pub use platforms::websocket::{run_ws_stream_consumer, WebSocketChannel};
-pub use platforms::feishu::{parse_webhook, FeishuChannel, WebhookResult};
 pub use registry::ChannelRegistry;
 pub use stream_consumer::{split_message, StreamConsumer};
 

--- a/crates/kestrel-channels/src/lib.rs
+++ b/crates/kestrel-channels/src/lib.rs
@@ -21,6 +21,7 @@ pub use platforms::telegram::{
     InlineKeyboardButton, InlineKeyboardMarkup,
 };
 pub use platforms::websocket::{run_ws_stream_consumer, WebSocketChannel};
+pub use platforms::feishu::{parse_webhook, FeishuChannel, WebhookResult};
 pub use registry::ChannelRegistry;
 pub use stream_consumer::{split_message, StreamConsumer};
 

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -172,7 +172,8 @@ pub enum WebhookResult {
 ///   during initial setup; respond with the same challenge string.
 /// - **Event callback**: Extracts message content and returns InboundMessage(s).
 pub fn parse_webhook(body: &[u8]) -> Result<WebhookResult> {
-    let event: WebhookEvent = serde_json::from_slice(body).context("invalid Feishu webhook JSON")?;
+    let event: WebhookEvent =
+        serde_json::from_slice(body).context("invalid Feishu webhook JSON")?;
 
     // URL verification challenge.
     if let Some(challenge) = &event.challenge {
@@ -258,7 +259,10 @@ pub fn parse_webhook(body: &[u8]) -> Result<WebhookResult> {
 
     let mut metadata = HashMap::new();
     if let Some(ref mid) = message_id {
-        metadata.insert("message_id".to_string(), serde_json::Value::String(mid.clone()));
+        metadata.insert(
+            "message_id".to_string(),
+            serde_json::Value::String(mid.clone()),
+        );
     }
 
     let inbound = InboundMessage {
@@ -354,9 +358,7 @@ fn parse_post_content(content: Option<&str>) -> String {
         .remove("zh_cn")
         .or_else(|| lang_posts.remove("en_us"))
         .or_else(|| lang_posts.into_values().next())
-        .unwrap_or(PostContent {
-            content: vec![],
-        });
+        .unwrap_or(PostContent { content: vec![] });
 
     let mut result = String::new();
     for line in &post.content {
@@ -645,9 +647,7 @@ impl FeishuChannel {
         content: &str,
         msg_type: &str,
     ) -> Result<SendResult> {
-        let url = format!(
-            "{FEISHU_BASE_URL}/im/v1/messages/{message_id}/reply"
-        );
+        let url = format!("{FEISHU_BASE_URL}/im/v1/messages/{message_id}/reply");
         let body = serde_json::json!({
             "msg_type": msg_type,
             "content": content,
@@ -667,10 +667,7 @@ impl FeishuChannel {
     }
 
     /// Handle the response from a send/reply API call.
-    async fn handle_send_response(
-        &self,
-        resp: reqwest::Response,
-    ) -> Result<SendResult> {
+    async fn handle_send_response(&self, resp: reqwest::Response) -> Result<SendResult> {
         let status = resp.status();
         let body: serde_json::Value = resp
             .json()
@@ -934,10 +931,7 @@ mod tests {
                 assert_eq!(msg.content, "hello feishu");
                 assert_eq!(msg.sender_id, "ou_user123");
                 assert_eq!(msg.message_id, Some("msg_abc".to_string()));
-                assert_eq!(
-                    msg.source.as_ref().unwrap().chat_type,
-                    "group"
-                );
+                assert_eq!(msg.source.as_ref().unwrap().chat_type, "group");
             }
             _ => panic!("Expected Messages result"),
         }

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -425,12 +425,19 @@ fn parse_image_content(content: Option<&str>, _chat_id: String) -> (String, Vec<
 pub struct FeishuChannel {
     app_id: String,
     app_secret: String,
+    #[allow(dead_code)]
     proxy: Option<String>,
     message_handler: Option<tokio::sync::mpsc::Sender<InboundMessage>>,
     running: Arc<AtomicBool>,
     client: reqwest::Client,
     access_token: Arc<Mutex<Option<String>>>,
     token_expires_at: Arc<Mutex<Instant>>,
+}
+
+impl Default for FeishuChannel {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FeishuChannel {

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -1,0 +1,1027 @@
+//! Feishu (Lark) channel adapter.
+//!
+//! Implements the BaseChannel trait for Feishu's open platform API.
+//! Uses HTTP callback (webhook) for receiving events and REST API for sending.
+//!
+//! ## Event subscription
+//!
+//! Feishu sends events via HTTP POST to a configured webhook URL.
+//! The gateway exposes a `/feishu/webhook` route that parses events
+//! and forwards them to the message bus.
+//!
+//! ## Authentication
+//!
+//! Uses tenant_access_token (app_id + app_secret) for API calls.
+//! Tokens are cached and auto-refreshed before expiry.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, warn};
+
+use kestrel_bus::events::InboundMessage;
+use kestrel_core::{MediaAttachment, MessageType, Platform, SessionSource};
+
+use crate::base::{BaseChannel, SendResult};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FEISHU_BASE_URL: &str = "https://open.feishu.cn/open-apis";
+const TOKEN_REFRESH_MARGIN_SECS: u64 = 300; // refresh 5 min before expiry
+
+// ---------------------------------------------------------------------------
+// Feishu API response types
+// ---------------------------------------------------------------------------
+
+/// Top-level wrapper for Feishu API responses.
+#[derive(Debug, Deserialize)]
+struct FeishuResponse<T> {
+    code: i64,
+    #[allow(dead_code)]
+    msg: Option<String>,
+    #[serde(default)]
+    data: Option<T>,
+}
+
+/// Token response from `auth/v3/tenant_access_token/internal`.
+#[derive(Debug, Deserialize)]
+struct TokenData {
+    tenant_access_token: String,
+    expire: u64,
+}
+
+/// Message sent response from `im/v1/messages`.
+#[derive(Debug, Deserialize)]
+struct SendMessageData {
+    #[allow(dead_code)]
+    message_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Webhook event types (public — used by the API server webhook route)
+// ---------------------------------------------------------------------------
+
+/// Top-level envelope for Feishu webhook callbacks.
+#[derive(Debug, Deserialize)]
+pub struct WebhookEvent {
+    /// Schema version (e.g. "2.0").
+    #[serde(default)]
+    pub schema: Option<String>,
+    /// Header containing event metadata.
+    #[serde(default)]
+    pub header: Option<WebhookHeader>,
+    /// Event payload (varies by type).
+    #[serde(default)]
+    pub event: Option<serde_json::Value>,
+    /// URL verification challenge.
+    #[serde(default)]
+    pub challenge: Option<String>,
+    /// Token for verification.
+    #[serde(default)]
+    pub token: Option<String>,
+    /// Event type string.
+    #[serde(rename = "type")]
+    #[serde(default)]
+    pub event_type: Option<String>,
+}
+
+/// Header in a Feishu webhook event.
+#[derive(Debug, Deserialize)]
+pub struct WebhookHeader {
+    #[serde(default)]
+    pub event_id: Option<String>,
+    #[serde(default)]
+    pub event_type: Option<String>,
+    #[serde(default)]
+    pub token: Option<String>,
+    #[serde(default)]
+    pub app_id: Option<String>,
+}
+
+/// Parsed message event from Feishu.
+#[derive(Debug, Deserialize)]
+pub struct MessageEvent {
+    #[serde(default)]
+    pub message: Option<MessageData>,
+    #[serde(default)]
+    pub sender: Option<SenderData>,
+}
+
+/// Message data in a Feishu event.
+#[derive(Debug, Deserialize)]
+pub struct MessageData {
+    #[serde(default)]
+    pub message_id: Option<String>,
+    #[serde(default)]
+    pub chat_id: Option<String>,
+    #[serde(default)]
+    pub chat_type: Option<String>,
+    #[serde(default)]
+    pub message_type: Option<String>,
+    /// Content is a JSON-encoded string (e.g. `"{\"text\":\"hello\"}"`).
+    #[serde(default)]
+    pub content: Option<String>,
+    /// Thread ID for threaded messages in groups.
+    #[serde(default)]
+    pub root_id: Option<String>,
+}
+
+/// Sender data in a Feishu event.
+#[derive(Debug, Deserialize)]
+pub struct SenderData {
+    #[serde(default)]
+    pub sender_id: Option<SenderId>,
+    #[serde(default)]
+    pub sender_type: Option<String>,
+}
+
+/// Sender identifiers.
+#[derive(Debug, Deserialize)]
+pub struct SenderId {
+    #[serde(default)]
+    pub open_id: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    #[serde(default)]
+    pub union_id: Option<String>,
+}
+
+/// Result of parsing a webhook request.
+#[derive(Debug)]
+pub enum WebhookResult {
+    /// URL verification challenge — respond with this JSON body.
+    Challenge(String),
+    /// One or more inbound messages extracted from the event.
+    Messages(Vec<InboundMessage>),
+    /// Ignored event (not a message or unsupported type).
+    Ignored,
+}
+
+/// Parse a Feishu webhook POST body.
+///
+/// Handles two cases:
+/// - **URL verification**: Feishu sends `{"challenge": "...", "token": "..."}`
+///   during initial setup; respond with the same challenge string.
+/// - **Event callback**: Extracts message content and returns InboundMessage(s).
+pub fn parse_webhook(body: &[u8]) -> Result<WebhookResult> {
+    let event: WebhookEvent = serde_json::from_slice(body).context("invalid Feishu webhook JSON")?;
+
+    // URL verification challenge.
+    if let Some(challenge) = &event.challenge {
+        let response = serde_json::json!({
+            "challenge": challenge,
+            "token": event.token.clone().unwrap_or_default()
+        });
+        info!("Feishu URL verification challenge received");
+        return Ok(WebhookResult::Challenge(response.to_string()));
+    }
+
+    // Event callback — try to extract message event.
+    let header = match &event.header {
+        Some(h) => h,
+        None => return Ok(WebhookResult::Ignored),
+    };
+
+    let event_type = header.event_type.as_deref().unwrap_or("");
+    if !event_type.starts_with("im.message.receive_v") {
+        debug!("Ignoring Feishu event type: {event_type}");
+        return Ok(WebhookResult::Ignored);
+    }
+
+    let event_json = match &event.event {
+        Some(v) => v,
+        None => return Ok(WebhookResult::Ignored),
+    };
+
+    let msg_event: MessageEvent = serde_json::from_value(event_json.clone())
+        .context("failed to parse Feishu message event")?;
+
+    let message = match msg_event.message {
+        Some(m) => m,
+        None => return Ok(WebhookResult::Ignored),
+    };
+
+    let chat_id = match &message.chat_id {
+        Some(id) if !id.is_empty() => id.clone(),
+        _ => return Ok(WebhookResult::Ignored),
+    };
+
+    let message_id = message.message_id.clone();
+    let msg_type = message.message_type.as_deref().unwrap_or("text");
+    let root_id = message.root_id.clone();
+
+    let sender_id = msg_event
+        .sender
+        .as_ref()
+        .and_then(|s| s.sender_id.as_ref())
+        .and_then(|id| id.open_id.clone().or(id.user_id.clone()))
+        .unwrap_or_default();
+
+    let chat_type_str = message.chat_type.as_deref().unwrap_or("p2p");
+    let chat_type = match chat_type_str {
+        "p2p" => "dm",
+        "group" => "group",
+        other => other,
+    };
+
+    // Parse content based on message type.
+    let (content, message_type, media) = match msg_type {
+        "text" => {
+            let text = parse_text_content(message.content.as_deref());
+            (text, MessageType::Text, vec![])
+        }
+        "image" => {
+            let (text, media) = parse_image_content(message.content.as_deref(), chat_id.clone());
+            (text, MessageType::Photo, media)
+        }
+        "post" => {
+            let text = parse_post_content(message.content.as_deref());
+            (text, MessageType::Text, vec![])
+        }
+        other => {
+            debug!("Unsupported Feishu message type: {other}");
+            return Ok(WebhookResult::Ignored);
+        }
+    };
+
+    if content.trim().is_empty() {
+        return Ok(WebhookResult::Ignored);
+    }
+
+    let mut metadata = HashMap::new();
+    if let Some(ref mid) = message_id {
+        metadata.insert("message_id".to_string(), serde_json::Value::String(mid.clone()));
+    }
+
+    let inbound = InboundMessage {
+        channel: Platform::Feishu,
+        sender_id: sender_id.clone(),
+        chat_id: chat_id.clone(),
+        content,
+        media,
+        metadata,
+        source: Some(SessionSource {
+            platform: Platform::Feishu,
+            chat_id: chat_id.clone(),
+            chat_name: None,
+            chat_type: chat_type.to_string(),
+            user_id: Some(sender_id),
+            user_name: None,
+            thread_id: root_id,
+            chat_topic: None,
+        }),
+        message_type,
+        message_id,
+        trace_id: None,
+        reply_to: None,
+        timestamp: chrono::Local::now(),
+    };
+
+    Ok(WebhookResult::Messages(vec![inbound]))
+}
+
+/// Parse text content from a Feishu message.
+///
+/// Feishu sends `content` as a JSON-encoded string: `{"text":"hello"}`.
+fn parse_text_content(content: Option<&str>) -> String {
+    let raw = match content {
+        Some(c) => c,
+        None => return String::new(),
+    };
+
+    #[derive(Deserialize)]
+    struct TextContent {
+        #[serde(default)]
+        text: Option<String>,
+    }
+
+    serde_json::from_str::<TextContent>(raw)
+        .ok()
+        .and_then(|c| c.text)
+        .unwrap_or_else(|| raw.to_string())
+}
+
+/// Parse rich text (post) content from a Feishu message.
+///
+/// Posts contain an array of content blocks with text runs.
+/// We flatten them to plain text.
+fn parse_post_content(content: Option<&str>) -> String {
+    let raw = match content {
+        Some(c) => c,
+        None => return String::new(),
+    };
+
+    #[derive(Deserialize)]
+    struct PostContent {
+        #[serde(default)]
+        content: Vec<Vec<PostElement>>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "tag")]
+    enum PostElement {
+        #[serde(rename = "text")]
+        Text {
+            #[serde(default)]
+            text: Option<String>,
+        },
+        #[serde(rename = "a")]
+        Link {
+            #[serde(default)]
+            text: Option<String>,
+            #[serde(default)]
+            href: Option<String>,
+        },
+        #[serde(other)]
+        Other,
+    }
+
+    let mut lang_posts: HashMap<String, PostContent> = match serde_json::from_str(raw) {
+        Ok(p) => p,
+        Err(_) => return raw.to_string(),
+    };
+
+    // Prefer zh_cn, then en_us, then first available.
+    let post = lang_posts
+        .remove("zh_cn")
+        .or_else(|| lang_posts.remove("en_us"))
+        .or_else(|| lang_posts.into_values().next())
+        .unwrap_or(PostContent {
+            content: vec![],
+        });
+
+    let mut result = String::new();
+    for line in &post.content {
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        for element in line {
+            match element {
+                PostElement::Text { text: Some(t) } => result.push_str(t),
+                PostElement::Link {
+                    text: Some(t),
+                    href: Some(h),
+                } => {
+                    result.push_str(t);
+                    result.push_str(" (");
+                    result.push_str(h);
+                    result.push(')');
+                }
+                PostElement::Link { text: Some(t), .. } => result.push_str(t),
+                _ => {}
+            }
+        }
+    }
+    result
+}
+
+/// Parse image content from a Feishu message.
+fn parse_image_content(content: Option<&str>, _chat_id: String) -> (String, Vec<MediaAttachment>) {
+    let raw = match content {
+        Some(c) => c,
+        None => return (String::new(), vec![]),
+    };
+
+    #[derive(Deserialize)]
+    struct ImageContent {
+        #[serde(default)]
+        image_key: Option<String>,
+    }
+
+    let parsed: ImageContent = match serde_json::from_str(raw) {
+        Ok(p) => p,
+        Err(_) => return (String::new(), vec![]),
+    };
+
+    let desc = parsed
+        .image_key
+        .as_deref()
+        .map(|k| format!("[image: {k}]"))
+        .unwrap_or_default();
+
+    (desc, vec![])
+}
+
+// ---------------------------------------------------------------------------
+// FeishuChannel
+// ---------------------------------------------------------------------------
+
+/// Feishu channel adapter implementing BaseChannel.
+///
+/// Handles:
+/// - Tenant access token management (auto-refresh)
+/// - Sending text and image messages via Feishu REST API
+/// - Webhook event parsing (via `parse_webhook`)
+pub struct FeishuChannel {
+    app_id: String,
+    app_secret: String,
+    proxy: Option<String>,
+    message_handler: Option<tokio::sync::mpsc::Sender<InboundMessage>>,
+    running: Arc<AtomicBool>,
+    client: reqwest::Client,
+    access_token: Arc<Mutex<Option<String>>>,
+    token_expires_at: Arc<Mutex<Instant>>,
+}
+
+impl FeishuChannel {
+    /// Build a reqwest client with optional proxy support.
+    fn build_client(proxy_config: Option<&str>) -> reqwest::Client {
+        let proxy_url = proxy_config
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                std::env::var("HTTPS_PROXY")
+                    .or_else(|_| std::env::var("https_proxy"))
+                    .or_else(|_| std::env::var("HTTP_PROXY"))
+                    .or_else(|_| std::env::var("http_proxy"))
+                    .or_else(|_| std::env::var("ALL_PROXY"))
+                    .or_else(|_| std::env::var("all_proxy"))
+                    .ok()
+            });
+
+        let dns = kestrel_core::dns::build_dns_resolver();
+
+        match proxy_url {
+            Some(ref url) if url.starts_with("socks5") => {
+                info!("Feishu HTTP client using SOCKS5 proxy: {}", url);
+                let proxy =
+                    reqwest::Proxy::all(url).expect("Failed to create SOCKS5 proxy from config");
+                reqwest::Client::builder()
+                    .dns_resolver(dns)
+                    .proxy(proxy)
+                    .build()
+                    .expect("Failed to build HTTP client with SOCKS5 proxy")
+            }
+            Some(ref url) if url.starts_with("http") => {
+                info!("Feishu HTTP client using HTTP proxy: {}", url);
+                let http_proxy =
+                    reqwest::Proxy::http(url).expect("Failed to create HTTP proxy from config");
+                let https_proxy =
+                    reqwest::Proxy::https(url).expect("Failed to create HTTPS proxy from config");
+                reqwest::Client::builder()
+                    .dns_resolver(dns)
+                    .proxy(http_proxy)
+                    .proxy(https_proxy)
+                    .build()
+                    .expect("Failed to build HTTP client with HTTP proxy")
+            }
+            Some(ref url) => {
+                info!(
+                    "Feishu HTTP client: unsupported proxy scheme in '{}', falling back to direct",
+                    url
+                );
+                reqwest::Client::builder()
+                    .dns_resolver(dns)
+                    .build()
+                    .expect("Failed to build HTTP client")
+            }
+            None => {
+                info!("Feishu HTTP client: no proxy configured (direct connection)");
+                reqwest::Client::builder()
+                    .dns_resolver(dns)
+                    .build()
+                    .expect("Failed to build HTTP client")
+            }
+        }
+    }
+
+    /// Create from environment variables `FEISHU_APP_ID` / `FEISHU_APP_SECRET`.
+    pub fn new() -> Self {
+        let app_id = std::env::var("FEISHU_APP_ID").unwrap_or_default();
+        let app_secret = std::env::var("FEISHU_APP_SECRET").unwrap_or_default();
+        Self {
+            app_id,
+            app_secret,
+            proxy: None,
+            message_handler: None,
+            running: Arc::new(AtomicBool::new(false)),
+            client: Self::build_client(None),
+            access_token: Arc::new(Mutex::new(None)),
+            token_expires_at: Arc::new(Mutex::new(Instant::now())),
+        }
+    }
+
+    /// Create from config struct.
+    pub fn new_with_config(config: &kestrel_config::schema::FeishuConfig) -> Self {
+        let app_id = config
+            .app_id
+            .clone()
+            .or_else(|| std::env::var("FEISHU_APP_ID").ok())
+            .unwrap_or_default();
+        let app_secret = config
+            .app_secret
+            .clone()
+            .or_else(|| std::env::var("FEISHU_APP_SECRET").ok())
+            .unwrap_or_default();
+        let proxy = config.proxy.clone();
+        let client = Self::build_client(proxy.as_deref());
+        Self {
+            app_id,
+            app_secret,
+            proxy,
+            message_handler: None,
+            running: Arc::new(AtomicBool::new(false)),
+            client,
+            access_token: Arc::new(Mutex::new(None)),
+            token_expires_at: Arc::new(Mutex::new(Instant::now())),
+        }
+    }
+
+    /// Get a valid tenant_access_token, refreshing if needed.
+    async fn get_access_token(&self) -> Result<String> {
+        {
+            let token = self.access_token.lock();
+            let expires = self.token_expires_at.lock();
+            if let Some(ref t) = *token {
+                if *expires > Instant::now() {
+                    return Ok(t.clone());
+                }
+            }
+        }
+
+        debug!("Refreshing Feishu tenant_access_token");
+        let url = format!("{FEISHU_BASE_URL}/auth/v3/tenant_access_token/internal");
+        let body = serde_json::json!({
+            "app_id": self.app_id,
+            "app_secret": self.app_secret,
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to request Feishu tenant_access_token")?;
+
+        let feishu_resp: FeishuResponse<TokenData> = resp
+            .json()
+            .await
+            .context("Failed to parse Feishu token response")?;
+
+        if feishu_resp.code != 0 {
+            anyhow::bail!(
+                "Feishu token request failed: code={}, msg={:?}",
+                feishu_resp.code,
+                feishu_resp.msg
+            );
+        }
+
+        let data = feishu_resp
+            .data
+            .context("Feishu token response missing data")?;
+
+        let expire_secs = data.expire.saturating_sub(TOKEN_REFRESH_MARGIN_SECS);
+        let expires_at = Instant::now() + Duration::from_secs(expire_secs);
+
+        *self.access_token.lock() = Some(data.tenant_access_token.clone());
+        *self.token_expires_at.lock() = expires_at;
+
+        info!(
+            "Feishu tenant_access_token refreshed, expires in {}s",
+            expire_secs
+        );
+        Ok(data.tenant_access_token)
+    }
+
+    /// Send a text message via Feishu API.
+    async fn send_text_message(
+        &self,
+        chat_id: &str,
+        text: &str,
+        reply_to: Option<&str>,
+    ) -> Result<SendResult> {
+        let token = self.get_access_token().await?;
+
+        let url = format!("{FEISHU_BASE_URL}/im/v1/messages?receive_id_type=chat_id");
+        let content = serde_json::json!({
+            "text": text
+        })
+        .to_string();
+
+        let mut body = serde_json::json!({
+            "receive_id": chat_id,
+            "msg_type": "text",
+            "content": content,
+        });
+
+        if let Some(reply_msg_id) = reply_to {
+            body["reply_in_thread"] = serde_json::Value::Bool(true);
+            // Feishu doesn't have a direct reply_to field in send API;
+            // instead, we use the reply API endpoint.
+            return self
+                .reply_message(&token, chat_id, reply_msg_id, &content, "text")
+                .await;
+        }
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to send Feishu message")?;
+
+        self.handle_send_response(resp).await
+    }
+
+    /// Reply to a specific message.
+    async fn reply_message(
+        &self,
+        token: &str,
+        _chat_id: &str,
+        message_id: &str,
+        content: &str,
+        msg_type: &str,
+    ) -> Result<SendResult> {
+        let url = format!(
+            "{FEISHU_BASE_URL}/im/v1/messages/{message_id}/reply"
+        );
+        let body = serde_json::json!({
+            "msg_type": msg_type,
+            "content": content,
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to reply to Feishu message")?;
+
+        self.handle_send_response(resp).await
+    }
+
+    /// Handle the response from a send/reply API call.
+    async fn handle_send_response(
+        &self,
+        resp: reqwest::Response,
+    ) -> Result<SendResult> {
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .context("Failed to parse Feishu send response")?;
+
+        let code = body.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
+
+        if code == 0 {
+            let message_id = body
+                .get("data")
+                .and_then(|d| d.get("message_id"))
+                .and_then(|m| m.as_str())
+                .map(|s| s.to_string());
+
+            Ok(SendResult {
+                success: true,
+                message_id,
+                error: None,
+                retryable: false,
+            })
+        } else {
+            let msg = body
+                .get("msg")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            let retryable = status.is_server_error() || code == 99991400; // rate limit
+            error!("Feishu send failed: code={code}, msg={msg}, status={status}");
+            Ok(SendResult {
+                success: false,
+                message_id: None,
+                error: Some(format!("Feishu API error: {msg} (code {code})")),
+                retryable,
+            })
+        }
+    }
+}
+
+#[async_trait]
+impl BaseChannel for FeishuChannel {
+    fn name(&self) -> &str {
+        "feishu"
+    }
+
+    fn platform(&self) -> Platform {
+        Platform::Feishu
+    }
+
+    fn is_connected(&self) -> bool {
+        self.running.load(Ordering::Relaxed)
+    }
+
+    async fn connect(&mut self) -> Result<bool> {
+        if self.app_id.is_empty() || self.app_secret.is_empty() {
+            warn!("Feishu app_id or app_secret not configured");
+            return Ok(false);
+        }
+
+        // Pre-fetch tenant_access_token to validate credentials.
+        match self.get_access_token().await {
+            Ok(_) => {
+                self.running.store(true, Ordering::Relaxed);
+                info!("Feishu channel connected (app_id={})", self.app_id);
+                Ok(true)
+            }
+            Err(e) => {
+                error!("Feishu connect failed: {e}");
+                Ok(false)
+            }
+        }
+    }
+
+    async fn disconnect(&mut self) -> Result<()> {
+        self.running.store(false, Ordering::Relaxed);
+        info!("Feishu channel disconnected");
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        chat_id: &str,
+        content: &str,
+        reply_to: Option<&str>,
+    ) -> Result<SendResult> {
+        self.send_text_message(chat_id, content, reply_to).await
+    }
+
+    async fn send_typing(&self, _chat_id: &str, _trace_id: Option<&str>) -> Result<()> {
+        // Feishu has no typing indicator API.
+        Ok(())
+    }
+
+    async fn send_image(
+        &self,
+        chat_id: &str,
+        image_url: &str,
+        caption: Option<&str>,
+    ) -> Result<SendResult> {
+        let token = self.get_access_token().await?;
+
+        let url = format!("{FEISHU_BASE_URL}/im/v1/messages?receive_id_type=chat_id");
+
+        // Send image as a text message with the URL.
+        // Feishu's image message requires uploading to Feishu first;
+        // fall back to sending URL as text with an image indicator.
+        let text = match caption {
+            Some(c) => format!("{c}\n{image_url}"),
+            None => image_url.to_string(),
+        };
+
+        let content = serde_json::json!({
+            "text": text
+        })
+        .to_string();
+
+        let body = serde_json::json!({
+            "receive_id": chat_id,
+            "msg_type": "text",
+            "content": content,
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to send Feishu image")?;
+
+        self.handle_send_response(resp).await
+    }
+
+    async fn edit_message(
+        &self,
+        _chat_id: &str,
+        message_id: &str,
+        content: &str,
+    ) -> Result<SendResult> {
+        let token = self.get_access_token().await?;
+
+        let url = format!("{FEISHU_BASE_URL}/im/v1/messages/{message_id}");
+        let body = serde_json::json!({
+            "content": serde_json::json!({"text": content}).to_string(),
+        });
+
+        let resp = self
+            .client
+            .patch(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to edit Feishu message")?;
+
+        self.handle_send_response(resp).await
+    }
+
+    async fn delete_message(&self, _chat_id: &str, message_id: &str) -> Result<bool> {
+        let token = self.get_access_token().await?;
+
+        let url = format!("{FEISHU_BASE_URL}/im/v1/messages/{message_id}");
+        let resp = self
+            .client
+            .delete(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+            .await
+            .context("Failed to delete Feishu message")?;
+
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .context("Failed to parse Feishu delete response")?;
+
+        let code = body.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
+        Ok(code == 0)
+    }
+
+    fn set_message_handler(&mut self, handler: tokio::sync::mpsc::Sender<InboundMessage>) {
+        self.message_handler = Some(handler);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_text_content() {
+        let content = r#"{"text":"hello world"}"#;
+        assert_eq!(parse_text_content(Some(content)), "hello world");
+    }
+
+    #[test]
+    fn test_parse_text_content_none() {
+        assert_eq!(parse_text_content(None), "");
+    }
+
+    #[test]
+    fn test_parse_webhook_challenge() {
+        let body = r#"{"challenge":"test_challenge_123","token":"verification_token"}"#;
+        let result = parse_webhook(body.as_bytes()).unwrap();
+        match result {
+            WebhookResult::Challenge(json_str) => {
+                let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+                assert_eq!(v["challenge"], "test_challenge_123");
+            }
+            _ => panic!("Expected Challenge result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_webhook_ignored_event() {
+        let body = r#"{"schema":"2.0","header":{"event_type":"some.other.event"}}"#;
+        let result = parse_webhook(body.as_bytes()).unwrap();
+        assert!(matches!(result, WebhookResult::Ignored));
+    }
+
+    #[test]
+    fn test_parse_webhook_message_event() {
+        let body = r#"{
+            "schema": "2.0",
+            "header": {
+                "event_id": "evt_123",
+                "event_type": "im.message.receive_v1",
+                "token": "xxx",
+                "app_id": "cli_test"
+            },
+            "event": {
+                "message": {
+                    "message_id": "msg_abc",
+                    "chat_id": "oc_chat123",
+                    "chat_type": "group",
+                    "message_type": "text",
+                    "content": "{\"text\":\"hello feishu\"}"
+                },
+                "sender": {
+                    "sender_id": {
+                        "open_id": "ou_user123",
+                        "user_id": "uid456"
+                    },
+                    "sender_type": "user"
+                }
+            }
+        }"#;
+
+        let result = parse_webhook(body.as_bytes()).unwrap();
+        match result {
+            WebhookResult::Messages(msgs) => {
+                assert_eq!(msgs.len(), 1);
+                let msg = &msgs[0];
+                assert_eq!(msg.channel, Platform::Feishu);
+                assert_eq!(msg.chat_id, "oc_chat123");
+                assert_eq!(msg.content, "hello feishu");
+                assert_eq!(msg.sender_id, "ou_user123");
+                assert_eq!(msg.message_id, Some("msg_abc".to_string()));
+                assert_eq!(
+                    msg.source.as_ref().unwrap().chat_type,
+                    "group"
+                );
+            }
+            _ => panic!("Expected Messages result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_webhook_p2p_chat() {
+        let body = r#"{
+            "schema": "2.0",
+            "header": {
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "message": {
+                    "message_id": "msg_dm",
+                    "chat_id": "oc_dm123",
+                    "chat_type": "p2p",
+                    "message_type": "text",
+                    "content": "{\"text\":\"dm message\"}"
+                },
+                "sender": {
+                    "sender_id": {"open_id": "ou_sender"}
+                }
+            }
+        }"#;
+
+        let result = parse_webhook(body.as_bytes()).unwrap();
+        match result {
+            WebhookResult::Messages(msgs) => {
+                assert_eq!(msgs[0].source.as_ref().unwrap().chat_type, "dm");
+            }
+            _ => panic!("Expected Messages result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_webhook_empty_text_ignored() {
+        let body = r#"{
+            "schema": "2.0",
+            "header": {
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "message": {
+                    "message_id": "msg_empty",
+                    "chat_id": "oc_chat",
+                    "chat_type": "p2p",
+                    "message_type": "text",
+                    "content": "{\"text\":\"  \"}"
+                },
+                "sender": {
+                    "sender_id": {"open_id": "ou_sender"}
+                }
+            }
+        }"#;
+
+        let result = parse_webhook(body.as_bytes()).unwrap();
+        assert!(matches!(result, WebhookResult::Ignored));
+    }
+
+    #[test]
+    fn test_channel_new_default() {
+        let ch = FeishuChannel::new();
+        assert_eq!(ch.name(), "feishu");
+        assert_eq!(ch.platform(), Platform::Feishu);
+        assert!(!ch.is_connected());
+    }
+
+    #[test]
+    fn test_parse_post_content() {
+        let content = r#"{
+            "zh_cn": {
+                "content": [
+                    [
+                        {"tag": "text", "text": "Hello "},
+                        {"tag": "a", "text": "link", "href": "https://example.com"}
+                    ],
+                    [
+                        {"tag": "text", "text": "Line 2"}
+                    ]
+                ]
+            }
+        }"#;
+        let result = parse_post_content(Some(content));
+        assert_eq!(result, "Hello link (https://example.com)\nLine 2");
+    }
+}

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -52,7 +52,7 @@ struct FeishuResponse<T> {
 }
 
 /// Token response from `auth/v3/tenant_access_token/internal`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 struct TokenData {
     tenant_access_token: String,
     expire: u64,

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use parking_lot::Mutex;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tracing::{debug, error, info, warn};
 
 use kestrel_bus::events::InboundMessage;
@@ -56,13 +56,6 @@ struct FeishuResponse<T> {
 struct TokenData {
     tenant_access_token: String,
     expire: u64,
-}
-
-/// Message sent response from `im/v1/messages`.
-#[derive(Debug, Deserialize)]
-struct SendMessageData {
-    #[allow(dead_code)]
-    message_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kestrel-channels/src/platforms/mod.rs
+++ b/crates/kestrel-channels/src/platforms/mod.rs
@@ -1,6 +1,7 @@
 //! Platform adapter implementations.
 
 pub mod discord;
+pub mod feishu;
 pub mod telegram;
 pub mod telegram_format;
 pub mod websocket;

--- a/crates/kestrel-channels/src/registry.rs
+++ b/crates/kestrel-channels/src/registry.rs
@@ -77,9 +77,7 @@ impl ChannelRegistry {
 
         if let Some(feishu) = config.channels.feishu.clone() {
             registry.register("feishu", move || {
-                Box::new(platforms::feishu::FeishuChannel::new_with_config(
-                    &feishu,
-                ))
+                Box::new(platforms::feishu::FeishuChannel::new_with_config(&feishu))
             });
         } else {
             registry.register("feishu", || {

--- a/crates/kestrel-channels/src/registry.rs
+++ b/crates/kestrel-channels/src/registry.rs
@@ -24,6 +24,9 @@ impl ChannelRegistry {
         self.register("discord", || {
             Box::new(platforms::discord::DiscordChannel::new())
         });
+        self.register("feishu", || {
+            Box::new(platforms::feishu::FeishuChannel::new())
+        });
         self.register("websocket", || {
             Box::new(platforms::websocket::WebSocketChannel::new())
         });
@@ -72,6 +75,18 @@ impl ChannelRegistry {
             Box::new(platforms::websocket::WebSocketChannel::new())
         });
 
+        if let Some(feishu) = config.channels.feishu.clone() {
+            registry.register("feishu", move || {
+                Box::new(platforms::feishu::FeishuChannel::new_with_config(
+                    &feishu,
+                ))
+            });
+        } else {
+            registry.register("feishu", || {
+                Box::new(platforms::feishu::FeishuChannel::new())
+            });
+        }
+
         registry
     }
 
@@ -115,6 +130,7 @@ mod tests {
         let names = registry.channel_names();
         assert!(names.contains(&"telegram".to_string()));
         assert!(names.contains(&"discord".to_string()));
+        assert!(names.contains(&"feishu".to_string()));
         assert!(names.contains(&"websocket".to_string()));
     }
 
@@ -122,7 +138,7 @@ mod tests {
     fn test_registry_default() {
         let registry = ChannelRegistry::default();
         let names = registry.channel_names();
-        assert_eq!(names.len(), 3);
+        assert_eq!(names.len(), 4);
     }
 
     #[test]
@@ -159,7 +175,7 @@ mod tests {
             Box::new(platforms::telegram::TelegramChannel::new())
         });
         let names = registry.channel_names();
-        assert_eq!(names.len(), 4);
+        assert_eq!(names.len(), 5);
         assert!(names.contains(&"custom".to_string()));
 
         let channel = registry.create_channel("custom").unwrap();

--- a/crates/kestrel-config/src/python_migrate.rs
+++ b/crates/kestrel-config/src/python_migrate.rs
@@ -599,6 +599,7 @@ fn convert_channels(
             app_id: f.app_id.clone(),
             app_secret: f.app_secret.clone(),
             enabled: f.enabled.unwrap_or(true),
+            proxy: None,
         });
         report.add_mapped("channels.feishu (appId → app_id, appSecret → app_secret)");
     }

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -397,6 +397,13 @@ pub struct FeishuConfig {
     /// Whether this channel is enabled.
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// HTTP/SOCKS5 proxy URL for Feishu API requests.
+    ///
+    /// - `"http://host:port"` or `"https://host:port"` → HTTP proxy
+    /// - `"socks5://host:port"` or `"socks5h://host:port"` → SOCKS5 proxy
+    /// - empty or absent → direct connection (no proxy)
+    #[serde(default)]
+    pub proxy: Option<String>,
 }
 
 /// WeCom (Enterprise WeChat) channel configuration.

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -2887,6 +2887,7 @@ token = "${MISSING_BBB}"
             app_id: None,
             app_secret: Some("secret".to_string()),
             enabled: true,
+            proxy: None,
         });
         let report = validate(&config);
         assert!(!report.is_valid());
@@ -2903,6 +2904,7 @@ token = "${MISSING_BBB}"
             app_id: Some("id".to_string()),
             app_secret: None,
             enabled: true,
+            proxy: None,
         });
         let report = validate(&config);
         assert!(!report.is_valid());

--- a/crates/kestrel-core/src/dns.rs
+++ b/crates/kestrel-core/src/dns.rs
@@ -24,19 +24,21 @@ impl Default for DnsResolver {
 
 impl DnsResolver {
     pub fn new() -> Self {
-        let resolver = TokioResolver::builder_tokio()
-            .map(|mut b| {
+        let resolver = match TokioResolver::builder_tokio() {
+            Ok(mut b) => {
                 b.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
                 b.build()
-            })
-            .unwrap_or_else(|_| {
+            }
+            Err(_) => {
                 let mut b = TokioResolver::builder_with_config(
                     ResolverConfig::default(),
                     Default::default(),
                 );
                 b.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
                 b.build()
-            });
+            }
+        }
+        .expect("failed to build DNS resolver");
         Self {
             inner: Arc::new(resolver),
         }
@@ -48,7 +50,8 @@ impl Resolve for DnsResolver {
         let inner = self.inner.clone();
         Box::pin(async move {
             let lookup = inner.lookup_ip(name.as_str()).await?;
-            let addrs: Addrs = Box::new(lookup.iter().map(|ip| SocketAddr::new(ip, 0)));
+            let ips: Vec<_> = lookup.iter().copied().map(|ip| SocketAddr::new(ip, 0)).collect();
+            let addrs: Addrs = Box::new(ips.into_iter());
             Ok(addrs)
         })
     }

--- a/crates/kestrel-core/src/dns.rs
+++ b/crates/kestrel-core/src/dns.rs
@@ -50,7 +50,7 @@ impl Resolve for DnsResolver {
         let inner = self.inner.clone();
         Box::pin(async move {
             let lookup = inner.lookup_ip(name.as_str()).await?;
-            let ips: Vec<_> = lookup.iter().copied().map(|ip| SocketAddr::new(ip, 0)).collect();
+            let ips: Vec<_> = lookup.iter().map(|ip| SocketAddr::new(ip, 0)).collect();
             let addrs: Addrs = Box::new(ips.into_iter());
             Ok(addrs)
         })

--- a/crates/kestrel-core/src/dns.rs
+++ b/crates/kestrel-core/src/dns.rs
@@ -50,7 +50,10 @@ impl Resolve for DnsResolver {
         let inner = self.inner.clone();
         Box::pin(async move {
             let lookup = inner.lookup_ip(name.as_str()).await?;
-            let ips: Vec<_> = lookup.iter().map(|ip| SocketAddr::new(ip, 0)).collect();
+            let ips: Vec<_> = lookup
+                .iter()
+                .map(|ip| SocketAddr::new(ip, 0))
+                .collect();
             let addrs: Addrs = Box::new(ips.into_iter());
             Ok(addrs)
         })

--- a/crates/kestrel-core/src/dns.rs
+++ b/crates/kestrel-core/src/dns.rs
@@ -50,10 +50,7 @@ impl Resolve for DnsResolver {
         let inner = self.inner.clone();
         Box::pin(async move {
             let lookup = inner.lookup_ip(name.as_str()).await?;
-            let ips: Vec<_> = lookup
-                .iter()
-                .map(|ip| SocketAddr::new(ip, 0))
-                .collect();
+            let ips: Vec<_> = lookup.iter().map(|ip| SocketAddr::new(ip, 0)).collect();
             let addrs: Addrs = Box::new(ips.into_iter());
             Ok(addrs)
         })

--- a/crates/kestrel-core/src/dns.rs
+++ b/crates/kestrel-core/src/dns.rs
@@ -4,7 +4,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use hickory_resolver::config::{LookupIpStrategy, ResolverConfig};
-use hickory_resolver::name_server::TokioConnectionProvider;
 use hickory_resolver::TokioResolver;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 
@@ -33,7 +32,7 @@ impl DnsResolver {
             .unwrap_or_else(|_| {
                 let mut b = TokioResolver::builder_with_config(
                     ResolverConfig::default(),
-                    TokioConnectionProvider::default(),
+                    Default::default(),
                 );
                 b.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
                 b.build()
@@ -49,7 +48,8 @@ impl Resolve for DnsResolver {
         let inner = self.inner.clone();
         Box::pin(async move {
             let lookup = inner.lookup_ip(name.as_str()).await?;
-            let addrs: Addrs = Box::new(lookup.into_iter().map(|ip| SocketAddr::new(ip, 0)));
+            let addrs: Addrs =
+                Box::new(lookup.iter().map(|ip| SocketAddr::new(ip, 0)));
             Ok(addrs)
         })
     }

--- a/crates/kestrel-core/src/dns.rs
+++ b/crates/kestrel-core/src/dns.rs
@@ -48,8 +48,7 @@ impl Resolve for DnsResolver {
         let inner = self.inner.clone();
         Box::pin(async move {
             let lookup = inner.lookup_ip(name.as_str()).await?;
-            let addrs: Addrs =
-                Box::new(lookup.iter().map(|ip| SocketAddr::new(ip, 0)));
+            let addrs: Addrs = Box::new(lookup.iter().map(|ip| SocketAddr::new(ip, 0)));
             Ok(addrs)
         })
     }

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -394,6 +394,16 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
             std::env::set_var("DISCORD_BOT_TOKEN", &dc.token);
         }
     }
+    if let Some(ref fs) = config.channels.feishu {
+        if fs.enabled {
+            if let Some(ref app_id) = fs.app_id {
+                std::env::set_var("FEISHU_APP_ID", app_id);
+            }
+            if let Some(ref app_secret) = fs.app_secret {
+                std::env::set_var("FEISHU_APP_SECRET", app_secret);
+            }
+        }
+    }
 
     // ── Channel manager (wrapped in Arc for shared access) ────
     let channel_registry = ChannelRegistry::new_with_config(&config);
@@ -518,6 +528,11 @@ pub async fn run(config: Config, channels: Vec<String>, dangerous: bool) -> Resu
         if let Some(ref ws) = config.channels.websocket {
             if ws.enabled {
                 auto.push("websocket".to_string());
+            }
+        }
+        if let Some(ref fs) = config.channels.feishu {
+            if fs.enabled {
+                auto.push("feishu".to_string());
             }
         }
         if auto.is_empty() {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -63,6 +63,7 @@ pub fn run(config: &Config) -> Result<()> {
             "Discord",
             config.channels.discord.as_ref().map(|c| c.enabled),
         ),
+        ("Feishu", config.channels.feishu.as_ref().map(|c| c.enabled)),
         ("Slack", config.channels.slack.as_ref().map(|c| c.enabled)),
         ("Matrix", config.channels.matrix.as_ref().map(|c| c.enabled)),
     ];


### PR DESCRIPTION
## Summary

Add Feishu (Lark) channel support to Kestrel Agent with HTTP webhook event subscription and setup wizard integration.

## Changes

- **New**: `crates/kestrel-channels/src/platforms/feishu.rs` — FeishuChannel implementing BaseChannel
  - tenant_access_token auto-refresh (2h TTL, refresh at <30min remaining)
  - send_message, send_image, send_typing, edit_message, delete_message
  - `parse_webhook()` for HTTP callback event parsing (im.message.receive_v1)
- **Update**: registry, mod.rs, lib.rs — register Feishu channel
- **Update**: `kestrel-api` — add POST /feishu/webhook route via Axum
- **Update**: `gateway.rs` — env var seeding + auto-detection
- **Update**: `status.rs` — Feishu channel status display
- **Update**: `schema.rs` — add `proxy` field to FeishuConfig

## Testing

- [ ] CI compilation passes
- [ ] Manual: configure channels.feishu, run gateway, send Feishu message

Closes #N (if applicable)