### PR TITLE
fix(tools): fix TOCTOU race in terminal_create_session (Issue #296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bug Fixes
 - fix(tools): terminal sessions auto-cleanup after 30-minute idle timeout — prevents orphaned sessions from leaking resources (Issue #290)
+- fix(tools): fix TOCTOU race in terminal_create_session — concurrent calls could exceed the configured session limit
 - fix(tools): terminal resize() now updates stored cols/rows — `terminal_list_sessions` returns correct dimensions after resize (Issue #288)
 - fix(tools): ScriptTool os.date() no longer crashes on chrono-incompatible format specifiers — falls back to default format with a warning (Issue #289)
 - fix(feishu): rewrite WebSocket long-connection to use endpoint discovery + protobuf (PR #284)

--- a/crates/kestrel-tools/src/builtins/terminal/manager.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/manager.rs
@@ -126,8 +126,8 @@ impl TerminalManager {
     ) -> Result<String> {
         self.reap_idle_sessions();
 
-        let current_count = self.sessions.read().len();
-        if current_count >= self.max_sessions {
+        // Fast-path pre-check with read lock to avoid wasteful PTY spawn.
+        if self.sessions.read().len() >= self.max_sessions {
             anyhow::bail!(
                 "Maximum number of terminal sessions reached ({})",
                 self.max_sessions
@@ -139,7 +139,20 @@ impl TerminalManager {
         let session = TerminalSession::spawn(id.clone(), shell, cwd, cols, rows, self.dangerous)
             .with_context(|| format!("Failed to spawn terminal session '{}'", id))?;
 
-        self.sessions.write().insert(id.clone(), Arc::new(session));
+        // Authoritative check + insert under a single write lock to prevent
+        // TOCTOU race where concurrent calls could exceed max_sessions.
+        let mut sessions = self.sessions.write();
+        if sessions.len() >= self.max_sessions {
+            drop(sessions);
+            drop(session);
+            anyhow::bail!(
+                "Maximum number of terminal sessions reached ({})",
+                self.max_sessions
+            );
+        }
+        sessions.insert(id.clone(), Arc::new(session));
+        drop(sessions);
+
         info!("Created terminal session '{}'", id);
         Ok(id)
     }
@@ -296,5 +309,35 @@ mod tests {
         assert!(id.is_ok());
         assert_eq!(mgr.reap_idle_sessions(), 0);
         assert_eq!(mgr.len(), 1);
+    }
+
+    #[test]
+    fn test_concurrent_create_respects_limit() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let mgr = Arc::new(TerminalManager::with_config(3, true));
+        let mut handles = vec![];
+
+        // Spawn 6 threads each trying to create a session (limit is 3).
+        for _ in 0..6 {
+            let mgr = mgr.clone();
+            handles.push(thread::spawn(move || {
+                mgr.create_session(None, None, 80, 24).ok()
+            }));
+        }
+
+        let successes: Vec<_> = handles
+            .into_iter()
+            .filter_map(|h| h.join().ok().flatten())
+            .collect();
+
+        // At most 3 sessions should have been created.
+        assert!(
+            successes.len() <= 3,
+            "Expected at most 3 sessions, got {}",
+            successes.len()
+        );
+        assert_eq!(mgr.len(), successes.len());
     }
 }


### PR DESCRIPTION
## Summary

Fixes a TOCTOU (time-of-check-time-of-use) race condition in `TerminalManager::create_session()` where concurrent calls could exceed the configured `max_sessions` limit.

**Root cause:** The session count check used a read lock and the insert used a separate write lock, creating a window where multiple threads could both pass the count check before either inserted.

**Fix:** Use a single write lock for the authoritative check-and-insert after spawning the session. The fast-path read check is kept for efficiency but the write lock ensures the final insertion is atomic.

## Changes

- `manager.rs`: Wrap authoritative count check + insert under a single write lock
- `manager.rs`: Add `test_concurrent_create_respects_limit` test (6 threads racing with limit=3)
- `CHANGELOG.md`: Add entry for the TOCTOU fix

## Test Plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes  
- [x] CI: All checks pass (Format, Clippy, Build & Test, Security Audit)

Closes #296

Bahtya