### PR TITLE
fix: re-enable Weixin wizard credentials and cover Feishu webhook flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ cargo build --release
 ```bash
 kestrel setup
 # Unified setup wizard for provider + channel onboarding
+kestrel setup weixin
+# Direct WeChat iLink QR onboarding
 # Edit ~/.kestrel/config.toml with your API keys if needed
 ```
 
@@ -338,6 +340,7 @@ Environment variables in values (`${VAR}`) are expanded at load time.
 | `config validate` | Validate the config.toml schema |
 | `config migrate` | Migrate Python kestrel config to kestrel format |
 | `setup` | Unified interactive configuration wizard, including Feishu / Lark onboarding |
+| `setup weixin` | Direct WeChat iLink QR onboarding flow |
 | `status` | Show current configuration and system status |
 | `doctor` | Run system diagnostics for config, provider reachability, and local environment |
 | `daemon start/stop/restart/status` | Native Unix daemon: double-fork, PID file (flock), SIGTERM/SIGINT/SIGHUP, log rotation |

--- a/crates/kestrel-api/src/server.rs
+++ b/crates/kestrel-api/src/server.rs
@@ -1026,6 +1026,7 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
+    use kestrel_core::Platform;
     use kestrel_test_utils::MockProvider;
     use tower::ServiceExt;
 
@@ -1080,6 +1081,7 @@ mod tests {
             .route("/v1/models", get(list_models))
             .route("/health", get(health))
             .route("/ready", get(ready))
+            .route("/feishu/webhook", post(feishu_webhook))
             .layer(middleware::from_fn(request_id_middleware))
             .with_state(test_state())
     }
