### PR TITLE
fix(tools): wrap Lua script execution in catch_unwind (Issue #300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+- fix(tools): wrap Lua script execution in catch_unwind to prevent Rust-side panics from crashing the process; also make all internal Mutex locks poison-resistant (Issue #300)
+- fix(tools): fix TOCTOU race in terminal_create_session — concurrent calls could exceed max_sessions limit (Issue #296, PR #299)
+- fix(memory): tantivy QueryParser now uses parse_query_lenient() to handle field-like syntax in user messages gracefully (Issue #292, PR #293)
+
 ## [v0.9.1] - 2026-05-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -620,8 +620,7 @@ impl Tool for ScriptTool {
         // binding bug that triggers a Rust panic instead of returning an error).
         let max_output = self.max_output_bytes;
         let exec_result: Result<(), ToolError> = tokio::task::block_in_place(|| {
-            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| lua.load(code).exec()))
-            {
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| lua.load(code).exec())) {
                 Ok(Ok(())) => Ok(()),
                 Ok(Err(e)) => Err(ToolError::Execution(format!("Lua error: {}", e))),
                 Err(panic) => {

--- a/crates/kestrel-tools/src/builtins/script.rs
+++ b/crates/kestrel-tools/src/builtins/script.rs
@@ -190,7 +190,7 @@ impl ScriptTool {
             let clock_start = Arc::new(std::sync::Mutex::new(std::time::Instant::now()));
             let os_clock_fn = lua
                 .create_function(move |_, _: ()| {
-                    let start = clock_start.lock().unwrap();
+                    let start = clock_start.lock().unwrap_or_else(|e| e.into_inner());
                     Ok(start.elapsed().as_secs_f64())
                 })
                 .map_err(|e| ToolError::Execution(format!("Failed to create os.clock: {}", e)))?;
@@ -604,7 +604,7 @@ impl Tool for ScriptTool {
                     })
                     .collect();
                 let line = parts.join("\t");
-                let mut buf = buf_clone.lock().unwrap();
+                let mut buf = buf_clone.lock().unwrap_or_else(|e| e.into_inner());
                 buf.extend_from_slice(line.as_bytes());
                 buf.push(b'\n');
                 Ok(())
@@ -615,13 +615,27 @@ impl Tool for ScriptTool {
             .set("print", print_capture)
             .map_err(|e| ToolError::Execution(format!("Failed to set print: {}", e)))?;
 
-        // Execute the script
+        // Execute the script — catch_unwind prevents Lua binding panics from
+        // crashing the process (e.g., poisoned mutex in print, or any future
+        // binding bug that triggers a Rust panic instead of returning an error).
         let max_output = self.max_output_bytes;
-        let exec_result: Result<(), ToolError> =
-            tokio::task::block_in_place(|| match lua.load(code).exec() {
-                Ok(()) => Ok(()),
-                Err(e) => Err(ToolError::Execution(format!("Lua error: {}", e))),
-            });
+        let exec_result: Result<(), ToolError> = tokio::task::block_in_place(|| {
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| lua.load(code).exec()))
+            {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(e)) => Err(ToolError::Execution(format!("Lua error: {}", e))),
+                Err(panic) => {
+                    let msg = if let Some(s) = panic.downcast_ref::<String>() {
+                        s.clone()
+                    } else if let Some(s) = panic.downcast_ref::<&str>() {
+                        s.to_string()
+                    } else {
+                        "unknown panic".to_string()
+                    };
+                    Err(ToolError::Execution(format!("Lua panic: {}", msg)))
+                }
+            }
+        });
 
         let elapsed_ms = start.elapsed().as_millis();
 
@@ -629,7 +643,7 @@ impl Tool for ScriptTool {
             Ok(()) => {
                 // Collect captured output
                 let output = {
-                    let buf = stdout_buf.lock().unwrap();
+                    let buf = stdout_buf.lock().unwrap_or_else(|e| e.into_inner());
                     String::from_utf8_lossy(&buf).to_string()
                 };
 


### PR DESCRIPTION
## Summary
- Wrap the entire `lua.load(code).exec()` call in `std::panic::catch_unwind(AssertUnwindSafe(|| ...))` so that any Rust-side panic from a Lua binding (poisoned mutex, future binding bug, etc.) is caught and returned as a `ToolError` instead of crashing the kestrel process
- Replace all `.lock().unwrap()` calls in the script execution path with `.lock().unwrap_or_else(|e| e.into_inner())` to handle poisoned mutexes gracefully (3 locations: os.clock, print capture, stdout collection)

## Context

The os.date fix (PR #291) added `catch_unwind` specifically for the os.date binding, but the general Lua execution wrapper was not protected. If any Lua binding triggers a Rust panic, the entire kestrel daemon would crash.

Closes #300

## Test plan
- [ ] Existing script tool tests pass
- [ ] Manual test: call script tool with code that would panic — should return error, not crash
- [ ] CI passes (format, clippy, tests, security audit)