### PR TITLE
fix(agent): gate Unix-only heartbeat tests with cfg(unix)

### DIFF
--- a/crates/kestrel-agent/src/heartbeat.rs
+++ b/crates/kestrel-agent/src/heartbeat.rs
@@ -1103,6 +1103,7 @@ mod tests {
         assert!(result.message.contains("default"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_config_store_unreadable_config() {
         let dir = tempfile::tempdir().unwrap();
@@ -1132,6 +1133,7 @@ mod tests {
         .ok();
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_config_store_unwritable_data_dir() {
         let dir = tempfile::tempdir().unwrap();
@@ -1370,6 +1372,7 @@ mod tests {
         assert!(result.message.contains("default"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_deep_config_unwritable_data_dir() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Closes #240

The following test functions use \std::os::unix::fs::PermissionsExt::from_mode(...)\ and fail to compile on non-Unix targets (e.g., Windows):

- \	est_config_store_unreadable_config\
- \	est_config_store_unwritable_data_dir\
- \	est_deep_config_unwritable_data_dir\

This PR adds \#[cfg(unix)]\ before each \#[tokio::test]\ attribute so these tests are only compiled on Unix platforms.