### PR TITLE
fix(tools): terminal session idle auto-cleanup + TOCTOU race fix (Issues #290, #296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bug Fixes
 - fix(tools): terminal sessions auto-cleanup after 30-minute idle timeout — prevents orphaned sessions from leaking resources (Issue #290)
+- fix(tools): fix TOCTOU race in terminal_create_session — concurrent calls could exceed the configured session limit
 - fix(tools): terminal resize() now updates stored cols/rows — `terminal_list_sessions` returns correct dimensions after resize (Issue #288)
 - fix(tools): ScriptTool os.date() no longer crashes on chrono-incompatible format specifiers — falls back to default format with a warning (Issue #289)
 - fix(feishu): rewrite WebSocket long-connection to use endpoint discovery + protobuf (PR #284)

--- a/crates/kestrel-tools/src/builtins/terminal/manager.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/manager.rs
@@ -126,8 +126,8 @@ impl TerminalManager {
     ) -> Result<String> {
         self.reap_idle_sessions();
 
-        let current_count = self.sessions.read().len();
-        if current_count >= self.max_sessions {
+        // Fast-path pre-check with read lock to avoid wasteful PTY spawn.
+        if self.sessions.read().len() >= self.max_sessions {
             anyhow::bail!(
                 "Maximum number of terminal sessions reached ({})",
                 self.max_sessions
@@ -139,7 +139,20 @@ impl TerminalManager {
         let session = TerminalSession::spawn(id.clone(), shell, cwd, cols, rows, self.dangerous)
             .with_context(|| format!("Failed to spawn terminal session '{}'", id))?;
 
-        self.sessions.write().insert(id.clone(), Arc::new(session));
+        // Authoritative check + insert under a single write lock to prevent
+        // TOCTOU race where concurrent calls could exceed max_sessions.
+        let mut sessions = self.sessions.write();
+        if sessions.len() >= self.max_sessions {
+            drop(sessions);
+            drop(session);
+            anyhow::bail!(
+                "Maximum number of terminal sessions reached ({})",
+                self.max_sessions
+            );
+        }
+        sessions.insert(id.clone(), Arc::new(session));
+        drop(sessions);
+
         info!("Created terminal session '{}'", id);
         Ok(id)
     }
@@ -296,5 +309,35 @@ mod tests {
         assert!(id.is_ok());
         assert_eq!(mgr.reap_idle_sessions(), 0);
         assert_eq!(mgr.len(), 1);
+    }
+
+    #[test]
+    fn test_concurrent_create_respects_limit() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let mgr = Arc::new(TerminalManager::with_config(3, true));
+        let mut handles = vec![];
+
+        // Spawn 6 threads each trying to create a session (limit is 3).
+        for _ in 0..6 {
+            let mgr = mgr.clone();
+            handles.push(thread::spawn(move || {
+                mgr.create_session(None, None, 80, 24).ok()
+            }));
+        }
+
+        let successes: Vec<_> = handles
+            .into_iter()
+            .filter_map(|h| h.join().ok().flatten())
+            .collect();
+
+        // At most 3 sessions should have been created.
+        assert!(
+            successes.len() <= 3,
+            "Expected at most 3 sessions, got {}",
+            successes.len()
+        );
+        assert_eq!(mgr.len(), successes.len());
     }
 }


### PR DESCRIPTION
## Summary

- **Idle session auto-cleanup (Issue #290)**: Sessions with no activity for 30 minutes are automatically reaped during `create_session()` and `list_sessions()` calls. Activity is tracked via `AtomicU64` timestamps on every `send_input`, `read_output`, and `resize` operation.
- **TOCTOU race fix (Issue #296)**: Fixed race condition in `create_session()` where concurrent calls could exceed the configured `max_sessions` limit. The count check and insert now happen under a single write lock.
- **Resize stale dimensions (Issue #288)**: `cols` and `rows` are now `AtomicU16`, updated atomically on resize (included from PR #291 via base branch).

## Changes

- `session.rs`: Add `last_activity: AtomicU64` timestamp, update on every interactive operation
- `session.rs`: Change `cols`/`rows` from `u16` to `AtomicU16` for atomic resize updates
- `manager.rs`: Add `reap_idle_sessions()` to kill idle sessions past 30-minute timeout
- `manager.rs`: Fix TOCTOU race in `create_session()` — authoritative check under write lock
- `manager.rs`: Add `with_idle_timeout()` constructor for testing
- Tests: Add `test_concurrent_create_respects_limit` to verify TOCTOU fix
- Tests: Add `test_reap_idle_no_timeout` to verify disabled reaping

## Test Plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [ ] CI: Format, Clippy, Build & Test, Security Audit

Closes #290
Closes #296

Bahtya