### PR TITLE
release: v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v0.9.2] - 2026-05-10
 
 ### Bug Fixes
 - fix(tools): wrap Lua script execution in catch_unwind to prevent Rust-side panics from crashing the process; also make all internal Mutex locks poison-resistant (Issue #300)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION
## Release v0.9.2

### Bug Fixes
- fix(tools): wrap Lua script execution in catch_unwind to prevent Rust-side panics from crashing the process; also make all internal Mutex locks poison-resistant (Issue #300)
- fix(tools): fix TOCTOU race in terminal_create_session — concurrent calls could exceed max_sessions limit (Issue #296, PR #299)
- fix(memory): tantivy QueryParser now uses parse_query_lenient() to handle field-like syntax in user messages gracefully (Issue #292, PR #293)