### PR TITLE
fix(config): default tool_timeout 120→60 to make per-tool timeout reachable (Issue #303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - fix(tools): add depth (max 10) and entry count (max 10,000) limits to `kestrel.list_dir` recursive mode to prevent filesystem enumeration DoS; gracefully skip unreadable directories instead of aborting (Issue #304, PR #305)
+- fix(config): change default `tool_timeout` from 120s to 60s — previous default exceeded `message_timeout` (90s), making the per-tool timeout unreachable (Issue #303)
 
 ## [v0.9.2] - 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/kestrel-channels/src/commands.rs
+++ b/crates/kestrel-channels/src/commands.rs
@@ -3103,14 +3103,14 @@ listen_addr = "0.0.0.0:9091"
         let toml_str = r#"
 [agent]
 model = "gpt-4o"
-tool_timeout = 120
+tool_timeout = 60
 "#;
         let _env = EnvVarGuard::set("KESTREL_HOME", dir.path());
         let config_path = dir.path().join("config.toml");
         std::fs::write(&config_path, toml_str).unwrap();
 
         let result = ws_settings_timeout("tool_timeout 300");
-        assert!(result.contains("tool_timeout: 120s → 300s"));
+        assert!(result.contains("tool_timeout: 60s → 300s"));
     }
 
     #[test]

--- a/crates/kestrel-config/src/python_schema.rs
+++ b/crates/kestrel-config/src/python_schema.rs
@@ -433,7 +433,7 @@ mod tests {
                     "max_tokens": 4096,
                     "max_iterations": 50,
                     "streaming": true,
-                    "tool_timeout": 120
+                    "tool_timeout": 60
                 }
             },
             "heartbeat": {"enabled": true, "interval_secs": 1800},

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -1174,7 +1174,7 @@ fn default_max_iterations() -> usize {
 }
 
 fn default_tool_timeout() -> u64 {
-    120
+    60
 }
 
 const fn default_message_timeout() -> u64 {
@@ -1310,7 +1310,7 @@ log_format: text
         assert!(agent.workspace.is_none());
         assert!(agent.system_prompt.is_none());
         assert!(agent.streaming);
-        assert_eq!(agent.tool_timeout, 120);
+        assert_eq!(agent.tool_timeout, 60);
     }
 
     #[test]

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -191,12 +191,19 @@ pub fn fill_defaults(config: &mut Config) -> Vec<String> {
         filled.push("agent.max_iterations".to_string());
     }
     if config.agent.tool_timeout == 0 {
-        config.agent.tool_timeout = 120;
+        config.agent.tool_timeout = 60;
         filled.push("agent.tool_timeout".to_string());
     }
     if config.agent.message_timeout == 0 {
         config.agent.message_timeout = 90;
         filled.push("agent.message_timeout".to_string());
+    }
+    if config.agent.tool_timeout > config.agent.message_timeout {
+        tracing::warn!(
+            tool_timeout = config.agent.tool_timeout,
+            message_timeout = config.agent.message_timeout,
+            "tool_timeout exceeds message_timeout — per-tool timeout will never trigger"
+        );
     }
 
     // Dream section
@@ -2128,7 +2135,7 @@ mod tests {
         assert_eq!(config.agent.model, "gpt-4o");
         assert_eq!(config.agent.max_tokens, 4096);
         assert_eq!(config.agent.max_iterations, 50);
-        assert_eq!(config.agent.tool_timeout, 120);
+        assert_eq!(config.agent.tool_timeout, 60);
         assert_eq!(config.dream.interval_secs, 7200);
         assert_eq!(config.heartbeat.interval_secs, 1800);
         assert_eq!(config.cron.tick_secs, 60);


### PR DESCRIPTION
## Summary

- Changed `default_tool_timeout()` from 120s to 60s — the previous default exceeded `message_timeout` (90s), making the per-tool timeout enforcement from PR #287 unreachable
- Added runtime `tracing::warn!` when `tool_timeout > message_timeout` in config validation
- Updated all test assertions referencing the old default

## Problem

With defaults `tool_timeout=120, message_timeout=90`:
1. A slow tool call starts executing
2. At 90s, `message_timeout` fires in `loop_mod.rs:255`, killing the entire message processing
3. The tool timeout at 120s is **never reached**
4. Users see the generic "Processing your message took too long (90s limit)" instead of the specific "Tool 'X' timed out after 60s"

## Fix

`tool_timeout=60` ensures tools are individually timed out with a clear error message well before the message processing deadline.

## Test plan
- [x] `cargo fmt` — no changes
- [x] `cargo clippy` — no new warnings
- [ ] CI: all tests pass with updated assertions

Closes #303