### PR TITLE
feat(feishu): WebSocket connection mode support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1802,11 +1802,12 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "chrono",
  "filetime",
+ "fs4",
  "kestrel-config",
  "libc",
  "nix",
@@ -1817,11 +1818,12 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "windows-service",
 ]
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1845,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1866,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1888,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1909,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1922,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1940,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1959,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1975,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2616,7 +2618,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4182,6 +4184,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
+dependencies = [
+ "bitflags 2.11.1",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -744,6 +744,7 @@ struct WsFrame {
     #[serde(default)]
     data: Option<serde_json::Value>,
     #[serde(default)]
+    #[allow(dead_code)]
     msg_id: Option<String>,
 }
 

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -502,8 +502,8 @@ impl FeishuChannel {
     pub fn new() -> Self {
         let app_id = std::env::var("FEISHU_APP_ID").unwrap_or_default();
         let app_secret = std::env::var("FEISHU_APP_SECRET").unwrap_or_default();
-        let connection_mode = std::env::var("FEISHU_CONNECTION_MODE")
-            .unwrap_or_else(|_| "webhook".to_string());
+        let connection_mode =
+            std::env::var("FEISHU_CONNECTION_MODE").unwrap_or_else(|_| "webhook".to_string());
         Self {
             app_id,
             app_secret,

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -814,7 +814,7 @@ async fn ws_connect_and_listen(
     };
     let auth_json = serde_json::to_string(&auth).context("serialize WS auth")?;
     write
-        .send(Message::Text(auth_json))
+        .send(Message::Text(auth_json.into()))
         .await
         .context("send WS auth")?;
 

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -1,13 +1,11 @@
 //! Feishu (Lark) channel adapter.
 //!
 //! Implements the BaseChannel trait for Feishu's open platform API.
-//! Uses HTTP callback (webhook) for receiving events and REST API for sending.
+//! Supports two connection modes:
+//! - **WebSocket**: Persistent outbound connection via `wss://` (recommended)
+//! - **Webhook**: HTTP callback endpoint for receiving events
 //!
-//! ## Event subscription
-//!
-//! Feishu sends events via HTTP POST to a configured webhook URL.
-//! The gateway exposes a `/feishu/webhook` route that parses events
-//! and forwards them to the message bus.
+//! Both modes use the same REST API for sending messages.
 //!
 //! ## Authentication
 //!
@@ -21,8 +19,10 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, error, info, warn};
 
 use kestrel_bus::events::InboundMessage;
@@ -35,7 +35,9 @@ use crate::base::{BaseChannel, SendResult};
 // ---------------------------------------------------------------------------
 
 const FEISHU_BASE_URL: &str = "https://open.feishu.cn/open-apis";
+const FEISHU_WS_URL: &str = "wss://open.feishu.cn/open-apis/callback/ws/event";
 const TOKEN_REFRESH_MARGIN_SECS: u64 = 300; // refresh 5 min before expiry
+const WS_RECONNECT_DELAY_SECS: u64 = 5;
 
 // ---------------------------------------------------------------------------
 // Feishu API response types
@@ -420,6 +422,7 @@ pub struct FeishuChannel {
     app_secret: String,
     #[allow(dead_code)]
     proxy: Option<String>,
+    connection_mode: String,
     message_handler: Option<tokio::sync::mpsc::Sender<InboundMessage>>,
     running: Arc<AtomicBool>,
     client: reqwest::Client,
@@ -499,10 +502,13 @@ impl FeishuChannel {
     pub fn new() -> Self {
         let app_id = std::env::var("FEISHU_APP_ID").unwrap_or_default();
         let app_secret = std::env::var("FEISHU_APP_SECRET").unwrap_or_default();
+        let connection_mode = std::env::var("FEISHU_CONNECTION_MODE")
+            .unwrap_or_else(|_| "webhook".to_string());
         Self {
             app_id,
             app_secret,
             proxy: None,
+            connection_mode,
             message_handler: None,
             running: Arc::new(AtomicBool::new(false)),
             client: Self::build_client(None),
@@ -524,11 +530,17 @@ impl FeishuChannel {
             .or_else(|| std::env::var("FEISHU_APP_SECRET").ok())
             .unwrap_or_default();
         let proxy = config.proxy.clone();
+        let connection_mode = config
+            .connection_mode
+            .clone()
+            .or_else(|| std::env::var("FEISHU_CONNECTION_MODE").ok())
+            .unwrap_or_else(|| "webhook".to_string());
         let client = Self::build_client(proxy.as_deref());
         Self {
             app_id,
             app_secret,
             proxy,
+            connection_mode,
             message_handler: None,
             running: Arc::new(AtomicBool::new(false)),
             client,
@@ -694,7 +706,7 @@ impl FeishuChannel {
                 .get("msg")
                 .and_then(|m| m.as_str())
                 .unwrap_or("unknown error");
-            let retryable = status.is_server_error() || code == 99991400; // rate limit
+            let retryable = status.is_server_error() || code == 99991400;
             error!("Feishu send failed: code={code}, msg={msg}, status={status}");
             Ok(SendResult {
                 success: false,
@@ -704,6 +716,203 @@ impl FeishuChannel {
             })
         }
     }
+
+    /// Spawn the WebSocket event loop in a background task.
+    fn spawn_ws_loop(
+        &self,
+        handler: tokio::sync::mpsc::Sender<InboundMessage>,
+        running: Arc<AtomicBool>,
+    ) {
+        let app_id = self.app_id.clone();
+        let app_secret = self.app_secret.clone();
+
+        tokio::spawn(async move {
+            run_ws_event_loop(app_id, app_secret, handler, running).await;
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket event loop
+// ---------------------------------------------------------------------------
+
+/// WebSocket frame types from Feishu long-connection protocol.
+#[derive(Debug, Deserialize)]
+struct WsFrame {
+    #[serde(default)]
+    cmd: Option<String>,
+    #[serde(default)]
+    data: Option<serde_json::Value>,
+    #[serde(default)]
+    msg_id: Option<String>,
+}
+
+/// Auth request sent to Feishu after WebSocket connection.
+#[derive(Debug, Serialize)]
+struct WsAuthRequest {
+    cmd: String,
+    data: WsAuthData,
+}
+
+#[derive(Debug, Serialize)]
+struct WsAuthData {
+    app_id: String,
+    app_secret: String,
+}
+
+/// Run the WebSocket event loop for Feishu long-connection mode.
+///
+/// Connects to Feishu's WebSocket endpoint, authenticates with app credentials,
+/// and forwards incoming events to the message handler.
+async fn run_ws_event_loop(
+    app_id: String,
+    app_secret: String,
+    handler: tokio::sync::mpsc::Sender<InboundMessage>,
+    running: Arc<AtomicBool>,
+) {
+    while running.load(Ordering::Relaxed) {
+        if let Err(e) = ws_connect_and_listen(&app_id, &app_secret, &handler, &running).await {
+            error!("[feishu:ws] connection error: {e}");
+        }
+
+        if !running.load(Ordering::Relaxed) {
+            break;
+        }
+
+        info!(
+            "[feishu:ws] reconnecting in {}s...",
+            WS_RECONNECT_DELAY_SECS
+        );
+        tokio::time::sleep(Duration::from_secs(WS_RECONNECT_DELAY_SECS)).await;
+    }
+
+    info!("[feishu:ws] event loop exited");
+}
+
+/// Connect to Feishu WebSocket, authenticate, and process incoming frames.
+async fn ws_connect_and_listen(
+    app_id: &str,
+    app_secret: &str,
+    handler: &tokio::sync::mpsc::Sender<InboundMessage>,
+    running: &AtomicBool,
+) -> Result<()> {
+    info!("[feishu:ws] connecting to {FEISHU_WS_URL}");
+    let (ws_stream, _) = connect_async(FEISHU_WS_URL)
+        .await
+        .context("Feishu WebSocket connect failed")?;
+
+    info!("[feishu:ws] connected, authenticating");
+    let (mut write, mut read) = ws_stream.split();
+
+    // Send authentication frame.
+    let auth = WsAuthRequest {
+        cmd: "command".to_string(),
+        data: WsAuthData {
+            app_id: app_id.to_string(),
+            app_secret: app_secret.to_string(),
+        },
+    };
+    let auth_json = serde_json::to_string(&auth).context("serialize WS auth")?;
+    write
+        .send(Message::Text(auth_json))
+        .await
+        .context("send WS auth")?;
+
+    // Process incoming frames.
+    while let Some(msg) = read.next().await {
+        if !running.load(Ordering::Relaxed) {
+            info!("[feishu:ws] shutting down");
+            break;
+        }
+
+        let msg = match msg {
+            Ok(m) => m,
+            Err(e) => {
+                warn!("[feishu:ws] read error: {e}");
+                break;
+            }
+        };
+
+        match msg {
+            Message::Text(text) => {
+                if let Err(e) = handle_ws_text_frame(&text, handler).await {
+                    debug!("[feishu:ws] frame handling error: {e}");
+                }
+            }
+            Message::Ping(data) => {
+                if let Err(e) = write.send(Message::Pong(data)).await {
+                    warn!("[feishu:ws] pong error: {e}");
+                    break;
+                }
+            }
+            Message::Close(_) => {
+                info!("[feishu:ws] server closed connection");
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let _ = write.close().await;
+    Ok(())
+}
+
+/// Handle a text frame from the Feishu WebSocket.
+async fn handle_ws_text_frame(
+    text: &str,
+    handler: &tokio::sync::mpsc::Sender<InboundMessage>,
+) -> Result<()> {
+    let frame: WsFrame = serde_json::from_str(text).context("parse WS frame")?;
+
+    match frame.cmd.as_deref() {
+        Some("command") => {
+            // Auth response or config response.
+            if let Some(data) = &frame.data {
+                let code = data.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
+                if code == 0 {
+                    info!("[feishu:ws] authentication successful");
+                } else {
+                    let msg = data
+                        .get("msg")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("unknown");
+                    error!("[feishu:ws] auth failed: code={code}, msg={msg}");
+                }
+            }
+        }
+        Some("ping") => {
+            // Server ping — handled at the Message::Ping level.
+            debug!("[feishu:ws] received server ping");
+        }
+        Some("event") | Some("callback") => {
+            // Event callback via WebSocket.
+            if let Some(event_data) = frame.data {
+                if let Ok(event_bytes) = serde_json::to_vec(&event_data) {
+                    match parse_webhook(&event_bytes) {
+                        Ok(WebhookResult::Messages(msgs)) => {
+                            for msg in msgs {
+                                if let Err(e) = handler.send(msg).await {
+                                    warn!("[feishu:ws] failed to forward message: {e}");
+                                }
+                            }
+                        }
+                        Ok(WebhookResult::Challenge(_)) => {
+                            debug!("[feishu:ws] challenge event via WS — not applicable");
+                        }
+                        Ok(WebhookResult::Ignored) => {}
+                        Err(e) => {
+                            debug!("[feishu:ws] event parse error: {e}");
+                        }
+                    }
+                }
+            }
+        }
+        other => {
+            debug!("[feishu:ws] unknown cmd: {:?}", other);
+        }
+    }
+
+    Ok(())
 }
 
 #[async_trait]
@@ -726,11 +935,34 @@ impl BaseChannel for FeishuChannel {
             return Ok(false);
         }
 
+        let mode = self.connection_mode.to_lowercase();
+        if mode != "websocket" && mode != "webhook" {
+            warn!(
+                "Feishu unsupported connection_mode='{}', expected 'websocket' or 'webhook'",
+                self.connection_mode
+            );
+            return Ok(false);
+        }
+
         // Pre-fetch tenant_access_token to validate credentials.
         match self.get_access_token().await {
             Ok(_) => {
                 self.running.store(true, Ordering::Relaxed);
-                info!("Feishu channel connected (app_id={})", self.app_id);
+
+                if mode == "websocket" {
+                    if let Some(handler) = self.message_handler.clone() {
+                        self.spawn_ws_loop(handler, self.running.clone());
+                    }
+                    info!(
+                        "Feishu channel connected via WebSocket (app_id={})",
+                        self.app_id
+                    );
+                } else {
+                    info!(
+                        "Feishu channel connected via Webhook (app_id={})",
+                        self.app_id
+                    );
+                }
                 Ok(true)
             }
             Err(e) => {

--- a/crates/kestrel-config/src/python_migrate.rs
+++ b/crates/kestrel-config/src/python_migrate.rs
@@ -600,7 +600,7 @@ fn convert_channels(
             app_secret: f.app_secret.clone(),
             enabled: f.enabled.unwrap_or(true),
             proxy: None,
-            connection_mode: None,
+            ..Default::default()
         });
         report.add_mapped("channels.feishu (appId → app_id, appSecret → app_secret)");
     }

--- a/crates/kestrel-config/src/python_migrate.rs
+++ b/crates/kestrel-config/src/python_migrate.rs
@@ -600,6 +600,7 @@ fn convert_channels(
             app_secret: f.app_secret.clone(),
             enabled: f.enabled.unwrap_or(true),
             proxy: None,
+            connection_mode: None,
         });
         report.add_mapped("channels.feishu (appId → app_id, appSecret → app_secret)");
     }

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -412,6 +412,18 @@ pub struct FeishuConfig {
     pub connection_mode: Option<String>,
 }
 
+impl Default for FeishuConfig {
+    fn default() -> Self {
+        Self {
+            app_id: None,
+            app_secret: None,
+            enabled: true,
+            proxy: None,
+            connection_mode: None,
+        }
+    }
+}
+
 /// WeCom (Enterprise WeChat) channel configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -404,6 +404,12 @@ pub struct FeishuConfig {
     /// - empty or absent → direct connection (no proxy)
     #[serde(default)]
     pub proxy: Option<String>,
+    /// Connection mode: `"websocket"` or `"webhook"` (default: `"webhook"`).
+    ///
+    /// WebSocket mode establishes a persistent outbound connection to Feishu,
+    /// no public endpoint needed. Also reads from `FEISHU_CONNECTION_MODE` env var.
+    #[serde(default)]
+    pub connection_mode: Option<String>,
 }
 
 /// WeCom (Enterprise WeChat) channel configuration.

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -2892,7 +2892,7 @@ token = "${MISSING_BBB}"
             app_secret: Some("secret".to_string()),
             enabled: true,
             proxy: None,
-            connection_mode: None,
+            ..Default::default()
         });
         let report = validate(&config);
         assert!(!report.is_valid());
@@ -2910,7 +2910,7 @@ token = "${MISSING_BBB}"
             app_secret: None,
             enabled: true,
             proxy: None,
-            connection_mode: None,
+            ..Default::default()
         });
         let report = validate(&config);
         assert!(!report.is_valid());

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -2892,6 +2892,7 @@ token = "${MISSING_BBB}"
             app_secret: Some("secret".to_string()),
             enabled: true,
             proxy: None,
+            connection_mode: None,
         });
         let report = validate(&config);
         assert!(!report.is_valid());
@@ -2909,6 +2910,7 @@ token = "${MISSING_BBB}"
             app_secret: None,
             enabled: true,
             proxy: None,
+            connection_mode: None,
         });
         let report = validate(&config);
         assert!(!report.is_valid());

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -543,6 +543,7 @@ fn configure_feishu(io: &dyn WizardIo, config: &mut Config) -> Result<()> {
         app_secret: Some(result.app_secret),
         enabled: true,
         proxy: existing_proxy,
+        ..Default::default()
     });
 
     Ok(())


### PR DESCRIPTION
## Summary
Closes #231

Adds WebSocket long-connection mode to the Feishu channel adapter, enabling event delivery without a public webhook endpoint.

### Changes
- **Config**: Added \connection_mode\ field to \FeishuConfig\ (values: \websocket\ / \webhook\, default: \webhook\). Also reads from \FEISHU_CONNECTION_MODE\ env var.
- **WebSocket client**: Implemented using \	okio-tungstenite\ to connect to \wss://open.feishu.cn/open-apis/callback/ws/event\.
- **Auth protocol**: Sends app_id/app_secret as JSON auth frame after connection.
- **Event loop**: Background task processes incoming frames (event/callback commands), reuses \parse_webhook()\ for message extraction, and forwards to the message bus.
- **Auto-reconnect**: Reconnects with 5s delay on disconnect while running.
- **Connect flow**: Updated \connect()\ to select WebSocket or Webhook mode based on config.

### Testing
- Local compilation deferred to CI per project rules.