### PR TITLE
fix: retroactive review fixes for PR #225

### DIFF
--- a/src/commands/setup_feishu.rs
+++ b/src/commands/setup_feishu.rs
@@ -155,9 +155,17 @@ async fn post_registration(
     Ok(text)
 }
 
-/// Parse a JSON response, returning both the raw string and the typed value.
+/// Parse a JSON response, returning the typed value.
 fn parse_json<T: serde::de::DeserializeOwned>(raw: &str) -> Result<T> {
-    serde_json::from_str(raw).with_context(|| format!("Failed to parse JSON: {}", raw))
+    serde_json::from_str(raw).with_context(|| {
+        // Truncate long responses to avoid leaking sensitive data in logs
+        let preview = if raw.len() > 200 {
+            format!("{}...(truncated)", &raw[..200])
+        } else {
+            raw.to_string()
+        };
+        format!("Failed to parse JSON: {}", preview)
+    })
 }
 
 // ── Step 1: Init ────────────────────────────────────────────────
@@ -180,7 +188,7 @@ async fn init_registration(client: &Client, domain: &str) -> Result<()> {
 struct BeginResult {
     device_code: String,
     qr_url: String,
-    #[expect(dead_code)]
+    #[allow(dead_code)]
     user_code: String,
     interval: u64,
     expire_in: u64,
@@ -407,11 +415,18 @@ fn persist_credentials(result: &RegistrationResult) -> Result<()> {
             .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
     }
 
+    // Preserve existing proxy config if present
+    let proxy = config
+        .channels
+        .feishu
+        .as_ref()
+        .and_then(|f| f.proxy.clone());
+
     config.channels.feishu = Some(FeishuConfig {
         app_id: Some(result.app_id.clone()),
         app_secret: Some(result.app_secret.clone()),
         enabled: true,
-        proxy: None,
+        proxy,
     });
 
     save_config(&config, &config_path)?;


### PR DESCRIPTION
## Summary

Retroactive code review fixes for #225 (Feishu QR onboarding).

## Changes

1. **Preserve existing proxy config** —  now preserves the user's existing  setting instead of overwriting it with .

2. **MSRV compatibility** — Replaced  with . The  attribute requires Rust 1.81+; this project may target an earlier MSRV.

3. **Security: truncate JSON error messages** —  now truncates long responses to 200 chars in error messages to avoid leaking sensitive data (tokens, secrets) into logs.

## Retroactive Review Notes

Original PR #225 was merged without manual review (my error). This PR addresses the issues found during post-merge review. The original implementation was functionally correct and well-tested (18 unit tests), but had these three quality/safety gaps.

Closes: post-merge review items for #225