### PR TITLE
chore: bump version to 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+## [v0.9.4] - 2026-05-10
+
+### Bug Fixes
+- fix(config): change default `tool_timeout` from 120s to 60s — previous default exceeded `message_timeout` (90s), making the per-tool timeout unreachable (Issue #303, PR #306)
+
 ## [v0.9.3] - 2026-05-10
 
 ### Bug Fixes
 - fix(tools): add depth (max 10) and entry count (max 10,000) limits to `kestrel.list_dir` recursive mode to prevent filesystem enumeration DoS; gracefully skip unreadable directories instead of aborting (Issue #304, PR #305)
-- fix(config): change default `tool_timeout` from 120s to 60s — previous default exceeded `message_timeout` (90s), making the per-tool timeout unreachable (Issue #303)
 
 ## [v0.9.2] - 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 
 [[package]]
 name = "matchers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION
Version bump for v0.9.4 release.

Includes:
- fix(config): default tool_timeout 120→60 (Issue #303, PR #306)