### PR TITLE
release: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.9.1] - 2026-05-10
+
+### Bug Fixes
+- fix(agent): enforce per-tool timeout in `AgentRunner::execute_tools` — tool calls that exceed the configured timeout are now aborted with descriptive error messages (Issue #286, PR #287)
+- fix(tools): terminal resize() now updates stored cols/rows — `terminal_list_sessions` returns correct dimensions after resize (Issue #288, PR #291)
+- fix(tools): ScriptTool os.date() no longer crashes on chrono-incompatible format specifiers — falls back to default format with a warning (Issue #289, PR #291)
+- fix(tools): terminal sessions auto-cleanup after 30-minute idle timeout — prevents orphaned sessions from leaking PTY file descriptors and memory (Issue #290, PR #294)
+
 ## [v0.9.0] - 2026-05-09
 
 ### New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION
## Summary
Version bump to 0.9.1 with changelog update.

### Changes since v0.9.0
- fix(agent): enforce per-tool timeout (PR #287)
- fix(tools): terminal resize stale dimensions (PR #291)
- fix(tools): ScriptTool os.date crash on bad format (PR #291)
- fix(tools): terminal session idle timeout (PR #294)

Bahtya