### PR TITLE
fix(tools): terminal resize stale dimensions + ScriptTool os.date crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - Automatic tool registration plus structured session lifecycle logging
 
 ### Bug Fixes
+- fix(tools): terminal resize() now updates stored cols/rows — `terminal_list_sessions` returns correct dimensions after resize (Issue #288)
+- fix(tools): ScriptTool os.date() no longer crashes on chrono-incompatible format specifiers — falls back to default format with a warning (Issue #289)
 - fix(feishu): rewrite WebSocket long-connection to use endpoint discovery + protobuf (PR #284)
   - Replace hardcoded WebSocket URL with Feishu endpoint discovery API
   - Switch frame handling from JSON auth messages to protobuf Frame protocol

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1700,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1736,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1768,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1780,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1798,6 +1804,8 @@ dependencies = [
  "kestrel-session",
  "kestrel-skill",
  "parking_lot",
+ "prost",
+ "prost-build",
  "rand 0.9.4",
  "regex",
  "reqwest",
@@ -1815,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1835,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1849,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1868,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1889,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1913,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1934,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1956,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1977,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1990,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2008,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2027,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2043,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2355,6 +2363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2600,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,6 +2773,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -149,8 +149,24 @@ impl ScriptTool {
                     let dt = chrono::DateTime::from_timestamp(time_val, 0)
                         .unwrap_or(chrono::DateTime::UNIX_EPOCH);
                     let format = fmt.unwrap_or_else(|| "%Y-%m-%d %H:%M:%S".to_string());
-                    // Lua strftime tokens are mostly compatible with chrono; pass through directly
-                    lua.create_string(dt.format(&format).to_string())
+                    // chrono::format() panics on unknown specifiers, so we use
+                    // DelayedFormat's fallible cousin via format_items + write.
+                    // For simplicity we catch the panic via a wrapper.
+                    let formatted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        dt.format(&format).to_string()
+                    }));
+                    match formatted {
+                        Ok(s) => lua.create_string(&s),
+                        Err(_) => {
+                            // Fallback: use a safe default format instead of crashing
+                            let fallback = dt.format("%Y-%m-%d %H:%M:%S").to_string();
+                            warn!(
+                                format_spec = %format,
+                                "os.date: unsupported format specifier, using default"
+                            );
+                            lua.create_string(&fallback)
+                        }
+                    }
                 })
                 .map_err(|e| ToolError::Execution(format!("Failed to create os.date: {}", e)))?;
             os_safe

--- a/crates/kestrel-tools/src/builtins/terminal/session.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/session.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use std::io::{Read, Write};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::{debug, warn};
 
@@ -89,8 +89,8 @@ pub struct TerminalSession {
     id: String,
     shell: String,
     cwd: Option<String>,
-    cols: u16,
-    rows: u16,
+    cols: AtomicU16,
+    rows: AtomicU16,
     master: Mutex<Option<Box<dyn MasterPty + Send>>>,
     child: Mutex<Option<Box<dyn Child + Send + Sync>>>,
     writer: Mutex<Box<dyn Write + Send>>,
@@ -101,7 +101,8 @@ pub struct TerminalSession {
 
 // Safety: TerminalSession implements Sync because all interior mutability
 // is protected by Mutex or atomic operations:
-// - id, shell, cwd, cols, rows: String/u16, inherently Send+Sync
+// - id, shell, cwd: String, inherently Send+Sync
+// - cols, rows: AtomicU16 — atomic provides Sync
 // - master: Mutex<Option<Box<dyn MasterPty + Send>>> — Mutex provides Sync
 // - child: Mutex<Option<Box<dyn Child + Send + Sync>>> — Mutex provides Sync
 // - writer: Mutex<Box<dyn Write + Send>> — Mutex provides Sync
@@ -176,8 +177,8 @@ impl TerminalSession {
             id,
             shell: shell_cmd,
             cwd: cwd.map(String::from),
-            cols,
-            rows,
+            cols: AtomicU16::new(cols),
+            rows: AtomicU16::new(rows),
             master: Mutex::new(Some(master)),
             child: Mutex::new(Some(child)),
             writer: Mutex::new(writer),
@@ -252,11 +253,8 @@ impl TerminalSession {
             })
             .context("Failed to resize PTY")?;
         }
-        // Update stored dimensions. We need interior mutability here.
-        // Since resize is not called concurrently with itself (mutating tool),
-        // we can safely update via Cell-like pattern. However, since u16
-        // is not easily made atomic, we accept a potential brief inconsistency
-        // in info() — the PTY resize itself is the source of truth.
+        self.cols.store(cols, Ordering::Relaxed);
+        self.rows.store(rows, Ordering::Relaxed);
         Ok(())
     }
 
@@ -295,8 +293,8 @@ impl TerminalSession {
             id: self.id.clone(),
             shell: self.shell.clone(),
             cwd: self.cwd.clone(),
-            cols: self.cols,
-            rows: self.rows,
+            cols: self.cols.load(Ordering::Relaxed),
+            rows: self.rows.load(Ordering::Relaxed),
             alive: self.is_alive(),
         }
     }


### PR DESCRIPTION
## Summary
- **Fix terminal resize() stale dimensions** (#288): Changed `cols`/`rows` from `u16` to `AtomicU16` in `TerminalSession` so that `resize()` actually updates the stored dimensions. `info()` and `terminal_list_sessions` now correctly reflect the resized dimensions.
- **Fix ScriptTool os.date() crash on unknown format** (#289): Wrapped `chrono::format()` in `catch_unwind` so that unsupported format specifiers (e.g., `%,`) fall back to the default format `%Y-%m-%d %H:%M:%S` with a warning log, instead of crashing the script execution.

## Testing
- WebSocket integration tests via `test-tool-bugs.py` — all 9 tests passed
- `cargo fmt` — clean
- `cargo clippy -p kestrel-tools --all-features` — no warnings
- CI will verify full build and test suite

## Related Issues
- Closes #288
- Closes #289
- See also #290 (terminal session leak — deferred to a follow-up PR as it requires new config/infrastructure)

Bahtya