### PR TITLE
fix(memory): tantivy query parse error on field-like user messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Bug Fixes
 - fix(tools): terminal sessions auto-cleanup after 30-minute idle timeout — prevents orphaned sessions from leaking resources (Issue #290)
 - fix(tools): fix TOCTOU race in terminal_create_session — concurrent calls could exceed the configured session limit
+- fix(memory): tantivy query parser no longer fails on user messages containing field-like syntax (e.g., `code:`, `script:`) — switched from `parse_query` to `parse_query_lenient` (Issue #292)
 - fix(tools): terminal resize() now updates stored cols/rows — `terminal_list_sessions` returns correct dimensions after resize (Issue #288)
 - fix(tools): ScriptTool os.date() no longer crashes on chrono-incompatible format specifiers — falls back to default format with a warning (Issue #289)
 - fix(feishu): rewrite WebSocket long-connection to use endpoint discovery + protobuf (PR #284)

--- a/crates/kestrel-memory/src/tantivy_store.rs
+++ b/crates/kestrel-memory/src/tantivy_store.rs
@@ -186,9 +186,7 @@ impl TantivyStore {
         if let Some(ref text) = query.text {
             if !text.is_empty() {
                 let parser = QueryParser::for_index(&self.index, vec![self.content_field]);
-                let parsed = parser
-                    .parse_query(text)
-                    .map_err(|e| MemoryError::SearchEngine(format!("query parse error: {e}")))?;
+                let (parsed, _errors) = parser.parse_query_lenient(text);
                 clauses.push((Occur::Must, parsed));
             }
         }
@@ -709,6 +707,35 @@ mod tests {
         );
         let result = store.store(entry).await;
         assert!(result.is_ok());
+    }
+
+    // -- Regression: field-like query syntax should not panic (#292) ---------
+
+    #[tokio::test]
+    async fn test_search_with_field_like_syntax_does_not_error() {
+        let (store, _dir) = make_test_store().await;
+        store
+            .store(MemoryEntry::new(
+                "Lua script execution result",
+                MemoryCategory::Fact,
+            ))
+            .await
+            .unwrap();
+
+        // These queries contain tantivy field syntax (`code:`, `script:`)
+        // which used to cause parse errors before the fix.
+        let tricky_queries = [
+            "code='print(\"hello\")'",
+            "script: run this",
+            "timeout: 30s",
+            "field:value AND other:thing",
+            "code:script:timeout:",
+        ];
+
+        for q in &tricky_queries {
+            let result = store.search(&MemoryQuery::new().with_text(q)).await;
+            assert!(result.is_ok(), "query '{q}' should not error: {:?}", result);
+        }
     }
 
     // -- Concurrent write test --------------------------------------------

--- a/crates/kestrel-memory/src/tantivy_store.rs
+++ b/crates/kestrel-memory/src/tantivy_store.rs
@@ -732,7 +732,7 @@ mod tests {
             "code:script:timeout:",
         ];
 
-        for q in &tricky_queries {
+        for q in tricky_queries {
             let result = store.search(&MemoryQuery::new().with_text(q)).await;
             assert!(result.is_ok(), "query '{q}' should not error: {:?}", result);
         }


### PR DESCRIPTION
## Summary

- Fixes memory recall failures caused by tantivy interpreting user message syntax (e.g., `code:`, `script:`, `timeout:`) as field queries
- Switches `QueryParser::parse_query()` → `parse_query_lenient()` in `TantivyStore::build_query()`
- Adds regression test with 5 tricky query patterns that previously caused errors

## Problem

Every message containing patterns like `code='...'` or `script: run this` failed memory recall with:
```
Memory recall failed: Search engine error: query parse error: Field does not exist: 'code'
```

This affected tool-heavy conversations most severely (13 occurrences in a single day's production log).

## Fix

`parse_query_lenient()` converts unparseable query parts into "match-nothing" subqueries instead of returning an error. This means memory recall still works for the valid parts of the query while gracefully handling tantivy query syntax in user messages.

## Test Plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes with no warnings
- [x] New regression test `test_search_with_field_like_syntax_does_not_error` covers 5 edge cases
- [ ] CI full test suite (awaiting results)

Closes #292

Bahtya