@@ -1831,6 +1833,88 @@ mod tests {
         let server = ApiServer::new(config, bus, session_manager, Some(8080))
             .with_api_key("sk-test".to_string());
         assert_eq!(server.state.api_key, Some("sk-test".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_feishu_webhook_returns_challenge() {
+        let app = test_router();
+        let payload = serde_json::json!({
+            "type": "url_verification",
+            "challenge": "challenge-token"
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/feishu/webhook")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+            serde_json::json!({
+                "challenge": "challenge-token",
+                "token": ""
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_feishu_webhook_forwards_message_to_bus() {
+        let state = test_state();
+        let mut inbound_rx = state.bus.consume_inbound().await.unwrap();
+        let app = Router::new()
+            .route("/feishu/webhook", post(feishu_webhook))
+            .with_state(state);
+        let payload = serde_json::json!({
+            "header": {
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "message": {
+                    "message_id": "om_123",
+                    "chat_id": "oc_group",
+                    "chat_type": "group",
+                    "message_type": "text",
+                    "content": "{\"text\":\"hello feishu\"}"
+                },
+                "sender": {
+                    "sender_id": {
+                        "open_id": "ou_user"
+                    }
+                }
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/feishu/webhook")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let forwarded = tokio::time::timeout(std::time::Duration::from_secs(1), inbound_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(forwarded.channel, Platform::Feishu);
+        assert_eq!(forwarded.chat_id, "oc_group");
+        assert_eq!(forwarded.sender_id, "ou_user");
+        assert_eq!(forwarded.content, "hello feishu");
+        assert_eq!(forwarded.message_id.as_deref(), Some("om_123"));
     }
 
     // ─── Serialization tests ─────────────────────────────

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -615,11 +615,12 @@ fn configure_weixin(io: &dyn WizardIo, config: &mut Config) -> Result<()> {
                 "  QR scan setup requires running `kestrel setup weixin` in a terminal.",
             )?;
             io.write_line("  Please run that command separately, then return to this wizard.")?;
-            // Mark as enabled if credentials already exist
-            if let Some(ref wx) = config.channels.weixin {
+            // Re-enable the channel when QR login credentials already exist.
+            if let Some(ref mut wx) = config.channels.weixin {
                 if wx.account_id.is_some() && wx.bot_token.is_some() {
+                    wx.enabled = true;
                     io.write_line(&format!(
-                        "  {} Existing WeChat credentials detected.",
+                        "  {} Existing WeChat credentials detected and enabled.",
                         "✓".green()
                     ))?;
                 }
@@ -1186,5 +1187,94 @@ mod tests {
 
         let output = mock.output();
         assert!(output.contains("(not set)"));
+    }
+
+    #[test]
+    fn configure_weixin_qr_enables_existing_credentials() {
+        let mock = MockWizard::new(vec![
+            MockAction::Confirm {
+                prompt_contains: "WeChat",
+                result: true,
+            },
+            MockAction::Select { result: 0 },
+        ]);
+        let mut config = Config::default();
+        config.channels.weixin = Some(WeixinConfig {
+            app_id: None,
+            app_secret: None,
+            token: None,
+            encoding_aes_key: None,
+            account_id: Some("wxid_existing@im.bot".to_string()),
+            bot_token: Some("tok_existing".to_string()),
+            base_url: None,
+            cdn_base_url: None,
+            dm_policy: "open".to_string(),
+            group_policy: "disabled".to_string(),
+            allowed_users: vec![],
+            group_allowed_users: vec![],
+            enabled: false,
+        });
+
+        configure_weixin(&mock, &mut config).unwrap();
+
+        let weixin = config.channels.weixin.unwrap();
+        assert!(weixin.enabled);
+        assert_eq!(weixin.account_id.as_deref(), Some("wxid_existing@im.bot"));
+        assert_eq!(weixin.bot_token.as_deref(), Some("tok_existing"));
+        assert!(mock.output().contains("detected and enabled"));
+    }
+
+    #[test]
+    fn configure_weixin_manual_preserves_existing_fields() {
+        let mock = MockWizard::new(vec![
+            MockAction::Confirm {
+                prompt_contains: "WeChat",
+                result: true,
+            },
+            MockAction::Select { result: 1 },
+            MockAction::Input {
+                result: "wxid_new@im.bot",
+            },
+            MockAction::Input { result: "tok_new" },
+        ]);
+        let mut config = Config::default();
+        config.channels.weixin = Some(WeixinConfig {
+            app_id: Some("app_existing".to_string()),
+            app_secret: Some("secret_existing".to_string()),
+            token: Some("verify_token".to_string()),
+            encoding_aes_key: Some("aes_key".to_string()),
+            account_id: Some("wxid_old@im.bot".to_string()),
+            bot_token: Some("tok_old".to_string()),
+            base_url: Some("https://ilinkai.weixin.qq.com".to_string()),
+            cdn_base_url: Some("https://novac2c.cdn.weixin.qq.com/c2c".to_string()),
+            dm_policy: "allowlist".to_string(),
+            group_policy: "open".to_string(),
+            allowed_users: vec!["u1".to_string()],
+            group_allowed_users: vec!["g1".to_string()],
+            enabled: false,
+        });
+
+        configure_weixin(&mock, &mut config).unwrap();
+
+        let weixin = config.channels.weixin.unwrap();
+        assert_eq!(weixin.account_id.as_deref(), Some("wxid_new@im.bot"));
+        assert_eq!(weixin.bot_token.as_deref(), Some("tok_new"));
+        assert_eq!(weixin.app_id.as_deref(), Some("app_existing"));
+        assert_eq!(weixin.app_secret.as_deref(), Some("secret_existing"));
+        assert_eq!(weixin.token.as_deref(), Some("verify_token"));
+        assert_eq!(weixin.encoding_aes_key.as_deref(), Some("aes_key"));
+        assert_eq!(
+            weixin.base_url.as_deref(),
+            Some("https://ilinkai.weixin.qq.com")
+        );
+        assert_eq!(
+            weixin.cdn_base_url.as_deref(),
+            Some("https://novac2c.cdn.weixin.qq.com/c2c")
+        );
+        assert_eq!(weixin.dm_policy, "allowlist");
+        assert_eq!(weixin.group_policy, "open");
+        assert_eq!(weixin.allowed_users, vec!["u1"]);
+        assert_eq!(weixin.group_allowed_users, vec!["g1"]);
+        assert!(weixin.enabled);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,10 @@ enum Commands {
     },
 
     /// Interactive configuration setup.
-    Setup,
+    Setup {
+        #[command(subcommand)]
+        subcommand: Option<SetupSubcommand>,
+    },
 
     /// Show current configuration and status.
     Status,
@@ -140,6 +143,12 @@ enum ConfigSubcommand {
 }
 
 #[derive(Subcommand)]
+enum SetupSubcommand {
+    /// Run the WeChat iLink QR onboarding flow directly.
+    Weixin,
+}
+
+#[derive(Subcommand)]
 enum DaemonSubcommand {
     /// Start the daemon (daemonize then run gateway).
     Start,
@@ -176,8 +185,11 @@ fn main() -> Result<()> {
             .init();
     }
 
-    if matches!(&cli.command, Commands::Setup) {
-        return commands::setup::run(kestrel_config::Config::default());
+    if let Commands::Setup { subcommand } = &cli.command {
+        return match subcommand {
+            Some(SetupSubcommand::Weixin) => commands::setup_weixin::run(),
+            None => commands::setup::run(kestrel_config::Config::default()),
+        };
     }
 
     // Load configuration
@@ -226,7 +238,7 @@ fn main() -> Result<()> {
                 commands::config::export(&config, &password, &output)?;
             }
         },
-        Commands::Setup => unreachable!("setup is handled before config loading"),
+        Commands::Setup { .. } => unreachable!("setup is handled before config loading"),
         Commands::Status => {
             commands::status::run(&config)?;
         }


### PR DESCRIPTION
## Summary
- re-enable the Weixin channel in  when QR-login credentials already exist
- add setup wizard tests covering Weixin QR/manual configuration behavior
- add API webhook tests covering Feishu challenge handling and message forwarding

## Testing
- cargo test configure_weixin -- --nocapture
- cargo test -p kestrel-api feishu_webhook -- --nocapture
- cargo test -p kestrel-channels feishu -- --nocapture
- cargo test setup_weixin -- --nocapture
- cargo test feishu_onboarding -- --nocapture