### PR TITLE
fix(tools): add 30s HTTP timeout to WebSearchTool (Issue #312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+- fix(tools): add 30s HTTP timeout to WebSearchTool — `search_brave()` and `search_tavily()` used bare `reqwest::Client::new()` without timeout, allowing requests to hang indefinitely until `tool_timeout` aborted the task (Issue #312)
+
 ## [v0.9.6] - 2026-05-10
 
 ### Bug Fixes

--- a/crates/kestrel-tools/src/builtins/web.rs
+++ b/crates/kestrel-tools/src/builtins/web.rs
@@ -102,7 +102,10 @@ impl WebSearchTool {
         let api_key = std::env::var("BRAVE_API_KEY")
             .map_err(|_| ToolError::NotAvailable("BRAVE_API_KEY not set".to_string()))?;
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| ToolError::Execution(format!("Failed to build HTTP client: {}", e)))?;
         let resp = client
             .get("https://api.search.brave.com/res/v1/web/search")
             .header("X-Subscription-Token", &api_key)
@@ -140,7 +143,10 @@ impl WebSearchTool {
         let api_key = std::env::var("TAVILY_API_KEY")
             .map_err(|_| ToolError::NotAvailable("TAVILY_API_KEY not set".to_string()))?;
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| ToolError::Execution(format!("Failed to build HTTP client: {}", e)))?;
         let resp = client
             .post("https://api.tavily.com/search")
             .json(&json!({
@@ -314,6 +320,17 @@ fn html_to_text(html: &str) -> String {
 mod tests {
     use super::*;
     use crate::trait_def::Tool;
+
+    #[test]
+    fn test_search_client_has_timeout() {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("build client");
+        // Verify the client is usable — timeout is set internally and cannot
+        // be inspected via public API, so we just confirm construction succeeds.
+        assert!(client.get("https://example.com").build().is_ok());
+    }
 
     #[test]
     fn test_web_search_tool_disabled() {


### PR DESCRIPTION
## Summary
- Add 30s HTTP timeout to `WebSearchTool::search_brave()` and `WebSearchTool::search_tavily()` — both methods used bare `reqwest::Client::new()` without any timeout
- Matches the pattern already used by `WebFetchTool` in the same file (`.timeout(Duration::from_secs(30))`)

## Problem
Without a client-level timeout, HTTP requests to search APIs could hang indefinitely until the agent runner's `tool_timeout` (60s) aborted the tokio task via `JoinHandle::abort()`. While `AbortOnDrop` eventually kills the task, the underlying TCP connection and response body linger, wasting file descriptors.

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy --package kestrel-tools -- -D warnings` passes
- [ ] CI: Format, Clippy, Test, Security Audit
- [ ] WebSocket functional test: `web_search` tool still works (requires API key)

Closes #312

Bahtya