### PR TITLE
fix(logging): add trace_id to all message processing log outputs

### DIFF
--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -239,7 +239,7 @@ impl AgentLoop {
                             metadata: Default::default(),
                         };
                         if let Err(e) = self.bus.publish_outbound(reply).await {
-                            error!("Failed to send /stop reply: {e}");
+                            error!(trace_id = %msg.trace_id.as_deref().unwrap_or("-"), "Failed to send /stop reply: {e}");
                         }
                         continue;
                     }
@@ -260,10 +260,12 @@ impl AgentLoop {
 
                     match result {
                         Ok(Ok(())) => {}
-                        Ok(Err(e)) => error!("Error processing message: {}", e),
+                        Ok(Err(e)) => {
+                            error!(trace_id = %timeout_trace_id.as_deref().unwrap_or("-"), "Error processing message: {}", e)
+                        }
                         Err(_) => {
                             let timeout_secs = self.config.agent.message_timeout;
-                            error!("Message processing timed out after {}s", timeout_secs);
+                            error!(trace_id = %timeout_trace_id.as_deref().unwrap_or("-"), "Message processing timed out after {}s", timeout_secs);
 
                             let timeout_reply = OutboundMessage {
                                 channel: timeout_channel,
@@ -274,12 +276,12 @@ impl AgentLoop {
                                     timeout_secs
                                 ),
                                 reply_to: timeout_message_id,
-                                trace_id: timeout_trace_id,
+                                trace_id: timeout_trace_id.clone(),
                                 media: vec![],
                                 metadata: Default::default(),
                             };
                             if let Err(e) = self.bus.publish_outbound(timeout_reply).await {
-                                error!("Failed to send timeout reply: {}", e);
+                                error!(trace_id = %timeout_trace_id.as_deref().unwrap_or("-"), "Failed to send timeout reply: {}", e);
                             }
 
                             // Clean up stale session entry after timeout
@@ -320,6 +322,7 @@ impl AgentLoop {
 
         async move {
             let session_key = msg.session_key();
+            let trace_id_str = msg.trace_id.as_deref().unwrap_or("-").to_string();
 
             // If session is busy, interrupt current run and replan with new message
             if self.is_session_active(&session_key) {
@@ -335,11 +338,12 @@ impl AgentLoop {
                     metadata: Default::default(),
                 };
                 if let Err(e) = self.bus.publish_outbound(confirmation).await {
-                    error!("Failed to send interrupt confirmation: {e}");
+                    error!(trace_id = %trace_id_str, "Failed to send interrupt confirmation: {e}");
                 }
 
                 self.pending_messages.insert(session_key.clone(), msg.clone());
                 info!(
+                    trace_id = %trace_id_str,
                     "Session {} interrupted by new message, queued for re-planning",
                     session_key
                 );
@@ -349,6 +353,7 @@ impl AgentLoop {
             // Audit log: message content at debug level for traceability
             let content_preview = truncate_str(&msg.content, 100);
             tracing::debug!(
+                trace_id = %trace_id_str,
                 content = %content_preview,
                 channel = %msg.channel,
                 "Incoming message"
@@ -363,7 +368,7 @@ impl AgentLoop {
                 duration_ms: None,
             });
 
-            info!("Processing message");
+            info!(trace_id = %trace_id_str, "Processing message");
 
             // Emit started event
             let started_event = AgentEvent::Started {
@@ -394,6 +399,7 @@ impl AgentLoop {
                     Ok(result) => {
                         if result.messages_after < result.messages_before {
                             info!(
+                                trace_id = %trace_id_str,
                                 session_key = %session_key,
                                 before = result.messages_before,
                                 after = result.messages_after,
@@ -403,6 +409,7 @@ impl AgentLoop {
                     }
                     Err(e) => {
                         warn!(
+                            trace_id = %trace_id_str,
                             "Context compaction failed for session {}: {}",
                             session_key, e
                         );
@@ -413,7 +420,7 @@ impl AgentLoop {
             self.session_manager.save_session_async(&session);
 
             // Recall relevant memories from the memory store (if configured).
-            let recalled_memory = self.recall_memories(&msg.content).await;
+            let recalled_memory = self.recall_memories(&msg.content, &trace_id_str).await;
 
             // Build context (with memory recall + skill matching if attached)
             let system_prompt = {
@@ -587,6 +594,7 @@ impl AgentLoop {
                             let now = std::time::Instant::now();
                             if now + backoff >= retry_deadline {
                                 warn!(
+                                    trace_id = %trace_id_str,
                                     remaining_ms = (retry_deadline - now).as_millis() as u64,
                                     backoff_ms = backoff.as_millis() as u64,
                                     "Skipping retry: would exceed message timeout budget"
@@ -595,6 +603,7 @@ impl AgentLoop {
                             }
 
                             warn!(
+                                trace_id = %trace_id_str,
                                 attempt = attempt + 1,
                                 max_retries,
                                 backoff_ms = backoff.as_millis() as u64,
@@ -615,7 +624,7 @@ impl AgentLoop {
                 match handle.await {
                     Ok((_text, msg_id)) => msg_id,
                     Err(e) => {
-                        warn!("Stream consumer task error: {e}");
+                        warn!(trace_id = %trace_id_str, "Stream consumer task error: {e}");
                         None
                     }
                 }
@@ -630,6 +639,7 @@ impl AgentLoop {
                 Ok(result) => {
                     let duration_ms = run_start.elapsed().as_millis() as u64;
                     info!(
+                        trace_id = %trace_id_str,
                         duration_ms = duration_ms,
                         tool_calls = result.tool_calls_made,
                         iterations = result.iterations_used,
@@ -650,11 +660,13 @@ impl AgentLoop {
 
                     if was_interrupted {
                         info!(
+                            trace_id = %trace_id_str,
                             session_key = %session_key,
                             "Agent run interrupted by new message, skipping cancelled response"
                         );
                         if let Err(e) = self.session_manager.save_session(&session) {
                             warn!(
+                                trace_id = %trace_id_str,
                                 session_key = %session_key,
                                 "Failed to persist session: {e}"
                             );
@@ -667,6 +679,7 @@ impl AgentLoop {
                             NotesManager::extract_notes_from_response(&mut session, &result.content);
                         if extracted > 0 {
                             info!(
+                                trace_id = %trace_id_str,
                                 "Auto-extracted {} notes from agent response in session {}",
                                 extracted, session_key
                             );
@@ -674,18 +687,19 @@ impl AgentLoop {
 
                         // Compact notes if they exceed the limit
                         if NotesManager::compact_if_needed(&mut session) {
-                            info!("Notes compacted for session {}", session_key);
+                            info!(trace_id = %trace_id_str, "Notes compacted for session {}", session_key);
                         }
 
                         if let Err(e) = self.session_manager.save_session(&session) {
                             warn!(
+                                trace_id = %trace_id_str,
                                 session_key = %session_key,
                                 "Failed to persist completed session: {e}"
                             );
                         }
 
                         // Store conversation memory (non-blocking — failures are logged, not propagated)
-                        self.store_conversation_memory(&msg.content, &result.content)
+                        self.store_conversation_memory(&msg.content, &result.content, &trace_id_str)
                             .await;
 
                         // Emit ToolSucceeded learning event if tools were used
@@ -724,7 +738,7 @@ impl AgentLoop {
                         // Skip outbound if stream consumer already delivered the response
                         if stream_delivered_msg_id.is_none() {
                             if let Err(e) = self.bus.publish_outbound(outbound).await {
-                                error!("Failed to publish outbound message: {}", e);
+                                error!(trace_id = %trace_id_str, "Failed to publish outbound message: {}", e);
                             }
                         }
 
@@ -787,6 +801,7 @@ impl AgentLoop {
                     });
 
                     error!(
+                        trace_id = %trace_id_str,
                         error = %e,
                         "Agent run error for session {}, sending error reply",
                         session_key
@@ -803,7 +818,7 @@ impl AgentLoop {
                         metadata: Default::default(),
                     };
                     if let Err(send_err) = self.bus.publish_outbound(error_outbound).await {
-                        error!("Failed to send error reply: {}", send_err);
+                        error!(trace_id = %trace_id_str, "Failed to send error reply: {}", send_err);
                     }
 
                     // Emit ToolFailed learning event
@@ -884,7 +899,7 @@ impl AgentLoop {
     /// configured or no memories were found. Output is bounded by the char budget
     /// from [`MemoryConfig`] (or [`DEFAULT_MEMORY_CHAR_BUDGET`] as fallback) —
     /// entries that would exceed the budget are skipped entirely.
-    async fn recall_memories(&self, query_text: &str) -> Option<String> {
+    async fn recall_memories(&self, query_text: &str, trace_id: &str) -> Option<String> {
         let store = self.memory_store.as_ref()?;
 
         let query = MemoryQuery::new()
@@ -946,7 +961,7 @@ impl AgentLoop {
                 ))
             }
             Err(e) => {
-                warn!("Memory recall failed: {}", e);
+                warn!(trace_id = %trace_id, "Memory recall failed: {}", e);
                 None
             }
         }
@@ -957,7 +972,12 @@ impl AgentLoop {
     /// Extracts a summary from the user message and agent response, then stores
     /// it as an [`MemoryCategory::AgentNote`]. Failures are logged but not propagated
     /// — memory storage must not break the agent loop.
-    async fn store_conversation_memory(&self, user_msg: &str, agent_response: &str) {
+    async fn store_conversation_memory(
+        &self,
+        user_msg: &str,
+        agent_response: &str,
+        trace_id: &str,
+    ) {
         let Some(store) = self.memory_store.as_ref() else {
             return;
         };
@@ -965,6 +985,7 @@ impl AgentLoop {
         let quality = summary_quality(user_msg, agent_response);
         if quality < MEMORY_QUALITY_THRESHOLD {
             tracing::debug!(
+                trace_id = %trace_id,
                 "Skipping low-quality conversation memory (quality={:.2}): {:.80}",
                 quality,
                 user_msg
@@ -985,7 +1006,7 @@ impl AgentLoop {
         {
             let entries: Vec<_> = existing.into_iter().map(|s| s.entry).collect();
             if is_near_duplicate(&content, &entries) {
-                tracing::debug!("Skipping duplicate conversation memory: {:.80}", content);
+                tracing::debug!(trace_id = %trace_id, "Skipping duplicate conversation memory: {:.80}", content);
                 return;
             }
         }
@@ -995,7 +1016,7 @@ impl AgentLoop {
             MemoryEntry::new(content, MemoryCategory::AgentNote).with_confidence(confidence);
 
         if let Err(e) = store.store(entry).await {
-            warn!("Failed to store conversation memory: {}", e);
+            warn!(trace_id = %trace_id, "Failed to store conversation memory: {}", e);
         }
     }
 
@@ -1329,7 +1350,7 @@ async fn post_task_reflect(task: ReflectionTask) {
     let provider = match task.provider_registry.get_provider(provider_name) {
         Some(p) => p,
         None => {
-            warn!("No provider available for task reflection");
+            warn!(trace_id = %task.trace_id.as_deref().unwrap_or("-"), "No provider available for task reflection");
             return;
         }
     };
@@ -1397,6 +1418,7 @@ async fn post_task_reflect(task: ReflectionTask) {
                 if attempt < REFLECTION_MAX_RETRIES {
                     let delay = REFLECTION_BACKOFF_BASE_MS * 2u64.pow(attempt);
                     warn!(
+                        trace_id = %task.trace_id.as_deref().unwrap_or("-"),
                         attempt,
                         max_retries = REFLECTION_MAX_RETRIES,
                         "Post-task reflection LLM call failed, retrying in {}ms: {}",
@@ -1416,11 +1438,13 @@ async fn post_task_reflect(task: ReflectionTask) {
     let total = prev + 1;
     if total >= REFLECTION_CONSECUTIVE_ERROR_THRESHOLD {
         error!(
+            trace_id = %task.trace_id.as_deref().unwrap_or("-"),
             consecutive_failures = total,
             "Post-task reflection has failed {} times in a row: {}", total, last_error
         );
     } else {
         warn!(
+            trace_id = %task.trace_id.as_deref().unwrap_or("-"),
             "Post-task reflection failed after {} retries: {}",
             REFLECTION_MAX_RETRIES, last_error
         );
@@ -2006,7 +2030,7 @@ mod tests {
     #[tokio::test]
     async fn test_recall_memories_no_store() {
         let al = make_agent_loop();
-        let result = al.recall_memories("test query").await;
+        let result = al.recall_memories("test query", "-").await;
         assert!(result.is_none());
     }
 
@@ -2014,7 +2038,7 @@ mod tests {
     async fn test_recall_memories_empty_store() {
         let mock = Arc::new(MockMemoryStore::new());
         let al = make_agent_loop().with_memory_store(mock.clone());
-        let result = al.recall_memories("test query").await;
+        let result = al.recall_memories("test query", "-").await;
         assert!(result.is_none());
         assert_eq!(mock.search_count(), 1);
     }
@@ -2029,7 +2053,7 @@ mod tests {
         .unwrap();
 
         let al = make_agent_loop().with_memory_store(mock.clone());
-        let result = al.recall_memories("rust").await;
+        let result = al.recall_memories("rust", "-").await;
         assert!(result.is_some());
         let text = result.unwrap();
         assert!(text.contains("User likes Rust"));
@@ -2046,7 +2070,7 @@ mod tests {
             .unwrap();
 
         let al = make_agent_loop().with_memory_store(mock.clone());
-        let result = al.recall_memories("rust programming").await;
+        let result = al.recall_memories("rust programming", "-").await;
         // "rust programming" does not match "Python scripting"
         assert!(result.is_none());
     }
@@ -2055,7 +2079,7 @@ mod tests {
     async fn test_store_conversation_memory_no_store() {
         let al = make_agent_loop();
         // Should not panic or error
-        al.store_conversation_memory("hello", "hi there").await;
+        al.store_conversation_memory("hello", "hi there", "-").await;
     }
 
     #[tokio::test]
@@ -2063,7 +2087,7 @@ mod tests {
         let mock = Arc::new(MockMemoryStore::new());
         let al = make_agent_loop().with_memory_store(mock.clone());
 
-        al.store_conversation_memory("What is Rust?", "Rust is a systems language")
+        al.store_conversation_memory("What is Rust?", "Rust is a systems language", "-")
             .await;
 
         assert_eq!(mock.store_count(), 1);
@@ -2088,11 +2112,13 @@ mod tests {
         al.store_conversation_memory(
             "How do I run the test suite?",
             "Use cargo test --workspace to run all tests across crates",
+            "-",
         )
         .await;
         al.store_conversation_memory(
             "What database driver should I use?",
             "The sqlx crate provides async database access with compile-time query checking",
+            "-",
         )
         .await;
 
@@ -2241,7 +2267,7 @@ mod tests {
         let mock = Arc::new(MockMemoryStore::new());
         let al = make_agent_loop().with_memory_store(mock.clone());
 
-        al.store_conversation_memory("hi", "hello").await;
+        al.store_conversation_memory("hi", "hello", "-").await;
         assert_eq!(
             mock.store_count(),
             0,
@@ -2257,6 +2283,7 @@ mod tests {
         al.store_conversation_memory(
             "How do I configure the database connection pool?",
             "Use the r2d2 crate with your database driver to manage the pool",
+            "-",
         )
         .await;
         assert_eq!(mock.store_count(), 1);
@@ -2315,7 +2342,7 @@ mod tests {
 
         let al = make_agent_loop().with_memory_store(Arc::new(store));
 
-        let result = al.recall_memories("dark mode").await;
+        let result = al.recall_memories("dark mode", "-").await;
         assert!(result.is_some());
         let text = result.unwrap();
         assert!(text.contains("dark mode"));
@@ -2329,7 +2356,7 @@ mod tests {
             .unwrap();
 
         let al = make_agent_loop().with_memory_store(mock);
-        let result = al.recall_memories("test").await.unwrap();
+        let result = al.recall_memories("test", "-").await.unwrap();
         assert!(
             result.starts_with("<memory-context>\n"),
             "should start with <memory-context> tag"
@@ -2360,7 +2387,7 @@ mod tests {
         .unwrap();
 
         let al = make_agent_loop().with_memory_store(mock);
-        let result = al.recall_memories("ignore").await.unwrap();
+        let result = al.recall_memories("ignore", "-").await.unwrap();
 
         // The raw </memory-context> must be escaped so it can't break out
         assert!(
@@ -2388,7 +2415,7 @@ mod tests {
             .unwrap();
 
         let al = make_agent_loop().with_memory_store(mock);
-        let result = al.recall_memories("A").await.unwrap();
+        let result = al.recall_memories("A", "-").await.unwrap();
 
         assert!(result.contains("A &amp; B &lt; C &gt; D"));
     }
@@ -2402,7 +2429,7 @@ mod tests {
             .unwrap();
 
         let al = make_agent_loop().with_memory_store(mock);
-        let result = al.recall_memories("test").await.unwrap();
+        let result = al.recall_memories("test", "-").await.unwrap();
         // Category "fact" has no special chars, just verify it still works
         assert!(result.contains("[fact]"));
     }
@@ -2421,7 +2448,7 @@ mod tests {
             .unwrap();
 
         let al = make_agent_loop().with_memory_store(mock);
-        let result = al.recall_memories("x").await.unwrap();
+        let result = al.recall_memories("x", "-").await.unwrap();
 
         assert!(
             result.contains("<memory-context>"),
@@ -2460,7 +2487,7 @@ mod tests {
         let al = make_agent_loop()
             .with_memory_store(mock)
             .with_memory_config(mem_config);
-        let result = al.recall_memories("a").await.unwrap();
+        let result = al.recall_memories("a", "-").await.unwrap();
 
         let inner = result
             .strip_prefix("<memory-context>\n")
@@ -2506,7 +2533,7 @@ mod tests {
         let al = make_agent_loop()
             .with_memory_store(mock)
             .with_memory_config(mem_config);
-        let result = al.recall_memories("a").await.unwrap();
+        let result = al.recall_memories("a", "-").await.unwrap();
 
         // With budget=50, each entry line is ~34 chars ("- ENTRY [fact] (confidence: 0.XX)"),
         // so only 1 entry should fit.
@@ -2539,7 +2566,7 @@ mod tests {
 
         let al = make_agent_loop().with_memory_store(Arc::new(store));
 
-        al.store_conversation_memory("How do I build?", "Use cargo build")
+        al.store_conversation_memory("How do I build?", "Use cargo build", "-")
             .await;
 
         // Verify stored by searching
@@ -2653,7 +2680,7 @@ mod tests {
             .with_learning_bus(bus);
 
         // Trigger recall (which emits the event)
-        let result = al.recall_memories("rust").await;
+        let result = al.recall_memories("rust", "-").await;
         assert!(result.is_some());
 
         // Verify the event was published
@@ -2681,7 +2708,7 @@ mod tests {
         let mut rx = bus.subscribe();
 
         let al = make_agent_loop().with_learning_bus(bus);
-        let result = al.recall_memories("rust").await;
+        let result = al.recall_memories("rust", "-").await;
         assert!(result.is_none());
 
         // No store → no event emitted
@@ -2701,7 +2728,7 @@ mod tests {
             .with_learning_bus(bus);
 
         // Empty store → recall returns None → no hit
-        let _ = al.recall_memories("anything").await;
+        let _ = al.recall_memories("anything", "-").await;
 
         // Verify event was emitted with hit=false
         let event = rx.try_recv().expect("should receive event");

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -168,6 +168,7 @@ impl AgentRunner {
             })?;
 
         info!(
+            trace_id = %self.trace_id.as_deref().unwrap_or("-"),
             llm_model = %model,
             llm_provider = %provider.name(),
             "Starting agent run"
@@ -195,7 +196,7 @@ impl AgentRunner {
             // Check for cancellation between iterations
             if let Some(ref token) = self.cancel_token {
                 if token.is_cancelled() {
-                    info!("Agent run cancelled at iteration {}", iteration + 1);
+                    info!(trace_id = %self.trace_id.as_deref().unwrap_or("-"), "Agent run cancelled at iteration {}", iteration + 1);
                     self.emit_stream_chunk(String::new(), true);
                     return Ok(RunResult {
                         content: "Agent run was cancelled.".to_string(),
@@ -208,7 +209,7 @@ impl AgentRunner {
                 }
             }
 
-            debug!("Agent iteration {}/{}", iteration + 1, max_iterations);
+            debug!(trace_id = %self.trace_id.as_deref().unwrap_or("-"), "Agent iteration {}/{}", iteration + 1, max_iterations);
 
             let request = CompletionRequest {
                 model: model.clone(),
@@ -252,6 +253,7 @@ impl AgentRunner {
                 _ => {
                     let content = response.content.unwrap_or_default();
                     info!(
+                        trace_id = %self.trace_id.as_deref().unwrap_or("-"),
                         llm_model = %model,
                         iterations = iteration + 1,
                         tool_calls = tool_calls_made,
@@ -304,6 +306,7 @@ impl AgentRunner {
 
             for (tc, (_, duration_ms, success)) in tool_calls.iter().zip(&results) {
                 debug!(
+                    trace_id = %self.trace_id.as_deref().unwrap_or("-"),
                     tool_name = %tc.function.name,
                     duration_ms = *duration_ms,
                     "Tool call completed"
@@ -333,7 +336,7 @@ impl AgentRunner {
             }
         }
 
-        warn!("Max iterations ({}) reached", max_iterations);
+        warn!(trace_id = %self.trace_id.as_deref().unwrap_or("-"), "Max iterations ({}) reached", max_iterations);
         Ok(RunResult {
             content: "I've reached the maximum number of iterations. Please continue the conversation if needed.".to_string(),
             reasoning_content,
@@ -370,6 +373,7 @@ impl AgentRunner {
             let connect_ms = send_start.elapsed().as_millis() as u64;
             if connect_ms > 5000 {
                 warn!(
+                    trace_id = %self.trace_id.as_deref().unwrap_or("-"),
                     elapsed_ms = connect_ms,
                     "Slow provider response: took >5s to establish stream"
                 );
@@ -400,6 +404,7 @@ impl AgentRunner {
                 let gap = now.duration_since(last_chunk_at);
                 if gap >= std::time::Duration::from_secs(10) {
                     warn!(
+                        trace_id = %self.trace_id.as_deref().unwrap_or("-"),
                         elapsed_ms = send_start.elapsed().as_millis() as u64,
                         gap_ms = gap.as_millis() as u64,
                         "SSE stream slow: long gap between chunks"
@@ -426,6 +431,7 @@ impl AgentRunner {
                             stream_attempt += 1;
                             let backoff = std::time::Duration::from_millis(500 << stream_attempt);
                             warn!(
+                                trace_id = %self.trace_id.as_deref().unwrap_or("-"),
                                 attempt = stream_attempt,
                                 max_retries = max_stream_retries,
                                 backoff_ms = backoff.as_millis() as u64,
@@ -449,6 +455,7 @@ impl AgentRunner {
                             stream_attempt += 1;
                             let backoff = std::time::Duration::from_millis(500 << stream_attempt);
                             warn!(
+                                trace_id = %self.trace_id.as_deref().unwrap_or("-"),
                                 attempt = stream_attempt,
                                 max_retries = max_stream_retries,
                                 backoff_ms = backoff.as_millis() as u64,
@@ -464,6 +471,7 @@ impl AgentRunner {
 
                 if !first_byte_logged {
                     debug!(
+                        trace_id = %self.trace_id.as_deref().unwrap_or("-"),
                         elapsed_ms = send_start.elapsed().as_millis() as u64,
                         "SSE first-byte received"
                     );
@@ -528,6 +536,7 @@ impl AgentRunner {
         let (full_content, full_reasoning, usage, tool_calls_map, send_start) = result?;
 
         debug!(
+            trace_id = %self.trace_id.as_deref().unwrap_or("-"),
             total_ms = send_start.elapsed().as_millis() as u64,
             "SSE stream completed"
         );

--- a/crates/kestrel-channels/src/manager.rs
+++ b/crates/kestrel-channels/src/manager.rs
@@ -91,6 +91,7 @@ impl ChannelManager {
     /// Handle an outbound message from the bus.
     pub async fn handle_outbound(&self, msg: OutboundMessage) {
         let channel_name = msg.channel.to_string();
+        let trace_id = msg.trace_id.clone();
         match self.running_channels.get(&channel_name) {
             Some(channel) => {
                 let channel = channel.lock().await;
@@ -115,19 +116,26 @@ impl ChannelManager {
                         Ok(result) => {
                             if !result.success {
                                 error!(
+                                    trace_id = %trace_id.as_deref().unwrap_or("-"),
                                     "Failed to send message to {} via {}: {:?}",
                                     msg.chat_id, channel_name, result.error
                                 );
                             }
                         }
                         Err(e) => {
-                            error!("Error sending message via {}: {}", channel_name, e);
+                            error!(
+                                trace_id = %trace_id.as_deref().unwrap_or("-"),
+                                "Error sending message via {}: {}", channel_name, e
+                            );
                         }
                     }
                 }
             }
             None => {
-                warn!("No running channel for platform: {}", channel_name);
+                warn!(
+                    trace_id = %trace_id.as_deref().unwrap_or("-"),
+                    "No running channel for platform: {}", channel_name
+                );
             }
         }
 

--- a/crates/kestrel-channels/src/platforms/discord.rs
+++ b/crates/kestrel-channels/src/platforms/discord.rs
@@ -1021,6 +1021,8 @@ impl DiscordChannel {
             metadata.insert("discord_guild_id".to_string(), serde_json::json!(guild_id));
         }
 
+        let trace_id = format!("dc_{}", msg.id);
+
         let inbound = InboundMessage {
             channel: Platform::Discord,
             sender_id,
@@ -1031,13 +1033,16 @@ impl DiscordChannel {
             source: Some(source),
             message_type,
             message_id: Some(msg.id.clone()),
-            trace_id: Some(format!("dc_{}", msg.id)),
+            trace_id: Some(trace_id.clone()),
             reply_to: None,
             timestamp: chrono::Local::now(),
         };
 
         if let Err(e) = handler.send(inbound).await {
-            warn!("Failed to dispatch Discord message: {}", e);
+            warn!(
+                trace_id = %trace_id,
+                "Failed to dispatch Discord message: {}", e
+            );
         }
         true
     }

--- a/crates/kestrel-channels/src/platforms/feishu.rs
+++ b/crates/kestrel-channels/src/platforms/feishu.rs
@@ -146,7 +146,10 @@ impl FeishuBatcher {
 
         // message_id dedup
         if !message_id.is_empty() && self.dedup.is_duplicate(message_id) {
-            debug!("Feishu dedup: skipping duplicate message_id={}", message_id);
+            debug!(
+                trace_id = %msg.trace_id.as_deref().unwrap_or("-"),
+                "Feishu dedup: skipping duplicate message_id={}", message_id
+            );
             return Err(msg);
         }
 
@@ -155,6 +158,7 @@ impl FeishuBatcher {
         let content_key = format!("{}:{}", sender_id, &msg.content[..prefix_len]);
         if self.dedup.is_duplicate(&content_key) {
             debug!(
+                trace_id = %msg.trace_id.as_deref().unwrap_or("-"),
                 "Feishu dedup: skipping content duplicate from {}",
                 sender_id
             );
@@ -278,6 +282,7 @@ fn merge_batch(messages: Vec<InboundMessage>) -> Option<InboundMessage> {
     };
 
     info!(
+        trace_id = %merged.trace_id.as_deref().unwrap_or("-"),
         "Feishu batcher: merged {} messages for chat {}",
         messages.len(),
         merged.chat_id
@@ -835,6 +840,11 @@ pub fn parse_webhook(body: &[u8], config: Option<&FeishuConfig>) -> Result<Webho
         );
     }
 
+    let trace_id = message_id
+        .as_deref()
+        .map(|mid| format!("fs_{mid}"))
+        .unwrap_or_else(kestrel_core::generate_trace_id);
+
     let inbound = InboundMessage {
         channel: Platform::Feishu,
         sender_id: sender_id.clone(),
@@ -854,7 +864,7 @@ pub fn parse_webhook(body: &[u8], config: Option<&FeishuConfig>) -> Result<Webho
         }),
         message_type,
         message_id,
-        trace_id: None,
+        trace_id: Some(trace_id),
         reply_to: None,
         timestamp: chrono::Local::now(),
     };
@@ -2016,8 +2026,12 @@ async fn ws_connect_and_listen(
                                         match parse_webhook(payload, None) {
                                             Ok(WebhookResult::Messages(msgs)) => {
                                                 for msg in msgs {
+                                                    let tid = msg.trace_id.clone();
                                                     if let Err(e) = handler.send(msg).await {
-                                                        warn!("[feishu:ws] failed to forward message: {e}");
+                                                        warn!(
+                                                            trace_id = %tid.as_deref().unwrap_or("-"),
+                                                            "[feishu:ws] failed to forward message: {e}"
+                                                        );
                                                     }
                                                 }
                                             }
@@ -2179,11 +2193,14 @@ impl BaseChannel for FeishuChannel {
         self.send_text_message(chat_id, content, reply_to).await
     }
 
-    async fn send_typing(&self, chat_id: &str, _trace_id: Option<&str>) -> Result<()> {
+    async fn send_typing(&self, chat_id: &str, trace_id: Option<&str>) -> Result<()> {
         let message_id = match self.last_message_ids.lock().get(chat_id).cloned() {
             Some(id) => id,
             None => {
-                debug!("Feishu typing: no message_id tracked for chat {chat_id}");
+                debug!(
+                    trace_id = %trace_id.unwrap_or("-"),
+                    "Feishu typing: no message_id tracked for chat {chat_id}"
+                );
                 return Ok(());
             }
         };
@@ -2199,7 +2216,10 @@ impl BaseChannel for FeishuChannel {
                     .insert(chat_id.to_string(), reaction_id);
             }
             Err(e) => {
-                debug!("Feishu typing reaction failed: {e}");
+                debug!(
+                    trace_id = %trace_id.unwrap_or("-"),
+                    "Feishu typing reaction failed: {e}"
+                );
             }
         }
 

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1172,6 +1172,7 @@ impl TelegramChannel {
                                     Ok(false) => {}
                                     Err(e) => {
                                         error!(
+                                            trace_id = %format!("tg_{}_{}", update.update_id, msg.message_id),
                                             "Failed to dispatch rewritten Telegram message: {e}"
                                         );
                                     }
@@ -1192,7 +1193,10 @@ impl TelegramChannel {
                             }
                             Ok(false) => {} // Skipped (no text/photo).
                             Err(e) => {
-                                error!("Failed to dispatch Telegram message: {e}");
+                                error!(
+                                    trace_id = %format!("tg_{}_{}", update.update_id, msg.message_id),
+                                    "Failed to dispatch Telegram message: {e}"
+                                );
                             }
                         }
                     }
@@ -1207,7 +1211,10 @@ impl TelegramChannel {
                     )
                     .await
                     {
-                        error!("Failed to dispatch Telegram callback query: {e}");
+                        error!(
+                            trace_id = %format!("tg_{}_{}", update.update_id, cq.id),
+                            "Failed to dispatch Telegram callback query: {e}"
+                        );
                     }
                 }
             }

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -789,6 +789,7 @@ impl WebSocketChannel {
 
             if let Err(e) = handler.send(inbound).await {
                 warn!(
+                    trace_id = %trace_id,
                     "Failed to forward WebSocket message from {}: {}",
                     client_id, e
                 );
@@ -953,7 +954,10 @@ impl BaseChannel for WebSocketChannel {
 
         match client.send(json) {
             Ok(()) => {
-                debug!("Sent message to WebSocket client {}", chat_id);
+                debug!(
+                    trace_id = %trace_id.unwrap_or("-"),
+                    "Sent message to WebSocket client {}", chat_id
+                );
                 if let Some(tid) = trace_id {
                     tracing::info!(
                         target: "comm",
@@ -971,7 +975,10 @@ impl BaseChannel for WebSocketChannel {
                 })
             }
             Err(e) => {
-                warn!("Failed to send to WebSocket client {}: {}", chat_id, e);
+                warn!(
+                    trace_id = %trace_id.unwrap_or("-"),
+                    "Failed to send to WebSocket client {}: {}", chat_id, e
+                );
                 Ok(SendResult {
                     success: false,
                     message_id: None,
@@ -1075,7 +1082,10 @@ pub async fn run_ws_stream_consumer(
             envelope.trace_id = chunk.trace_id.clone();
             if let Ok(json) = envelope.to_json() {
                 if client_tx.send(json).is_err() {
-                    debug!("Failed to send streaming chunk to client {}", chat_id);
+                    debug!(
+                        trace_id = %chunk.trace_id.as_deref().unwrap_or("-"),
+                        "Failed to send streaming chunk to client {}", chat_id
+                    );
                 }
             }
         }

--- a/crates/kestrel-channels/src/platforms/weixin.rs
+++ b/crates/kestrel-channels/src/platforms/weixin.rs
@@ -2022,6 +2022,12 @@ async fn process_message(
         return Ok(());
     }
 
+    let trace_id = if !message_id.is_empty() {
+        format!("wx_{message_id}")
+    } else {
+        kestrel_core::generate_trace_id()
+    };
+
     let item_list = message.item_list.as_deref().unwrap_or(&[]);
     let text = extract_text(item_list);
 
@@ -2029,6 +2035,7 @@ async fn process_message(
         let content_key = format!("content:{}:{}", sender_id, &text[..text.len().min(200)]);
         if dedup.is_duplicate(&content_key) {
             debug!(
+                trace_id = %trace_id,
                 "[weixin] Content-dedup: skipping duplicate from {}",
                 sender_id
             );
@@ -2128,6 +2135,7 @@ async fn process_message(
 
     if primary_type != MessageType::Text {
         debug!(
+            trace_id = %trace_id,
             "[weixin] processing {} media attachment(s) from {}",
             media.len(),
             sender_id
@@ -2178,7 +2186,7 @@ async fn process_message(
         } else {
             Some(message_id.to_string())
         },
-        trace_id: None,
+        trace_id: Some(trace_id),
         reply_to: None,
         timestamp: Local::now(),
     };

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -51,6 +51,7 @@ pub struct StreamConsumer {
     current_edit_interval: f64,
     in_think_block: bool,
     think_buffer: String,
+    trace_id: String,
 }
 
 impl StreamConsumer {
@@ -80,6 +81,7 @@ impl StreamConsumer {
             current_edit_interval,
             in_think_block: false,
             think_buffer: String::new(),
+            trace_id: "-".to_string(),
         }
     }
 
@@ -102,6 +104,11 @@ impl StreamConsumer {
                         // Drop chunks from other sessions
                         if chunk.session_key != self.session_key {
                             continue;
+                        }
+                        if self.trace_id == "-" {
+                            if let Some(ref tid) = chunk.trace_id {
+                                self.trace_id = tid.clone();
+                            }
                         }
                         if chunk.done {
                             got_done = true;
@@ -181,6 +188,7 @@ impl StreamConsumer {
                     let ok = self.send_or_edit(&chunk, false).await;
                     if !ok {
                         warn!(
+                            trace_id = %self.trace_id,
                             "Stream chunk split-and-send failed ({} bytes remaining), dropping rest",
                             self.accumulated.len()
                         );
@@ -272,6 +280,7 @@ impl StreamConsumer {
                             self.current_edit_interval =
                                 (self.current_edit_interval * 2.0).min(10.0);
                             debug!(
+                                trace_id = %self.trace_id,
                                 "Flood control on edit (strike {}/{}), backoff → {:.1}s",
                                 self.flood_strikes, MAX_FLOOD_STRIKES, self.current_edit_interval
                             );
@@ -283,6 +292,7 @@ impl StreamConsumer {
 
                         // Non-flood or strikes exhausted: enter fallback mode
                         debug!(
+                            trace_id = %self.trace_id,
                             "Edit failed (strikes={}), entering fallback mode",
                             self.flood_strikes
                         );
@@ -290,7 +300,7 @@ impl StreamConsumer {
                         false
                     }
                     Err(e) => {
-                        warn!("Edit message error: {e}");
+                        warn!(trace_id = %self.trace_id, "Edit message error: {e}");
                         self.edit_supported = false;
                         false
                     }
@@ -317,7 +327,7 @@ impl StreamConsumer {
                     false
                 }
                 Err(e) => {
-                    warn!("Stream send error: {e}");
+                    warn!(trace_id = %self.trace_id, "Stream send error: {e}");
                     self.edit_supported = false;
                     false
                 }

--- a/crates/kestrel-providers/src/anthropic.rs
+++ b/crates/kestrel-providers/src/anthropic.rs
@@ -394,7 +394,7 @@ impl LlmProvider for AnthropicProvider {
             "HTTP REQ"
         );
 
-        debug!("Anthropic request to {} (model: {})", url, request.model);
+        debug!(trace_id = %trace_id, "Anthropic request to {} (model: {})", url, request.model);
 
         let start = std::time::Instant::now();
         let trace_id_for_log = trace_id.clone();
@@ -543,6 +543,7 @@ impl LlmProvider for AnthropicProvider {
         );
 
         debug!(
+            trace_id = %trace_id,
             "Anthropic streaming request to {} (model: {})",
             url, request.model
         );

--- a/crates/kestrel-providers/src/openai_compat.rs
+++ b/crates/kestrel-providers/src/openai_compat.rs
@@ -454,6 +454,7 @@ impl LlmProvider for OpenAiCompatProvider {
         );
 
         debug!(
+            trace_id = %trace_id,
             "Sending completion request to {} (model: {})",
             url, request.model
         );
@@ -565,6 +566,7 @@ impl LlmProvider for OpenAiCompatProvider {
         );
 
         debug!(
+            trace_id = %trace_id,
             "Sending streaming request to {} (model: {})",
             url, request.model
         );


### PR DESCRIPTION
## Summary

Ensure every log call in the message processing pipeline includes a `trace_id` field for full-chain correlation — from channel dispatch through agent loop, runner, providers, and streaming.

## Changes

### Channel Layer (`kestrel-channels`)

| File | Changes |
|---|---|
| **feishu.rs** | Generate `fs_{message_id}` trace_id in `parse_webhook` (was `None`); add to batcher dedup, merge, send_typing, WS forwarding logs (6 total) |
| **telegram.rs** | Add `tg_{update_id}_{msg_id}` to dispatch error logs (3 total) |
| **discord.rs** | Add `dc_{msg.id}` to dispatch error log |
| **weixin.rs** | Generate `wx_{message_id}` trace_id in `process_message` (was `None`); add to content dedup and media logs (3 total) |
| **websocket.rs** | Add trace_id to message forwarding, send success/failure, streaming chunk logs (4 total) |
| **manager.rs** | Add trace_id to outbound handler error/warning logs (3 total) |

### Agent Layer (`kestrel-agent`)

| File | Changes |
|---|---|
| **loop_mod.rs** | Add `trace_id_str` local var covering ~20 logs in `process_message`; timeout/error paths in `run()`; add `trace_id` param to `recall_memories`/`store_conversation_memory` signatures; `post_task_reflect` uses `task.trace_id` (4 logs) |
| **runner.rs** | Add `self.trace_id` to all 12 non-comm log calls |

### Provider Layer (`kestrel-providers`)

| File | Changes |
|---|---|
| **anthropic.rs** | Add trace_id to 2 debug logs |
| **openai_compat.rs** | Add trace_id to 2 debug logs |

### Streaming

| File | Changes |
|---|---|
| **stream_consumer.rs** | Add `trace_id: String` field to struct, capture from first StreamChunk, add to 5 log calls |

## Verification

- `cargo fmt` — clean
- `cargo clippy` (kestrel-agent, kestrel-channels, kestrel-providers) — clean, no warnings

## Not Changed

- Infrastructure logs (startup, connect, disconnect, proxy config, token refresh) — intentionally no trace_id
- `tracing::info!(target: "comm", ...)` structured logs — already have trace_id
