### PR TITLE
feat(tools): add built-in Lua script engine (ScriptTool)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2035,7 @@ dependencies = [
  "kestrel-memory",
  "kestrel-security",
  "kestrel-skill",
+ "mlua",
  "notify",
  "parking_lot",
  "regex",
@@ -2160,6 +2171,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lua-src"
+version = "550.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.6.6+707c12b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,6 +2277,40 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlua"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
+dependencies = [
+ "bstr",
+ "either",
+ "erased-serde",
+ "futures-util",
+ "libc",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2411,6 +2475,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -3012,6 +3085,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,7 +3470,7 @@ checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
 dependencies = [
  "fnv",
  "nom",
- "ordered-float",
+ "ordered-float 5.3.0",
  "serde",
  "serde_json",
 ]
@@ -4145,6 +4228,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/kestrel-tools/Cargo.toml
+++ b/crates/kestrel-tools/Cargo.toml
@@ -30,6 +30,12 @@ toml = { workspace = true }
 
 notify = { version = "6", default-features = false, features = ["macos_fsevent"] }
 
+mlua = { version = "0.11", features = ["lua54", "vendored", "async", "serialize"], optional = true }
+
+[features]
+default = ["lua-script"]
+lua-script = ["mlua"]
+
 [dev-dependencies]
 tokio = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/kestrel-tools/src/builtins/mod.rs
+++ b/crates/kestrel-tools/src/builtins/mod.rs
@@ -4,6 +4,8 @@ pub mod cron;
 pub mod filesystem;
 pub mod memory;
 pub mod message;
+#[cfg(feature = "lua-script")]
+pub mod script;
 pub mod search;
 pub mod shell;
 pub mod spawn;
@@ -39,6 +41,8 @@ pub fn register_all_with_config(registry: &ToolRegistry, config: BuiltinsConfig)
     registry.register(message::MessageTool::new());
     registry.register(cron::CronTool::new());
     registry.register(spawn::SpawnTool::new());
+    #[cfg(feature = "lua-script")]
+    registry.register(script::ScriptTool::new().dangerous(config.dangerous));
 }
 
 /// Register memory tools that require a memory store.
@@ -68,6 +72,8 @@ mod tests {
         );
         assert!(registry.is_mutating("cron"), "cron should be mutating");
         assert!(registry.is_mutating("spawn"), "spawn should be mutating");
+        #[cfg(feature = "lua-script")]
+        assert!(registry.is_mutating("script"), "script should be mutating");
         assert!(
             registry.is_mutating("send_message"),
             "send_message should be mutating"

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -1031,7 +1031,10 @@ mod tests {
         } else {
             "/etc/test"
         };
-        let code = format!("kestrel.write_file('{}', 'hacked')", blocked_path.replace('\\', "\\\\"));
+        let code = format!(
+            "kestrel.write_file('{}', 'hacked')",
+            blocked_path.replace('\\', "\\\\")
+        );
         let result = tool.execute(json!({"code": code})).await;
         // Should either error at Lua level or Rust level
         assert!(result.is_err() || result.unwrap().contains("not allowed"));

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 const DEFAULT_SCRIPT_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
@@ -100,6 +100,9 @@ impl ScriptTool {
 
     /// Create a sandboxed Lua VM with restricted standard libraries.
     fn create_sandboxed_vm(&self) -> Result<Lua, ToolError> {
+        if self.dangerous {
+            info!("Creating script VM in dangerous mode — all standard libraries enabled");
+        }
         let safe_libs = if self.dangerous {
             // Dangerous mode: all standard libraries
             StdLib::ALL
@@ -251,6 +254,12 @@ impl ScriptTool {
                     let content_len = content.len();
                     let prev = wc.fetch_add(content_len, Ordering::SeqCst);
                     if prev + content_len > max_write_bytes {
+                        warn!(
+                            path,
+                            write_bytes = prev + content_len,
+                            max_write_bytes,
+                            "Script write limit exceeded"
+                        );
                         return Err(mlua::Error::external(format!(
                             "Write limit exceeded: {} bytes (max {})",
                             prev + content_len,
@@ -259,6 +268,10 @@ impl ScriptTool {
                     }
                     let file_count = wfc.fetch_add(1, Ordering::SeqCst) + 1;
                     if file_count > max_write_files {
+                        warn!(
+                            path,
+                            file_count, max_write_files, "Script file count limit exceeded"
+                        );
                         return Err(mlua::Error::external(format!(
                             "File count limit exceeded: {} files (max {})",
                             file_count, max_write_files
@@ -501,9 +514,11 @@ impl Tool for ScriptTool {
         let timeout_secs = args["timeout"].as_u64().unwrap_or(self.timeout.as_secs());
 
         debug!(
-            "Executing Lua script ({} chars, timeout: {}s)",
-            code.len(),
-            timeout_secs
+            code_len = code.len(),
+            timeout_secs,
+            dangerous = self.dangerous,
+            max_instructions = self.max_instructions,
+            "Script execution starting"
         );
 
         let lua = self.create_sandboxed_vm()?;
@@ -517,6 +532,10 @@ impl Tool for ScriptTool {
                 move |_lua, _debug| {
                     let count = instruction_counter.fetch_add(1000, Ordering::Relaxed);
                     if count >= max_instructions {
+                        warn!(
+                            instruction_count = count,
+                            max_instructions, "Script instruction limit exceeded, aborting"
+                        );
                         return Err(mlua::Error::external(format!(
                             "Instruction limit exceeded (max {})",
                             max_instructions
@@ -564,16 +583,9 @@ impl Tool for ScriptTool {
             .map_err(|e| ToolError::Execution(format!("Failed to set print: {}", e)))?;
 
         // Execute the script with timeout
-        // Lua is not Send, so we execute on the current thread with a manual timeout check.
-        // For truly async timeout, we use tokio::task::block_in_place which doesn't require Send.
         let max_output = self.max_output_bytes;
+        let start = std::time::Instant::now();
         let exec_result: Result<(), ToolError> = tokio::task::block_in_place(|| {
-            // Set up an alarm-based timeout for blocking execution
-            let start = std::time::Instant::now();
-
-            // We wrap execution in a thread that we can join with a timeout
-            // Note: Lua cannot be sent between threads. Execute directly but
-            // check elapsed time before execution.
             if start.elapsed() > Duration::from_secs(timeout_secs) {
                 return Err(ToolError::Timeout(format!(
                     "Script timed out after {}s",
@@ -581,35 +593,59 @@ impl Tool for ScriptTool {
                 )));
             }
 
-            // Execute the Lua script directly
             match lua.load(code).exec() {
                 Ok(()) => Ok(()),
                 Err(e) => Err(ToolError::Execution(format!("Lua error: {}", e))),
             }
         });
 
-        exec_result?;
+        let elapsed_ms = start.elapsed().as_millis();
 
-        // Collect captured output
-        let output = {
-            let buf = stdout_buf.lock().unwrap();
-            String::from_utf8_lossy(&buf).to_string()
-        };
+        match &exec_result {
+            Ok(()) => {
+                // Collect captured output
+                let output = {
+                    let buf = stdout_buf.lock().unwrap();
+                    String::from_utf8_lossy(&buf).to_string()
+                };
 
-        if output.is_empty() {
-            Ok("(script completed, no output)".to_string())
-        } else if output.len() > MAX_TOOL_OUTPUT_LENGTH {
-            let mut truncated = output[..MAX_TOOL_OUTPUT_LENGTH].to_string();
-            truncated.push_str("\n... (output truncated)");
-            Ok(truncated)
-        } else if output.len() > max_output {
-            Ok(format!(
-                "{}\n... (output truncated at {} bytes)",
-                &output[..max_output.min(output.len())],
-                max_output
-            ))
-        } else {
-            Ok(output)
+                let output_len = output.len();
+                let truncated = output_len > MAX_TOOL_OUTPUT_LENGTH || output_len > max_output;
+
+                info!(
+                    duration_ms = elapsed_ms,
+                    output_len,
+                    truncated,
+                    dangerous = self.dangerous,
+                    "Script execution completed"
+                );
+
+                if output.is_empty() {
+                    Ok("(script completed, no output)".to_string())
+                } else if output.len() > MAX_TOOL_OUTPUT_LENGTH {
+                    let mut truncated_output = output[..MAX_TOOL_OUTPUT_LENGTH].to_string();
+                    truncated_output.push_str("\n... (output truncated)");
+                    Ok(truncated_output)
+                } else if output.len() > max_output {
+                    Ok(format!(
+                        "{}\n... (output truncated at {} bytes)",
+                        &output[..max_output.min(output.len())],
+                        max_output
+                    ))
+                } else {
+                    Ok(output)
+                }
+            }
+            Err(e) => {
+                warn!(
+                    duration_ms = elapsed_ms,
+                    error = %e,
+                    dangerous = self.dangerous,
+                    "Script execution failed"
+                );
+                exec_result?;
+                unreachable!()
+            }
         }
     }
 }
@@ -624,6 +660,11 @@ fn validate_write_path(path: &str) -> Result<(), mlua::Error> {
     {
         for blocked in BLOCKED_WRITE_PATHS_UNIX {
             if p.starts_with(blocked) {
+                warn!(
+                    path,
+                    blocked_system_path = *blocked,
+                    "Script write blocked: system path"
+                );
                 return Err(mlua::Error::external(format!(
                     "Write to system path '{}' is not allowed",
                     path
@@ -637,6 +678,11 @@ fn validate_write_path(path: &str) -> Result<(), mlua::Error> {
         let lower = path.to_lowercase();
         for blocked in BLOCKED_WRITE_PATHS_WINDOWS {
             if lower.starts_with(&blocked.to_lowercase()) {
+                warn!(
+                    path,
+                    blocked_system_path = *blocked,
+                    "Script write blocked: system path"
+                );
                 return Err(mlua::Error::external(format!(
                     "Write to system path '{}' is not allowed",
                     path
@@ -650,6 +696,11 @@ fn validate_write_path(path: &str) -> Result<(), mlua::Error> {
         let lower = file_name.to_lowercase();
         for blocked in BLOCKED_HOME_SUBPATHS {
             if lower == *blocked {
+                warn!(
+                    path,
+                    sensitive_component = *blocked,
+                    "Script write blocked: sensitive path"
+                );
                 return Err(mlua::Error::external(format!(
                     "Write to sensitive path '{}' is not allowed",
                     path
@@ -673,6 +724,11 @@ fn validate_write_path(path: &str) -> Result<(), mlua::Error> {
             .collect();
         for blocked in BLOCKED_HOME_SUBPATHS {
             if components.iter().any(|c| c == *blocked) {
+                warn!(
+                    path,
+                    sensitive_component = *blocked,
+                    "Script write blocked: sensitive path in components"
+                );
                 return Err(mlua::Error::external(format!(
                     "Write to sensitive path '{}' is not allowed",
                     path

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -887,7 +887,7 @@ mod tests {
         assert!(tool.dangerous);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_missing_code() {
         let tool = ScriptTool::new();
         let result = tool.execute(json!({})).await;
@@ -895,7 +895,7 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("Missing 'code'"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_hello_world() {
         let tool = ScriptTool::new();
         let result = tool.execute(json!({"code": "print('hello world')"})).await;
@@ -903,7 +903,7 @@ mod tests {
         assert!(result.unwrap().contains("hello world"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_string_operations() {
         let tool = ScriptTool::new();
         let result = tool
@@ -913,7 +913,7 @@ mod tests {
         assert!(result.unwrap().contains("result: 50"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_table_operations() {
         let tool = ScriptTool::new();
         let result = tool
@@ -925,7 +925,7 @@ mod tests {
         assert!(result.unwrap().contains("1,2,3"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_json_decode_encode() {
         let tool = ScriptTool::new();
         let result = tool
@@ -937,7 +937,7 @@ mod tests {
         assert!(output.contains("42"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_json_encode() {
         let tool = ScriptTool::new();
         let result = tool
@@ -949,7 +949,7 @@ mod tests {
         assert!(output.contains("world"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_platform() {
         let tool = ScriptTool::new();
         let result = tool
@@ -963,7 +963,7 @@ mod tests {
         assert!(output.contains("linux") || output.contains("macos") || output.contains("android"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_sandbox_blocks_io() {
         let tool = ScriptTool::new();
         let result = tool
@@ -973,7 +973,7 @@ mod tests {
         assert!(err_msg.contains("nil") || err_msg.contains("error"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_sandbox_blocks_os_execute() {
         let tool = ScriptTool::new();
         // Our safe os table has no execute method, so this should error
@@ -983,14 +983,14 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_sandbox_blocks_require() {
         let tool = ScriptTool::new();
         let result = tool.execute(json!({"code": "require('os')"})).await;
         assert!(result.is_err());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_read_file() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("test.txt");
@@ -1008,7 +1008,7 @@ mod tests {
         assert!(output.contains("line3"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_write_file() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("output.txt");
@@ -1023,7 +1023,7 @@ mod tests {
         assert_eq!(content, "hello from lua");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_write_file_blocked_system_path() {
         let tool = ScriptTool::new();
         let result = tool
@@ -1033,7 +1033,7 @@ mod tests {
         assert!(result.is_err() || result.unwrap().contains("not allowed"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_list_dir() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("a.txt"), "").unwrap();
@@ -1052,7 +1052,7 @@ mod tests {
         assert!(output.contains("b.rs"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_exists() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("exists.txt");
@@ -1071,7 +1071,7 @@ mod tests {
         assert!(output.contains("false"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_math_and_loop() {
         let tool = ScriptTool::new();
         let result = tool
@@ -1083,7 +1083,7 @@ mod tests {
         assert!(result.unwrap().contains("5050"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_env() {
         let tool = ScriptTool::new();
         let code = r#"

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -29,6 +29,7 @@ const BLOCKED_WRITE_PATHS_UNIX: &[&str] = &[
     "/opt",
 ];
 
+#[cfg(windows)]
 const BLOCKED_WRITE_PATHS_WINDOWS: &[&str] = &[
     "C:\\Windows",
     "C:\\Program Files",
@@ -912,16 +913,14 @@ mod tests {
         let result = tool
             .execute(json!({"code": "io.open('/tmp/test', 'w')"}))
             .await;
-        assert!(result.is_err());
-        assert!(
-            result.unwrap_err().to_string().contains("nil")
-                || result.unwrap_err().to_string().contains("error")
-        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("nil") || err_msg.contains("error"));
     }
 
     #[tokio::test]
     async fn test_script_sandbox_blocks_os_execute() {
         let tool = ScriptTool::new();
+        // Our safe os table has no execute method, so this should error
         let result = tool
             .execute(json!({"code": "os.execute('echo pwned')"}))
             .await;

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -1026,9 +1026,13 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_script_write_file_blocked_system_path() {
         let tool = ScriptTool::new();
-        let result = tool
-            .execute(json!({"code": "kestrel.write_file('/etc/test', 'hacked')"}))
-            .await;
+        let blocked_path = if cfg!(windows) {
+            r"C:\Windows\System32\kestrel_test.txt"
+        } else {
+            "/etc/test"
+        };
+        let code = format!("kestrel.write_file('{}', 'hacked')", blocked_path.replace('\\', "\\\\"));
+        let result = tool.execute(json!({"code": code})).await;
         // Should either error at Lua level or Rust level
         assert!(result.is_err() || result.unwrap().contains("not allowed"));
     }

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -107,8 +107,8 @@ impl ScriptTool {
             // Dangerous mode: all standard libraries
             StdLib::ALL
         } else {
-            // Safe mode: only non-dangerous libraries
-            StdLib::STRING | StdLib::TABLE | StdLib::MATH | StdLib::UTF8 | StdLib::PACKAGE
+            // Safe mode: only non-dangerous libraries (no PACKAGE to prevent loader abuse)
+            StdLib::STRING | StdLib::TABLE | StdLib::MATH | StdLib::UTF8
         };
 
         let lua = unsafe { Lua::unsafe_new_with(safe_libs, LuaOptions::default()) };
@@ -128,6 +128,9 @@ impl ScriptTool {
             globals
                 .set("loadfile", mlua::Value::Nil)
                 .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
+            globals
+                .set("package", mlua::Value::Nil)
+                .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
 
             // Replace os table with safe subset (date, time, clock only)
             let os_safe = lua.create_table().map_err(|e| {
@@ -143,13 +146,11 @@ impl ScriptTool {
                             .unwrap_or_default()
                             .as_secs() as i64
                     });
-                    // Use Lua's own os.date if available, otherwise return time
-                    let format = fmt.unwrap_or_else(|| "%c".to_string());
-                    // Simple implementation: return formatted time string
-                    lua.create_string(format!(
-                        "os.date({}) not fully implemented - timestamp: {}",
-                        format, time_val
-                    ))
+                    let dt = chrono::DateTime::from_timestamp(time_val, 0)
+                        .unwrap_or(chrono::DateTime::UNIX_EPOCH);
+                    let format = fmt.unwrap_or_else(|| "%Y-%m-%d %H:%M:%S".to_string());
+                    // Lua strftime tokens are mostly compatible with chrono; pass through directly
+                    lua.create_string(dt.format(&format).to_string())
                 })
                 .map_err(|e| ToolError::Execution(format!("Failed to create os.date: {}", e)))?;
             os_safe
@@ -169,11 +170,12 @@ impl ScriptTool {
                 .set("time", os_time_fn)
                 .map_err(|e| ToolError::Execution(format!("Failed to set os.time: {}", e)))?;
 
-            // os.clock() -> elapsed CPU time
+            // os.clock() -> elapsed wall-clock time since first call
+            let clock_start = Arc::new(std::sync::Mutex::new(std::time::Instant::now()));
             let os_clock_fn = lua
-                .create_function(|_, _: ()| {
-                    // Return a simple elapsed time approximation
-                    Ok(0.0f64)
+                .create_function(move |_, _: ()| {
+                    let start = clock_start.lock().unwrap();
+                    Ok(start.elapsed().as_secs_f64())
                 })
                 .map_err(|e| ToolError::Execution(format!("Failed to create os.clock: {}", e)))?;
             os_safe
@@ -372,6 +374,7 @@ impl ScriptTool {
         // --- kestrel.mkdir(path) ---
         let mkdir_fn = lua
             .create_function(|_, path: String| {
+                validate_write_path(&path)?;
                 std::fs::create_dir_all(&path)
                     .map_err(|e| mlua::Error::external(format!("mkdir failed: {}", e)))
             })
@@ -383,6 +386,7 @@ impl ScriptTool {
         // --- kestrel.remove(path) ---
         let remove_fn = lua
             .create_function(|_, path: String| {
+                validate_write_path(&path)?;
                 let p = Path::new(&path);
                 if p.is_dir() {
                     std::fs::remove_dir_all(p)
@@ -523,10 +527,12 @@ impl Tool for ScriptTool {
 
         let lua = self.create_sandboxed_vm()?;
 
-        // Set up instruction limit via debug hook
+        // Set up instruction limit and wall-clock timeout via debug hook
+        let start = std::time::Instant::now();
         if !self.dangerous {
             let max_instructions = self.max_instructions;
             let instruction_counter = Arc::new(AtomicUsize::new(0));
+            let timeout = Duration::from_secs(timeout_secs);
             lua.set_hook(
                 HookTriggers::new().every_nth_instruction(1000),
                 move |_lua, _debug| {
@@ -539,6 +545,17 @@ impl Tool for ScriptTool {
                         return Err(mlua::Error::external(format!(
                             "Instruction limit exceeded (max {})",
                             max_instructions
+                        )));
+                    }
+                    if start.elapsed() > timeout {
+                        warn!(
+                            elapsed_secs = start.elapsed().as_secs(),
+                            timeout_secs = timeout.as_secs(),
+                            "Script timed out, aborting"
+                        );
+                        return Err(mlua::Error::external(format!(
+                            "Script timed out after {}s",
+                            timeout.as_secs()
                         )));
                     }
                     Ok(VmState::Continue)
@@ -582,22 +599,13 @@ impl Tool for ScriptTool {
             .set("print", print_capture)
             .map_err(|e| ToolError::Execution(format!("Failed to set print: {}", e)))?;
 
-        // Execute the script with timeout
+        // Execute the script
         let max_output = self.max_output_bytes;
-        let start = std::time::Instant::now();
-        let exec_result: Result<(), ToolError> = tokio::task::block_in_place(|| {
-            if start.elapsed() > Duration::from_secs(timeout_secs) {
-                return Err(ToolError::Timeout(format!(
-                    "Script timed out after {}s",
-                    timeout_secs
-                )));
-            }
-
-            match lua.load(code).exec() {
+        let exec_result: Result<(), ToolError> =
+            tokio::task::block_in_place(|| match lua.load(code).exec() {
                 Ok(()) => Ok(()),
                 Err(e) => Err(ToolError::Execution(format!("Lua error: {}", e))),
-            }
-        });
+            });
 
         let elapsed_ms = start.elapsed().as_millis();
 
@@ -808,32 +816,47 @@ fn lua_value_to_json(val: &mlua::Value) -> Result<Value, mlua::Error> {
         mlua::Value::Number(n) => Ok(json!(*n)),
         mlua::Value::String(s) => Ok(Value::String(s.to_str()?.to_string())),
         mlua::Value::Table(t) => {
-            // Determine if array or object
-            let mut is_array = true;
-            let mut max_key = 0i64;
-            for pair in t.sequence_values::<mlua::Value>() {
-                match pair {
-                    Ok(_) => max_key += 1,
-                    Err(_) => {
-                        is_array = false;
-                        break;
+            // Collect integer-keyed and string-keyed entries separately
+            let mut arr = Vec::new();
+            let mut has_int_keys = false;
+            for i in 1.. {
+                let v: mlua::Value = match t.get(i) {
+                    Ok(v) => v,
+                    Err(_) => break, // no more integer keys
+                };
+                if v.is_nil() {
+                    break;
+                }
+                has_int_keys = true;
+                arr.push(lua_value_to_json(&v)?);
+            }
+
+            let mut obj = serde_json::Map::new();
+            for pair in t.pairs::<mlua::Value, mlua::Value>() {
+                let (k, v): (mlua::Value, mlua::Value) = pair?;
+                match &k {
+                    mlua::Value::Integer(n) if *n >= 1 => continue, // already handled above
+                    mlua::Value::String(s) => {
+                        obj.insert(s.to_str()?.to_string(), lua_value_to_json(&v)?);
                     }
+                    _ => {} // skip other key types
                 }
             }
 
-            if is_array && max_key > 0 {
-                let mut arr = Vec::new();
-                for i in 1..=max_key {
-                    let v: mlua::Value = t.get(i)?;
-                    arr.push(lua_value_to_json(&v)?);
-                }
+            if has_int_keys && obj.is_empty() {
+                // Pure array
                 Ok(Value::Array(arr))
-            } else {
-                let mut obj = serde_json::Map::new();
-                for pair in t.pairs::<String, mlua::Value>() {
-                    let (k, v): (String, mlua::Value) = pair?;
-                    obj.insert(k, lua_value_to_json(&v)?);
+            } else if has_int_keys {
+                // Mixed: encode as object with integer keys as string keys
+                let mut mixed = serde_json::Map::new();
+                for (i, v) in arr.iter().enumerate() {
+                    mixed.insert((i + 1).to_string(), v.clone());
                 }
+                for (k, v) in obj {
+                    mixed.insert(k, v);
+                }
+                Ok(Value::Object(mixed))
+            } else {
                 Ok(Value::Object(obj))
             }
         }
@@ -1041,6 +1064,32 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_script_mkdir_blocked_system_path() {
+        let tool = ScriptTool::new();
+        let blocked_path = if cfg!(windows) {
+            r"C:\Windows\kestrel_test_dir"
+        } else {
+            "/etc/kestrel_test_dir"
+        };
+        let code = format!("kestrel.mkdir('{}')", blocked_path.replace('\\', "\\\\"));
+        let result = tool.execute(json!({"code": code})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_script_remove_blocked_system_path() {
+        let tool = ScriptTool::new();
+        let blocked_path = if cfg!(windows) {
+            r"C:\Windows\System32\kestrel_test.txt"
+        } else {
+            "/etc/passwd"
+        };
+        let code = format!("kestrel.remove('{}')", blocked_path.replace('\\', "\\\\"));
+        let result = tool.execute(json!({"code": code})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_script_list_dir() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("a.txt"), "").unwrap();
@@ -1088,6 +1137,28 @@ mod tests {
             .await;
         assert!(result.is_ok());
         assert!(result.unwrap().contains("5050"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_script_os_date() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "print(os.date('%Y-%m-%d'))"}))
+            .await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        // Should contain a 4-digit year (e.g. 2026)
+        assert!(output.trim().len() >= 10, "os.date output: {}", output);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_script_os_clock() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "local t = os.clock(); print(type(t))"}))
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("number"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -7,7 +7,7 @@
 use crate::trait_def::{Tool, ToolError};
 use async_trait::async_trait;
 use kestrel_core::MAX_TOOL_OUTPUT_LENGTH;
-use mlua::{Lua, LuaOptions, StdLib};
+use mlua::{HookTriggers, Lua, LuaOptions, StdLib, VmState};
 use serde_json::{json, Value};
 use std::io::Write;
 use std::path::Path;
@@ -20,6 +20,7 @@ const DEFAULT_SCRIPT_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 const DEFAULT_MAX_WRITE_BYTES: usize = 10 * 1024 * 1024;
 const DEFAULT_MAX_WRITE_FILES: usize = 100;
+const DEFAULT_MAX_INSTRUCTIONS: usize = 10_000_000;
 
 /// System paths that are never writable from Lua scripts.
 #[cfg(unix)]
@@ -49,6 +50,7 @@ pub struct ScriptTool {
     max_output_bytes: usize,
     max_write_bytes: usize,
     max_write_files: usize,
+    max_instructions: usize,
     dangerous: bool,
 }
 
@@ -60,6 +62,7 @@ impl ScriptTool {
             max_output_bytes: DEFAULT_MAX_OUTPUT_BYTES,
             max_write_bytes: DEFAULT_MAX_WRITE_BYTES,
             max_write_files: DEFAULT_MAX_WRITE_FILES,
+            max_instructions: DEFAULT_MAX_INSTRUCTIONS,
             dangerous: false,
         }
     }
@@ -107,13 +110,10 @@ impl ScriptTool {
         let lua = unsafe { Lua::unsafe_new_with(safe_libs, LuaOptions::default()) };
 
         if !self.dangerous {
-            // Remove dangerous globals
+            // Remove dangerous globals, but preserve safe os.* subset
             let globals = lua.globals();
             globals
                 .set("io", mlua::Value::Nil)
-                .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
-            globals
-                .set("os", mlua::Value::Nil)
                 .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
             globals
                 .set("require", mlua::Value::Nil)
@@ -124,6 +124,61 @@ impl ScriptTool {
             globals
                 .set("loadfile", mlua::Value::Nil)
                 .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
+
+            // Replace os table with safe subset (date, time, clock only)
+            let os_safe = lua.create_table().map_err(|e| {
+                ToolError::Execution(format!("Failed to create safe os table: {}", e))
+            })?;
+
+            // os.date([format [, time]])
+            let os_date_fn = lua
+                .create_function(|lua, (fmt, t): (Option<String>, Option<i64>)| {
+                    let time_val = t.unwrap_or_else(|| {
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs() as i64
+                    });
+                    // Use Lua's own os.date if available, otherwise return time
+                    let format = fmt.unwrap_or_else(|| "%c".to_string());
+                    // Simple implementation: return formatted time string
+                    lua.create_string(format!(
+                        "os.date({}) not fully implemented - timestamp: {}",
+                        format, time_val
+                    ))
+                })
+                .map_err(|e| ToolError::Execution(format!("Failed to create os.date: {}", e)))?;
+            os_safe
+                .set("date", os_date_fn)
+                .map_err(|e| ToolError::Execution(format!("Failed to set os.date: {}", e)))?;
+
+            // os.time() -> current timestamp
+            let os_time_fn = lua
+                .create_function(|_, _: ()| {
+                    Ok(std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs() as i64)
+                })
+                .map_err(|e| ToolError::Execution(format!("Failed to create os.time: {}", e)))?;
+            os_safe
+                .set("time", os_time_fn)
+                .map_err(|e| ToolError::Execution(format!("Failed to set os.time: {}", e)))?;
+
+            // os.clock() -> elapsed CPU time
+            let os_clock_fn = lua
+                .create_function(|_, _: ()| {
+                    // Return a simple elapsed time approximation
+                    Ok(0.0f64)
+                })
+                .map_err(|e| ToolError::Execution(format!("Failed to create os.clock: {}", e)))?;
+            os_safe
+                .set("clock", os_clock_fn)
+                .map_err(|e| ToolError::Execution(format!("Failed to set os.clock: {}", e)))?;
+
+            globals
+                .set("os", os_safe)
+                .map_err(|e| ToolError::Execution(format!("Failed to set safe os: {}", e)))?;
         }
 
         // Inject kestrel API
@@ -451,6 +506,26 @@ impl Tool for ScriptTool {
         );
 
         let lua = self.create_sandboxed_vm()?;
+
+        // Set up instruction limit via debug hook
+        if !self.dangerous {
+            let max_instructions = self.max_instructions;
+            let instruction_counter = Arc::new(AtomicUsize::new(0));
+            lua.set_hook(
+                HookTriggers::new().every_nth_instruction(1000),
+                move |_lua, _debug| {
+                    let count = instruction_counter.fetch_add(1000, Ordering::Relaxed);
+                    if count >= max_instructions {
+                        return Err(mlua::Error::external(format!(
+                            "Instruction limit exceeded (max {})",
+                            max_instructions
+                        )));
+                    }
+                    Ok(VmState::Continue)
+                },
+            )
+            .map_err(|e| ToolError::Execution(format!("Failed to set instruction hook: {}", e)))?;
+        }
 
         // Set up output capture buffer
         let stdout_buf: Arc<std::sync::Mutex<Vec<u8>>> =

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -1,0 +1,998 @@
+//! Built-in Lua script engine tool.
+//!
+//! Provides a cross-platform sandboxed Lua execution environment for script
+//! orchestration (string processing, JSON, file I/O, batch operations) when
+//! shell commands are unavailable or unreliable (especially on Windows).
+
+use crate::trait_def::{Tool, ToolError};
+use async_trait::async_trait;
+use kestrel_core::MAX_TOOL_OUTPUT_LENGTH;
+use mlua::{Lua, LuaOptions, StdLib};
+use serde_json::{json, Value};
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::debug;
+
+const DEFAULT_SCRIPT_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
+const DEFAULT_MAX_WRITE_BYTES: usize = 10 * 1024 * 1024;
+const DEFAULT_MAX_WRITE_FILES: usize = 100;
+
+/// System paths that are never writable from Lua scripts.
+#[cfg(unix)]
+const BLOCKED_WRITE_PATHS_UNIX: &[&str] = &[
+    "/usr", "/bin", "/sbin", "/etc", "/var", "/sys", "/proc", "/dev", "/boot", "/lib", "/lib64",
+    "/opt",
+];
+
+const BLOCKED_WRITE_PATHS_WINDOWS: &[&str] = &[
+    "C:\\Windows",
+    "C:\\Program Files",
+    "C:\\Program Files (x86)",
+    "C:\\ProgramData",
+];
+
+/// Sensitive paths relative to home directory.
+const BLOCKED_HOME_SUBPATHS: &[&str] = &[".ssh", ".gnupg", ".gitconfig"];
+
+/// Built-in Lua script engine tool.
+///
+/// Provides a cross-platform sandboxed Lua execution environment that
+/// complements the `exec` tool. While `exec` calls external system commands,
+/// `script` handles pure logic orchestration: string processing, JSON
+/// manipulation, batch file operations, and data transformation.
+pub struct ScriptTool {
+    timeout: Duration,
+    max_output_bytes: usize,
+    max_write_bytes: usize,
+    max_write_files: usize,
+    dangerous: bool,
+}
+
+impl ScriptTool {
+    /// Create a new ScriptTool with safe defaults.
+    pub fn new() -> Self {
+        Self {
+            timeout: Duration::from_secs(DEFAULT_SCRIPT_TIMEOUT_SECS),
+            max_output_bytes: DEFAULT_MAX_OUTPUT_BYTES,
+            max_write_bytes: DEFAULT_MAX_WRITE_BYTES,
+            max_write_files: DEFAULT_MAX_WRITE_FILES,
+            dangerous: false,
+        }
+    }
+
+    /// Disable sandbox restrictions for trusted environments.
+    pub fn dangerous(mut self, dangerous: bool) -> Self {
+        self.dangerous = dangerous;
+        self
+    }
+
+    /// Override the default execution timeout.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Override the maximum combined stdout output captured.
+    pub fn with_max_output_bytes(mut self, max: usize) -> Self {
+        self.max_output_bytes = max;
+        self
+    }
+
+    /// Override the maximum total bytes written via `kestrel.write_file`.
+    pub fn with_max_write_bytes(mut self, max: usize) -> Self {
+        self.max_write_bytes = max;
+        self
+    }
+
+    /// Override the maximum number of files written via `kestrel.write_file`.
+    pub fn with_max_write_files(mut self, max: usize) -> Self {
+        self.max_write_files = max;
+        self
+    }
+
+    /// Create a sandboxed Lua VM with restricted standard libraries.
+    fn create_sandboxed_vm(&self) -> Result<Lua, ToolError> {
+        let safe_libs = if self.dangerous {
+            // Dangerous mode: all standard libraries
+            StdLib::ALL
+        } else {
+            // Safe mode: only non-dangerous libraries
+            StdLib::STRING | StdLib::TABLE | StdLib::MATH | StdLib::UTF8 | StdLib::PACKAGE
+        };
+
+        let lua = unsafe { Lua::unsafe_new_with(safe_libs, LuaOptions::default()) };
+
+        if !self.dangerous {
+            // Remove dangerous globals
+            let globals = lua.globals();
+            globals
+                .set("io", mlua::Value::Nil)
+                .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
+            globals
+                .set("os", mlua::Value::Nil)
+                .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
+            globals
+                .set("require", mlua::Value::Nil)
+                .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
+            globals
+                .set("dofile", mlua::Value::Nil)
+                .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
+            globals
+                .set("loadfile", mlua::Value::Nil)
+                .map_err(|e| ToolError::Execution(format!("Failed to sandbox: {}", e)))?;
+        }
+
+        // Inject kestrel API
+        self.inject_kestrel_api(&lua)?;
+
+        Ok(lua)
+    }
+
+    /// Inject the `kestrel` global table with safe helper functions.
+    fn inject_kestrel_api(&self, lua: &Lua) -> Result<(), ToolError> {
+        let kestrel_table = lua
+            .create_table()
+            .map_err(|e| ToolError::Execution(format!("Failed to create kestrel table: {}", e)))?;
+
+        // --- kestrel.read_file(path [, offset, limit]) ---
+        let max_output = self.max_output_bytes;
+        let read_file_fn = lua
+            .create_function(
+                move |lua, (path, offset, limit): (String, Option<usize>, Option<usize>)| {
+                    let content = std::fs::read_to_string(&path).map_err(|e| {
+                        mlua::Error::external(format!("Failed to read {}: {}", path, e))
+                    })?;
+
+                    let lines: Vec<&str> = content.lines().collect();
+                    let off = offset.unwrap_or(0);
+                    let lim = limit;
+
+                    let selected: String = if lim.is_some() || off > 0 {
+                        let iter = lines.iter().skip(off);
+                        let taken: Vec<&str> = if let Some(l) = lim {
+                            iter.take(l).copied().collect()
+                        } else {
+                            iter.copied().collect()
+                        };
+                        taken.join("\n")
+                    } else {
+                        content
+                    };
+
+                    let truncated = if selected.len() > max_output {
+                        &selected[..max_output]
+                    } else {
+                        &selected
+                    };
+
+                    lua.create_string(truncated)
+                },
+            )
+            .map_err(|e| ToolError::Execution(format!("Failed to create read_file: {}", e)))?;
+        kestrel_table
+            .set("read_file", read_file_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set read_file: {}", e)))?;
+
+        // --- kestrel.write_file(path, content [, append]) ---
+        let max_write_bytes = self.max_write_bytes;
+        let max_write_files = self.max_write_files;
+        let write_counter = Arc::new(AtomicUsize::new(0));
+        let write_file_counter = Arc::new(AtomicUsize::new(0));
+
+        let wc = write_counter.clone();
+        let wfc = write_file_counter.clone();
+        let write_file_fn = lua
+            .create_function(
+                move |_, (path, content, append): (String, String, Option<bool>)| {
+                    // Path validation
+                    validate_write_path(&path)?;
+
+                    // Write limits
+                    let content_len = content.len();
+                    let prev = wc.fetch_add(content_len, Ordering::SeqCst);
+                    if prev + content_len > max_write_bytes {
+                        return Err(mlua::Error::external(format!(
+                            "Write limit exceeded: {} bytes (max {})",
+                            prev + content_len,
+                            max_write_bytes
+                        )));
+                    }
+                    let file_count = wfc.fetch_add(1, Ordering::SeqCst) + 1;
+                    if file_count > max_write_files {
+                        return Err(mlua::Error::external(format!(
+                            "File count limit exceeded: {} files (max {})",
+                            file_count, max_write_files
+                        )));
+                    }
+
+                    // Create parent directory if needed
+                    if let Some(parent) = Path::new(&path).parent() {
+                        if !parent.as_os_str().is_empty() {
+                            std::fs::create_dir_all(parent).map_err(|e| {
+                                mlua::Error::external(format!("Failed to create dir: {}", e))
+                            })?;
+                        }
+                    }
+
+                    if append.unwrap_or(false) {
+                        let mut file = std::fs::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open(&path)
+                            .map_err(|e| {
+                                mlua::Error::external(format!("Failed to open {}: {}", path, e))
+                            })?;
+                        file.write_all(content.as_bytes()).map_err(|e| {
+                            mlua::Error::external(format!("Failed to write: {}", e))
+                        })?;
+                        file.flush().map_err(|e| {
+                            mlua::Error::external(format!("Failed to flush: {}", e))
+                        })?;
+                    } else {
+                        std::fs::write(&path, &content).map_err(|e| {
+                            mlua::Error::external(format!("Failed to write {}: {}", path, e))
+                        })?;
+                    }
+
+                    Ok(format!("Wrote {} bytes to {}", content_len, path))
+                },
+            )
+            .map_err(|e| ToolError::Execution(format!("Failed to create write_file: {}", e)))?;
+        kestrel_table
+            .set("write_file", write_file_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set write_file: {}", e)))?;
+
+        // --- kestrel.list_dir(path [, recursive]) ---
+        let list_dir_fn = lua
+            .create_function(|lua, (path, recursive): (String, Option<bool>)| {
+                let mut result = Vec::new();
+                list_dir_recursive(&path, recursive.unwrap_or(false), &mut result, 0)
+                    .map_err(|e| mlua::Error::external(e.to_string()))?;
+
+                let table = lua.create_table()?;
+                for entry in &result {
+                    table.push(lua.create_string(entry)?)?;
+                }
+                Ok(table)
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create list_dir: {}", e)))?;
+        kestrel_table
+            .set("list_dir", list_dir_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set list_dir: {}", e)))?;
+
+        // --- kestrel.exists(path) ---
+        let exists_fn = lua
+            .create_function(|_, path: String| Ok(Path::new(&path).exists()))
+            .map_err(|e| ToolError::Execution(format!("Failed to create exists: {}", e)))?;
+        kestrel_table
+            .set("exists", exists_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set exists: {}", e)))?;
+
+        // --- kestrel.stat(path) ---
+        let stat_fn = lua
+            .create_function(|lua, path: String| {
+                let meta = std::fs::metadata(&path).map_err(|e| {
+                    mlua::Error::external(format!("stat failed for {}: {}", path, e))
+                })?;
+                let table = lua.create_table()?;
+                let file_type = if meta.is_dir() {
+                    "dir"
+                } else if meta.is_file() {
+                    "file"
+                } else {
+                    "other"
+                };
+                table.set("type", file_type)?;
+                table.set("size", meta.len())?;
+                if let Ok(modified) = meta.modified() {
+                    if let Ok(dur) = modified.duration_since(std::time::UNIX_EPOCH) {
+                        table.set("modified_secs", dur.as_secs())?;
+                    }
+                }
+                Ok(table)
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create stat: {}", e)))?;
+        kestrel_table
+            .set("stat", stat_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set stat: {}", e)))?;
+
+        // --- kestrel.mkdir(path) ---
+        let mkdir_fn = lua
+            .create_function(|_, path: String| {
+                std::fs::create_dir_all(&path)
+                    .map_err(|e| mlua::Error::external(format!("mkdir failed: {}", e)))
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create mkdir: {}", e)))?;
+        kestrel_table
+            .set("mkdir", mkdir_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set mkdir: {}", e)))?;
+
+        // --- kestrel.remove(path) ---
+        let remove_fn = lua
+            .create_function(|_, path: String| {
+                let p = Path::new(&path);
+                if p.is_dir() {
+                    std::fs::remove_dir_all(p)
+                } else {
+                    std::fs::remove_file(p)
+                }
+                .map_err(|e| mlua::Error::external(format!("remove failed: {}", e)))
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create remove: {}", e)))?;
+        kestrel_table
+            .set("remove", remove_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set remove: {}", e)))?;
+
+        // --- kestrel.json_decode(string) ---
+        let json_decode_fn = lua
+            .create_function(|lua, json_str: String| {
+                let val: Value = serde_json::from_str(&json_str)
+                    .map_err(|e| mlua::Error::external(format!("JSON decode error: {}", e)))?;
+                json_value_to_lua(lua, &val)
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create json_decode: {}", e)))?;
+        kestrel_table
+            .set("json_decode", json_decode_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set json_decode: {}", e)))?;
+
+        // --- kestrel.json_encode(table) ---
+        let json_encode_fn = lua
+            .create_function(|_, table: mlua::Value| {
+                let json_val = lua_value_to_json(&table)?;
+                serde_json::to_string_pretty(&json_val)
+                    .map_err(|e| mlua::Error::external(format!("JSON encode error: {}", e)))
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create json_encode: {}", e)))?;
+        kestrel_table
+            .set("json_encode", json_encode_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set json_encode: {}", e)))?;
+
+        // --- kestrel.env(name) ---
+        let env_fn = lua
+            .create_function(|lua, name: String| match std::env::var(&name) {
+                Ok(val) => Ok(Some(lua.create_string(&val)?)),
+                Err(_) => Ok(None),
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create env: {}", e)))?;
+        kestrel_table
+            .set("env", env_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set env: {}", e)))?;
+
+        // --- kestrel.platform() ---
+        let platform_fn = lua
+            .create_function(|lua, _: ()| {
+                let platform = if cfg!(windows) {
+                    "windows"
+                } else if kestrel_config::platform::is_android() {
+                    "android"
+                } else if cfg!(target_os = "macos") {
+                    "macos"
+                } else {
+                    "linux"
+                };
+                lua.create_string(platform)
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create platform: {}", e)))?;
+        kestrel_table
+            .set("platform", platform_fn)
+            .map_err(|e| ToolError::Execution(format!("Failed to set platform: {}", e)))?;
+
+        // Set kestrel global
+        lua.globals()
+            .set("kestrel", kestrel_table)
+            .map_err(|e| ToolError::Execution(format!("Failed to set kestrel global: {}", e)))?;
+
+        Ok(())
+    }
+}
+
+impl Default for ScriptTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for ScriptTool {
+    fn name(&self) -> &str {
+        "script"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a Lua script in a built-in sandboxed engine. \
+         Use for cross-platform scripting: string processing, \
+         file I/O, JSON manipulation, and logic orchestration \
+         when shell commands are unavailable or unreliable (e.g. Windows). \
+         Available APIs: kestrel.read_file, kestrel.write_file, kestrel.list_dir, \
+         kestrel.exists, kestrel.stat, kestrel.mkdir, kestrel.remove, \
+         kestrel.json_decode, kestrel.json_encode, kestrel.env, kestrel.platform."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "Lua script to execute"
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Timeout in seconds (default: 30)"
+                }
+            },
+            "required": ["code"]
+        })
+    }
+
+    fn toolset(&self) -> &str {
+        "default"
+    }
+
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value) -> Result<String, ToolError> {
+        let code = args["code"]
+            .as_str()
+            .ok_or_else(|| ToolError::Validation("Missing 'code' parameter".to_string()))?;
+
+        let timeout_secs = args["timeout"].as_u64().unwrap_or(self.timeout.as_secs());
+
+        debug!(
+            "Executing Lua script ({} chars, timeout: {}s)",
+            code.len(),
+            timeout_secs
+        );
+
+        let lua = self.create_sandboxed_vm()?;
+
+        // Set up output capture buffer
+        let stdout_buf: Arc<std::sync::Mutex<Vec<u8>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let buf_clone = stdout_buf.clone();
+
+        // Override print to write to our buffer
+        let globals = lua.globals();
+        let print_capture = lua
+            .create_function(move |_, args: mlua::MultiValue| {
+                let parts: Vec<String> = args
+                    .iter()
+                    .map(|v| match v {
+                        mlua::Value::String(s) => s
+                            .to_str()
+                            .map(|x| x.to_string())
+                            .unwrap_or_else(|_| "<invalid>".to_string()),
+                        mlua::Value::Integer(n) => n.to_string(),
+                        mlua::Value::Number(n) => n.to_string(),
+                        mlua::Value::Boolean(b) => b.to_string(),
+                        mlua::Value::Nil => "nil".to_string(),
+                        _ => format!("{:?}", v),
+                    })
+                    .collect();
+                let line = parts.join("\t");
+                let mut buf = buf_clone.lock().unwrap();
+                buf.extend_from_slice(line.as_bytes());
+                buf.push(b'\n');
+                Ok(())
+            })
+            .map_err(|e| ToolError::Execution(format!("Failed to create print: {}", e)))?;
+
+        globals
+            .set("print", print_capture)
+            .map_err(|e| ToolError::Execution(format!("Failed to set print: {}", e)))?;
+
+        // Execute the script with timeout
+        // Lua is not Send, so we execute on the current thread with a manual timeout check.
+        // For truly async timeout, we use tokio::task::block_in_place which doesn't require Send.
+        let max_output = self.max_output_bytes;
+        let exec_result: Result<(), ToolError> = tokio::task::block_in_place(|| {
+            // Set up an alarm-based timeout for blocking execution
+            let start = std::time::Instant::now();
+
+            // We wrap execution in a thread that we can join with a timeout
+            // Note: Lua cannot be sent between threads. Execute directly but
+            // check elapsed time before execution.
+            if start.elapsed() > Duration::from_secs(timeout_secs) {
+                return Err(ToolError::Timeout(format!(
+                    "Script timed out after {}s",
+                    timeout_secs
+                )));
+            }
+
+            // Execute the Lua script directly
+            match lua.load(code).exec() {
+                Ok(()) => Ok(()),
+                Err(e) => Err(ToolError::Execution(format!("Lua error: {}", e))),
+            }
+        });
+
+        exec_result?;
+
+        // Collect captured output
+        let output = {
+            let buf = stdout_buf.lock().unwrap();
+            String::from_utf8_lossy(&buf).to_string()
+        };
+
+        if output.is_empty() {
+            Ok("(script completed, no output)".to_string())
+        } else if output.len() > MAX_TOOL_OUTPUT_LENGTH {
+            let mut truncated = output[..MAX_TOOL_OUTPUT_LENGTH].to_string();
+            truncated.push_str("\n... (output truncated)");
+            Ok(truncated)
+        } else if output.len() > max_output {
+            Ok(format!(
+                "{}\n... (output truncated at {} bytes)",
+                &output[..max_output.min(output.len())],
+                max_output
+            ))
+        } else {
+            Ok(output)
+        }
+    }
+}
+
+// --- Path validation ---
+
+fn validate_write_path(path: &str) -> Result<(), mlua::Error> {
+    let p = Path::new(path);
+
+    // Check for blocked system paths
+    #[cfg(unix)]
+    {
+        for blocked in BLOCKED_WRITE_PATHS_UNIX {
+            if p.starts_with(blocked) {
+                return Err(mlua::Error::external(format!(
+                    "Write to system path '{}' is not allowed",
+                    path
+                )));
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let lower = path.to_lowercase();
+        for blocked in BLOCKED_WRITE_PATHS_WINDOWS {
+            if lower.starts_with(&blocked.to_lowercase()) {
+                return Err(mlua::Error::external(format!(
+                    "Write to system path '{}' is not allowed",
+                    path
+                )));
+            }
+        }
+    }
+
+    // Check for sensitive home subpaths
+    if let Some(file_name) = p.file_name().and_then(|n| n.to_str()) {
+        let lower = file_name.to_lowercase();
+        for blocked in BLOCKED_HOME_SUBPATHS {
+            if lower == *blocked {
+                return Err(mlua::Error::external(format!(
+                    "Write to sensitive path '{}' is not allowed",
+                    path
+                )));
+            }
+        }
+    }
+
+    // Check for directory traversal that escapes to sensitive areas
+    let canonical_attempt = if p.is_absolute() {
+        Some(p.to_path_buf())
+    } else {
+        std::env::current_dir().ok().map(|d| d.join(p))
+    };
+
+    if let Some(canonical_base) = canonical_attempt {
+        // Block if the canonical path contains .ssh, .gnupg etc.
+        let components: Vec<String> = canonical_base
+            .components()
+            .filter_map(|c| c.as_os_str().to_str().map(|s| s.to_lowercase()))
+            .collect();
+        for blocked in BLOCKED_HOME_SUBPATHS {
+            if components.iter().any(|c| c == *blocked) {
+                return Err(mlua::Error::external(format!(
+                    "Write to sensitive path '{}' is not allowed",
+                    path
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// --- Directory listing ---
+
+fn list_dir_recursive(
+    path: &str,
+    recursive: bool,
+    result: &mut Vec<String>,
+    depth: usize,
+) -> Result<(), ToolError> {
+    let entries = std::fs::read_dir(path)
+        .map_err(|e| ToolError::Execution(format!("Failed to read dir '{}': {}", path, e)))?;
+
+    let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    entries.sort_by_key(|e| e.file_name());
+
+    let indent = "  ".repeat(depth);
+    for entry in entries {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let file_type = entry
+            .file_type()
+            .map_err(|e| ToolError::Execution(e.to_string()))?;
+
+        if file_type.is_dir() {
+            result.push(format!("{}{}/", indent, name));
+            if recursive {
+                let sub_path = format!("{}/{}", path, name);
+                list_dir_recursive(&sub_path, true, result, depth + 1)?;
+            }
+        } else {
+            result.push(format!("{}{}", indent, name));
+        }
+    }
+
+    Ok(())
+}
+
+// --- JSON <-> Lua conversion helpers ---
+
+fn json_value_to_lua(lua: &Lua, val: &Value) -> Result<mlua::Value, mlua::Error> {
+    match val {
+        Value::Null => Ok(mlua::Value::Nil),
+        Value::Bool(b) => Ok(mlua::Value::Boolean(*b)),
+        Value::Number(n) => Ok(mlua::Value::Number(n.as_f64().unwrap_or(0.0))),
+        Value::String(s) => Ok(mlua::Value::String(lua.create_string(s)?)),
+        Value::Array(arr) => {
+            let table = lua.create_table()?;
+            for (i, item) in arr.iter().enumerate() {
+                table.set(i + 1, json_value_to_lua(lua, item)?)?;
+            }
+            Ok(mlua::Value::Table(table))
+        }
+        Value::Object(obj) => {
+            let table = lua.create_table()?;
+            for (k, v) in obj {
+                table.set(k.as_str(), json_value_to_lua(lua, v)?)?;
+            }
+            Ok(mlua::Value::Table(table))
+        }
+    }
+}
+
+fn lua_value_to_json(val: &mlua::Value) -> Result<Value, mlua::Error> {
+    match val {
+        mlua::Value::Nil => Ok(Value::Null),
+        mlua::Value::Boolean(b) => Ok(Value::Bool(*b)),
+        mlua::Value::Integer(n) => Ok(json!(*n)),
+        mlua::Value::Number(n) => Ok(json!(*n)),
+        mlua::Value::String(s) => Ok(Value::String(s.to_str()?.to_string())),
+        mlua::Value::Table(t) => {
+            // Determine if array or object
+            let mut is_array = true;
+            let mut max_key = 0i64;
+            for pair in t.sequence_values::<mlua::Value>() {
+                match pair {
+                    Ok(_) => max_key += 1,
+                    Err(_) => {
+                        is_array = false;
+                        break;
+                    }
+                }
+            }
+
+            if is_array && max_key > 0 {
+                let mut arr = Vec::new();
+                for i in 1..=max_key {
+                    let v: mlua::Value = t.get(i)?;
+                    arr.push(lua_value_to_json(&v)?);
+                }
+                Ok(Value::Array(arr))
+            } else {
+                let mut obj = serde_json::Map::new();
+                for pair in t.pairs::<String, mlua::Value>() {
+                    let (k, v): (String, mlua::Value) = pair?;
+                    obj.insert(k, lua_value_to_json(&v)?);
+                }
+                Ok(Value::Object(obj))
+            }
+        }
+        _ => Ok(Value::Null),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trait_def::Tool;
+
+    #[test]
+    fn test_script_tool_name() {
+        let tool = ScriptTool::new();
+        assert_eq!(tool.name(), "script");
+    }
+
+    #[test]
+    fn test_script_tool_schema() {
+        let tool = ScriptTool::new();
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        let required = schema["required"].as_array().unwrap();
+        let names: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(names.contains(&"code"));
+    }
+
+    #[test]
+    fn test_script_tool_is_mutating() {
+        let tool = ScriptTool::new();
+        assert!(tool.is_mutating());
+    }
+
+    #[test]
+    fn test_script_tool_default() {
+        let tool = ScriptTool::default();
+        assert_eq!(tool.name(), "script");
+    }
+
+    #[test]
+    fn test_script_tool_with_timeout() {
+        let tool = ScriptTool::new().with_timeout(Duration::from_secs(5));
+        assert_eq!(tool.name(), "script");
+    }
+
+    #[test]
+    fn test_script_tool_dangerous_mode() {
+        let tool = ScriptTool::new().dangerous(true);
+        assert_eq!(tool.name(), "script");
+        assert!(tool.dangerous);
+    }
+
+    #[tokio::test]
+    async fn test_script_missing_code() {
+        let tool = ScriptTool::new();
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Missing 'code'"));
+    }
+
+    #[tokio::test]
+    async fn test_script_hello_world() {
+        let tool = ScriptTool::new();
+        let result = tool.execute(json!({"code": "print('hello world')"})).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("hello world"));
+    }
+
+    #[tokio::test]
+    async fn test_script_string_operations() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "print(string.format('result: %d', 42 + 8))"}))
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("result: 50"));
+    }
+
+    #[tokio::test]
+    async fn test_script_table_operations() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(
+                json!({"code": "local t = {3, 1, 2}; table.sort(t); print(table.concat(t, ','))"}),
+            )
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("1,2,3"));
+    }
+
+    #[tokio::test]
+    async fn test_script_json_decode_encode() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "local data = kestrel.json_decode('{\"name\":\"test\",\"value\":42}'); print(data.name); print(data.value)"}))
+            .await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.contains("test"));
+        assert!(output.contains("42"));
+    }
+
+    #[tokio::test]
+    async fn test_script_json_encode() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "local t = {hello = 'world', num = 123}; print(kestrel.json_encode(t))"}))
+            .await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.contains("hello"));
+        assert!(output.contains("world"));
+    }
+
+    #[tokio::test]
+    async fn test_script_platform() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "print(kestrel.platform())"}))
+            .await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        #[cfg(windows)]
+        assert!(output.contains("windows"));
+        #[cfg(not(windows))]
+        assert!(output.contains("linux") || output.contains("macos") || output.contains("android"));
+    }
+
+    #[tokio::test]
+    async fn test_script_sandbox_blocks_io() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "io.open('/tmp/test', 'w')"}))
+            .await;
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("nil")
+                || result.unwrap_err().to_string().contains("error")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_script_sandbox_blocks_os_execute() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "os.execute('echo pwned')"}))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_script_sandbox_blocks_require() {
+        let tool = ScriptTool::new();
+        let result = tool.execute(json!({"code": "require('os')"})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_script_read_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.txt");
+        std::fs::write(&file_path, "line1\nline2\nline3\n").unwrap();
+
+        let tool = ScriptTool::new();
+        let code = format!(
+            "local content = kestrel.read_file('{}'); print(content)",
+            file_path.to_str().unwrap().replace('\\', "\\\\")
+        );
+        let result = tool.execute(json!({"code": code})).await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.contains("line1"));
+        assert!(output.contains("line3"));
+    }
+
+    #[tokio::test]
+    async fn test_script_write_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("output.txt");
+        let path_str = file_path.to_str().unwrap().replace('\\', "\\\\");
+
+        let tool = ScriptTool::new();
+        let code = format!("kestrel.write_file('{}', 'hello from lua')", path_str);
+        let result = tool.execute(json!({"code": code})).await;
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "hello from lua");
+    }
+
+    #[tokio::test]
+    async fn test_script_write_file_blocked_system_path() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(json!({"code": "kestrel.write_file('/etc/test', 'hacked')"}))
+            .await;
+        // Should either error at Lua level or Rust level
+        assert!(result.is_err() || result.unwrap().contains("not allowed"));
+    }
+
+    #[tokio::test]
+    async fn test_script_list_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "").unwrap();
+
+        let path_str = dir.path().to_str().unwrap().replace('\\', "\\\\");
+        let tool = ScriptTool::new();
+        let code = format!(
+            "local entries = kestrel.list_dir('{}'); for _, e in ipairs(entries) do print(e) end",
+            path_str
+        );
+        let result = tool.execute(json!({"code": code})).await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.contains("a.txt"));
+        assert!(output.contains("b.rs"));
+    }
+
+    #[tokio::test]
+    async fn test_script_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("exists.txt");
+        std::fs::write(&file_path, "yes").unwrap();
+
+        let path_str = file_path.to_str().unwrap().replace('\\', "\\\\");
+        let tool = ScriptTool::new();
+        let code = format!(
+            "print(kestrel.exists('{}')); print(kestrel.exists('/nonexistent_xyz_123'))",
+            path_str
+        );
+        let result = tool.execute(json!({"code": code})).await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.contains("true"));
+        assert!(output.contains("false"));
+    }
+
+    #[tokio::test]
+    async fn test_script_math_and_loop() {
+        let tool = ScriptTool::new();
+        let result = tool
+            .execute(
+                json!({"code": "local sum = 0; for i = 1, 100 do sum = sum + i end; print(sum)"}),
+            )
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("5050"));
+    }
+
+    #[tokio::test]
+    async fn test_script_env() {
+        let tool = ScriptTool::new();
+        let code = r#"
+            local path = kestrel.env("PATH")
+            if path then
+                print("PATH is set")
+            else
+                print("PATH is nil")
+            end
+        "#;
+        let result = tool.execute(json!({"code": code})).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("PATH is set"));
+    }
+
+    #[test]
+    fn test_validate_write_path_allows_normal() {
+        assert!(validate_write_path("./output.txt").is_ok());
+        assert!(validate_write_path("src/main.rs").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_write_path_blocks_system() {
+        assert!(validate_write_path("/etc/passwd").is_err());
+        assert!(validate_write_path("/usr/bin/evil").is_err());
+        assert!(validate_write_path("/bin/sh").is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_validate_write_path_blocks_system_windows() {
+        assert!(validate_write_path("C:\\Windows\\System32\\evil.dll").is_err());
+        assert!(validate_write_path("C:\\Program Files\\bad.exe").is_err());
+    }
+
+    #[test]
+    fn test_validate_write_path_blocks_sensitive_home() {
+        assert!(validate_write_path(".ssh/authorized_keys").is_err());
+        assert!(validate_write_path(".gnupg/pubring.gpg").is_err());
+    }
+}

--- a/crates/kestrel-tools/src/builtins/shell.rs
+++ b/crates/kestrel-tools/src/builtins/shell.rs
@@ -238,7 +238,10 @@ impl Tool for ExecTool {
     }
 
     fn description(&self) -> &str {
-        "Execute a shell command and return the output. Use for running system commands, scripts, and programs."
+        "Execute a shell command and return the output. \
+         Use for running external programs and system commands (git, docker, python, npm, etc.). \
+         For cross-platform string processing, JSON manipulation, or batch file operations \
+         (especially on Windows where cmd.exe is limited), prefer the 'script' tool instead."
     }
 
     fn parameters_schema(&self) -> Value {


### PR DESCRIPTION
## 背景

当前 `exec` 工具在 Windows 下使用 `cmd.exe /c` 执行命令，脚本编排能力极度受限（无数组、map、正则、JSON 解析、循环/条件等）。AI agent 生成的同一任务脚本在 Windows 上往往无法运行。

详细设计文档见 `docs/rfc-lua-script-tool.md`（在 main 分支上）。

## 设计方案

### 定位：exec 的互补工具，而非替代

```
exec    -> 调用外部系统命令 (git, docker, python...)   -> 不可替代
script  -> 内置脚本编排 (字符串处理, JSON, 文件IO)      -> exec 的互补
```

### 技术选型：Lua 5.4 (mlua 0.11)

| 维度 | 选择 |
|------|------|
| 引擎 | Lua 5.4 via mlua 0.11 (vendored) |
| 沙箱 | 禁用 io/os.execute/require/dofile/loadfile |
| 路径校验 | 阻止写入系统目录和敏感路径 |
| Feature flag | lua-script（默认启用，可关闭） |

### 暴露的 API（kestrel 全局表）

| API | 说明 |
|-----|------|
| kestrel.read_file(path [, offset, limit]) | 读取文件 |
| kestrel.write_file(path, content [, append]) | 写入文件（路径校验+写入量限制） |
| kestrel.list_dir(path [, recursive]) | 列出目录 |
| kestrel.exists(path) / kestrel.stat(path) | 文件状态 |
| kestrel.mkdir(path) / kestrel.remove(path) | 创建/删除 |
| kestrel.json_decode(str) / kestrel.json_encode(table) | JSON 处理 |
| kestrel.env(name) / kestrel.platform() | 环境信息 |

### 安全机制（四层防护）

1. **沙箱隔离** — 默认禁用 io、os.execute、require 等，仅暴露安全 os 子集（date/time/clock）
2. **指令计数限制** — 通过 mlua::HookTriggers 限制最大 10M 条 VM 指令（防止死循环）
3. **路径校验** — 阻止写入 /etc、C:\Windows、.ssh/ 等敏感路径
4. **写入量限制** — 单次执行最大 10MB / 100 文件

## 变更摘要

| 文件 | 变更 |
|------|------|
| kestrel-tools/Cargo.toml | 添加 mlua 0.11 依赖，lua-script feature flag |
| kestrel-tools/src/builtins/script.rs | **新增** ScriptTool 实现（约1070行） |
| kestrel-tools/src/builtins/mod.rs | 注册 ScriptTool |
| kestrel-tools/src/builtins/shell.rs | 优化 exec 工具描述，引导 AI 选择 exec vs script |

## 示例

批量 JSON 文件处理（cmd.exe 无法完成）:

```lua
local result = {}
for _, name in ipairs(kestrel.list_dir("./config")) do
  if name:match("%.json$") then
    local data = kestrel.json_decode(kestrel.read_file("./config/" .. name))
    table.insert(result, {name = name, version = data.version})
  end
end
for _, item in ipairs(result) do
  print(item.name .. ": " .. item.version)
end
```

## 测试

包含 25+ 单元测试覆盖：
- 基本脚本执行（hello world, 字符串操作, 表操作, 数学计算）
- kestrel API（read_file, write_file, list_dir, exists, json, env, platform）
- 沙箱验证（io/os.execute/require 被阻止）
- 路径校验（系统路径和敏感路径被阻止）

CI 将验证三平台（Windows/Linux/macOS）编译通过。
