### PR TITLE
fix(daemon): gate nix/libc deps to Unix-only for Windows compat

### DIFF
--- a/crates/kestrel-daemon/Cargo.toml
+++ b/crates/kestrel-daemon/Cargo.toml
@@ -7,8 +7,6 @@ edition.workspace = true
 kestrel-config = { path = "../kestrel-config" }
 anyhow = { workspace = true }
 chrono = { workspace = true }
-libc = "0.2"
-nix = { version = "0.29", features = ["process", "signal", "fs"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
@@ -16,6 +14,12 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = "0.2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+nix = { version = "0.29", features = ["process", "signal", "fs"] }
+
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[target.'cfg(unix)'.dev-dependencies]
 filetime = "0.2"

--- a/crates/kestrel-daemon/src/lib.rs
+++ b/crates/kestrel-daemon/src/lib.rs
@@ -21,3 +21,10 @@ pub mod logging;
 pub mod pid_file;
 #[cfg(target_family = "unix")]
 pub mod signal;
+
+#[cfg(not(target_family = "unix"))]
+compile_error!(
+    "kestrel-daemon only supports Unix platforms. \
+     This crate provides daemonization, PID file management, and signal handling \
+     that depend on Unix-specific APIs (fork, flock, SIGTERM, etc.)."
+);

--- a/crates/kestrel-daemon/src/logging.rs
+++ b/crates/kestrel-daemon/src/logging.rs
@@ -278,6 +278,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_cleanup_old_logs_removes_expired() {
         let tmp = TempDir::new().unwrap();
@@ -340,6 +341,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_cleanup_old_logs_also_cleans_comm_log() {
         let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
Closes #238

## Summary

Moves `libc`, `nix`, and `filetime` dependencies under `cfg(unix)`-gated sections in Cargo.toml so the `kestrel-daemon` crate can be resolved on Windows.

## Changes

- **Cargo.toml**: Moved `libc` and `nix` from `[dependencies]` to `[target.'cfg(unix)'.dependencies]`
- **Cargo.toml**: Moved `filetime` from `[dev-dependencies]` to `[target.'cfg(unix)'.dev-dependencies]`
- **lib.rs**: Added `#[cfg(not(target_family = "unix"))]` `compile_error!` for non-Unix platforms
- **logging.rs**: Gated two `filetime`-using tests with `#[cfg(unix)]`

All modules were already gated with `#[cfg(target_family = "unix")]` in lib.rs.
