### PR TITLE
fix(tools): use /c flag for cmd.exe on Windows in shell build_command

### DIFF
--- a/crates/kestrel-tools/src/builtins/shell.rs
+++ b/crates/kestrel-tools/src/builtins/shell.rs
@@ -200,7 +200,10 @@ fn build_command(command: &str, dangerous: bool, max_memory_kib: u64) -> Command
     let mut cmd = if dangerous || kestrel_config::platform::is_android() {
         // No ulimit wrapper — safe to use user's preferred shell
         let mut c = Command::new(&shell);
+        #[cfg(unix)]
         c.arg("-c").arg(command);
+        #[cfg(not(unix))]
+        c.arg("/c").arg(command);
         c
     } else {
         #[cfg(unix)]
@@ -220,7 +223,7 @@ fn build_command(command: &str, dangerous: bool, max_memory_kib: u64) -> Command
         {
             let _ = max_memory_kib;
             let mut c = Command::new(&shell);
-            c.arg("-c").arg(command);
+            c.arg("/c").arg(command);
             c
         }
     };


### PR DESCRIPTION
## Summary

Closes #248

\shell.rs\ \uild_command()\ used POSIX \-c\ flag on all platforms, but Windows \cmd.exe\ expects \/c\.

### Changes

- **Dangerous/android branch**: Added \#[cfg(unix)]\ for \-c\ and \#[cfg(not(unix))]\ for \/c\
- **Non-dangerous \#[cfg(not(unix))]\ branch**: Changed \-c\ to \/c\

### Testing

CI will validate. ExecTool will work correctly on Windows after this fix.