### PR TITLE
fix(tools): terminal session idle auto-cleanup + TOCTOU race fix (Issues #290, #296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Bug Fixes
 - fix(tools): terminal sessions auto-cleanup after 30-minute idle timeout — prevents orphaned sessions from leaking resources (Issue #290)
+- fix(tools): fix TOCTOU race in terminal_create_session — concurrent calls could exceed the configured session limit
 - fix(tools): terminal resize() now updates stored cols/rows — `terminal_list_sessions` returns correct dimensions after resize (Issue #288)
 - fix(tools): ScriptTool os.date() no longer crashes on chrono-incompatible format specifiers — falls back to default format with a warning (Issue #289)
 - fix(feishu): rewrite WebSocket long-connection to use endpoint discovery + protobuf (PR #284)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Automatic tool registration plus structured session lifecycle logging
 
 ### Bug Fixes
+- fix(tools): terminal sessions auto-cleanup after 30-minute idle timeout — prevents orphaned sessions from leaking resources (Issue #290)
 - fix(tools): terminal resize() now updates stored cols/rows — `terminal_list_sessions` returns correct dimensions after resize (Issue #288)
 - fix(tools): ScriptTool os.date() no longer crashes on chrono-incompatible format specifiers — falls back to default format with a warning (Issue #289)
 - fix(feishu): rewrite WebSocket long-connection to use endpoint discovery + protobuf (PR #284)

--- a/crates/kestrel-tools/src/builtins/terminal/manager.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/manager.rs
@@ -126,8 +126,8 @@ impl TerminalManager {
     ) -> Result<String> {
         self.reap_idle_sessions();
 
-        let current_count = self.sessions.read().len();
-        if current_count >= self.max_sessions {
+        // Fast-path pre-check with read lock to avoid wasteful PTY spawn.
+        if self.sessions.read().len() >= self.max_sessions {
             anyhow::bail!(
                 "Maximum number of terminal sessions reached ({})",
                 self.max_sessions
@@ -139,7 +139,20 @@ impl TerminalManager {
         let session = TerminalSession::spawn(id.clone(), shell, cwd, cols, rows, self.dangerous)
             .with_context(|| format!("Failed to spawn terminal session '{}'", id))?;
 
-        self.sessions.write().insert(id.clone(), Arc::new(session));
+        // Authoritative check + insert under a single write lock to prevent
+        // TOCTOU race where concurrent calls could exceed max_sessions.
+        let mut sessions = self.sessions.write();
+        if sessions.len() >= self.max_sessions {
+            drop(sessions);
+            drop(session);
+            anyhow::bail!(
+                "Maximum number of terminal sessions reached ({})",
+                self.max_sessions
+            );
+        }
+        sessions.insert(id.clone(), Arc::new(session));
+        drop(sessions);
+
         info!("Created terminal session '{}'", id);
         Ok(id)
     }
@@ -296,5 +309,35 @@ mod tests {
         assert!(id.is_ok());
         assert_eq!(mgr.reap_idle_sessions(), 0);
         assert_eq!(mgr.len(), 1);
+    }
+
+    #[test]
+    fn test_concurrent_create_respects_limit() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let mgr = Arc::new(TerminalManager::with_config(3, true));
+        let mut handles = vec![];
+
+        // Spawn 6 threads each trying to create a session (limit is 3).
+        for _ in 0..6 {
+            let mgr = mgr.clone();
+            handles.push(thread::spawn(move || {
+                mgr.create_session(None, None, 80, 24).ok()
+            }));
+        }
+
+        let successes: Vec<_> = handles
+            .into_iter()
+            .filter_map(|h| h.join().ok().flatten())
+            .collect();
+
+        // At most 3 sessions should have been created.
+        assert!(
+            successes.len() <= 3,
+            "Expected at most 3 sessions, got {}",
+            successes.len()
+        );
+        assert_eq!(mgr.len(), successes.len());
     }
 }

--- a/crates/kestrel-tools/src/builtins/terminal/manager.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/manager.rs
@@ -6,12 +6,22 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{info, warn};
 
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 /// Default maximum number of concurrent terminal sessions.
 const DEFAULT_MAX_SESSIONS: usize = 10;
+
+/// Default idle timeout in seconds (30 minutes).
+const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 30 * 60;
+
+fn epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
 
 /// Manages multiple PTY terminal sessions.
 ///
@@ -20,19 +30,24 @@ const DEFAULT_MAX_SESSIONS: usize = 10;
 ///
 /// Sessions are stored as `Arc<TerminalSession>` so async operations can
 /// release the registry lock before awaiting on session-level I/O.
+///
+/// Idle sessions (no activity for `idle_timeout_secs`) are automatically
+/// reaped during `create_session()` and `list_sessions()` calls.
 pub struct TerminalManager {
     sessions: RwLock<HashMap<String, Arc<TerminalSession>>>,
     max_sessions: usize,
     dangerous: bool,
+    idle_timeout_secs: u64,
 }
 
 impl TerminalManager {
-    /// Create a new empty session manager with default limits.
+    /// Create a new empty session manager with default limits and idle timeout.
     pub fn new() -> Self {
         Self {
             sessions: RwLock::new(HashMap::new()),
             max_sessions: DEFAULT_MAX_SESSIONS,
             dangerous: false,
+            idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
         }
     }
 
@@ -42,12 +57,60 @@ impl TerminalManager {
             sessions: RwLock::new(HashMap::new()),
             max_sessions,
             dangerous,
+            idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
+        }
+    }
+
+    /// Create a session manager with explicit idle timeout.
+    ///
+    /// A value of 0 disables idle reaping.
+    pub fn with_idle_timeout(max_sessions: usize, dangerous: bool, idle_timeout_secs: u64) -> Self {
+        Self {
+            sessions: RwLock::new(HashMap::new()),
+            max_sessions,
+            dangerous,
+            idle_timeout_secs,
         }
     }
 
     /// Whether this manager runs in dangerous (unrestricted) mode.
     pub fn is_dangerous(&self) -> bool {
         self.dangerous
+    }
+
+    /// Kill and remove sessions that have been idle past the timeout.
+    ///
+    /// Returns the number of sessions reaped. A timeout of 0 disables reaping.
+    pub fn reap_idle_sessions(&self) -> usize {
+        let timeout = self.idle_timeout_secs;
+        if timeout == 0 {
+            return 0;
+        }
+
+        let now = epoch_secs();
+        let to_kill: Vec<String> = {
+            let sessions = self.sessions.read();
+            sessions
+                .iter()
+                .filter(|(_, s)| {
+                    let idle_secs = now.saturating_sub(s.last_activity_secs());
+                    idle_secs > timeout
+                })
+                .map(|(id, _)| id.clone())
+                .collect()
+        };
+
+        let count = to_kill.len();
+        for id in to_kill {
+            if let Some(session) = self.sessions.write().remove(&id) {
+                session.kill();
+                warn!(
+                    "Reaped idle terminal session '{}' (idle > {}s)",
+                    id, timeout
+                );
+            }
+        }
+        count
     }
 
     /// Spawn a new terminal session.
@@ -61,6 +124,8 @@ impl TerminalManager {
         cols: u16,
         rows: u16,
     ) -> Result<String> {
+        self.reap_idle_sessions();
+
         let current_count = self.sessions.read().len();
         if current_count >= self.max_sessions {
             anyhow::bail!(
@@ -105,6 +170,7 @@ impl TerminalManager {
 
     /// List all sessions with their metadata.
     pub fn list_sessions(&self) -> Vec<SessionInfo> {
+        self.reap_idle_sessions();
         let sessions = self.sessions.read();
         sessions.values().map(|s| s.info()).collect()
     }
@@ -128,12 +194,6 @@ impl TerminalManager {
         let session = sessions
             .get(session_id)
             .context(format!("Session '{}' not found", session_id))?;
-        debug!(
-            session_id = session_id,
-            cols = cols,
-            rows = rows,
-            "Resizing terminal session via manager"
-        );
         session.resize(cols, rows)
     }
 
@@ -221,13 +281,20 @@ mod tests {
 
     #[test]
     fn test_max_sessions_limit() {
-        // Create a manager with max_sessions=1 and dangerous=true to allow
-        // any shell (avoids shell validation issues in test environments).
         let mgr = TerminalManager::with_config(1, true);
         let id = mgr.create_session(None, None, 80, 24);
         assert!(id.is_ok(), "First session should succeed");
         let id2 = mgr.create_session(None, None, 80, 24);
         assert!(id2.is_err(), "Second session should fail due to limit");
         assert!(id2.unwrap_err().to_string().contains("Maximum number"));
+    }
+
+    #[test]
+    fn test_reap_idle_no_timeout() {
+        let mgr = TerminalManager::with_idle_timeout(10, true, 0);
+        let id = mgr.create_session(None, None, 80, 24);
+        assert!(id.is_ok());
+        assert_eq!(mgr.reap_idle_sessions(), 0);
+        assert_eq!(mgr.len(), 1);
     }
 }

--- a/crates/kestrel-tools/src/builtins/terminal/session.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/session.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use std::io::{Read, Write};
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::{debug, warn};
 
@@ -91,6 +91,7 @@ pub struct TerminalSession {
     cwd: Option<String>,
     cols: AtomicU16,
     rows: AtomicU16,
+    last_activity: AtomicU64,
     master: Mutex<Option<Box<dyn MasterPty + Send>>>,
     child: Mutex<Option<Box<dyn Child + Send + Sync>>>,
     writer: Mutex<Box<dyn Write + Send>>,
@@ -102,7 +103,7 @@ pub struct TerminalSession {
 // Safety: TerminalSession implements Sync because all interior mutability
 // is protected by Mutex or atomic operations:
 // - id, shell, cwd: String, inherently Send+Sync
-// - cols, rows: AtomicU16 — atomic provides Sync
+// - cols, rows, last_activity: AtomicU16/AtomicU64 — atomics provide Sync
 // - master: Mutex<Option<Box<dyn MasterPty + Send>>> — Mutex provides Sync
 // - child: Mutex<Option<Box<dyn Child + Send + Sync>>> — Mutex provides Sync
 // - writer: Mutex<Box<dyn Write + Send>> — Mutex provides Sync
@@ -110,6 +111,13 @@ pub struct TerminalSession {
 // - alive: Arc<AtomicBool> — Arc+Atomic provides Sync
 // - reader_handle: Option<JoinHandle<()>> — JoinHandle is Send+Sync (Rust 1.72+)
 unsafe impl Sync for TerminalSession {}
+
+fn epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
 
 impl TerminalSession {
     /// Spawn a new PTY session.
@@ -179,6 +187,7 @@ impl TerminalSession {
             cwd: cwd.map(String::from),
             cols: AtomicU16::new(cols),
             rows: AtomicU16::new(rows),
+            last_activity: AtomicU64::new(epoch_secs()),
             master: Mutex::new(Some(master)),
             child: Mutex::new(Some(child)),
             writer: Mutex::new(writer),
@@ -199,6 +208,7 @@ impl TerminalSession {
             .write_all(input.as_bytes())
             .context("Failed to write to PTY")?;
         writer.flush().context("Failed to flush PTY writer")?;
+        self.last_activity.store(epoch_secs(), Ordering::Relaxed);
         Ok(())
     }
 
@@ -207,6 +217,7 @@ impl TerminalSession {
     /// If `timeout_ms` is `Some`, waits up to that many milliseconds for
     /// new output before returning.
     pub fn read_output(&self, timeout_ms: Option<u64>) -> Result<String> {
+        self.last_activity.store(epoch_secs(), Ordering::Relaxed);
         {
             let mut buf = self.output_buffer.lock().unwrap();
             if !buf.is_empty() {
@@ -255,6 +266,7 @@ impl TerminalSession {
         }
         self.cols.store(cols, Ordering::Relaxed);
         self.rows.store(rows, Ordering::Relaxed);
+        self.last_activity.store(epoch_secs(), Ordering::Relaxed);
         Ok(())
     }
 
@@ -285,6 +297,11 @@ impl TerminalSession {
     /// Whether the underlying process is still alive.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Relaxed)
+    }
+
+    /// Return the epoch timestamp (seconds) of the last activity.
+    pub fn last_activity_secs(&self) -> u64 {
+        self.last_activity.load(Ordering::Relaxed)
     }
 
     /// Return session metadata.


### PR DESCRIPTION
## Summary

- **Idle session auto-cleanup (Issue #290)**: Sessions with no activity for 30 minutes are automatically reaped during `create_session()` and `list_sessions()` calls. Activity is tracked via `AtomicU64` timestamps on every `send_input`, `read_output`, and `resize` operation.
- **TOCTOU race fix (Issue #296)**: Fixed race condition in `create_session()` where concurrent calls could exceed the configured `max_sessions` limit. The count check and insert now happen under a single write lock.
- **Resize stale dimensions (Issue #288)**: `cols` and `rows` are now `AtomicU16`, updated atomically on resize (included from PR #291 via base branch).

## Changes

- `session.rs`: Add `last_activity: AtomicU64` timestamp, update on every interactive operation
- `session.rs`: Change `cols`/`rows` from `u16` to `AtomicU16` for atomic resize updates
- `manager.rs`: Add `reap_idle_sessions()` to kill idle sessions past 30-minute timeout
- `manager.rs`: Fix TOCTOU race in `create_session()` — authoritative check under write lock
- `manager.rs`: Add `with_idle_timeout()` constructor for testing
- Tests: Add `test_concurrent_create_respects_limit` to verify TOCTOU fix
- Tests: Add `test_reap_idle_no_timeout` to verify disabled reaping

## Test Plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [ ] CI: Format, Clippy, Build & Test, Security Audit

Bahtya