### PR TITLE
fix(tools): add content size limit (10MB) to WriteFileTool (Issue #322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.9.12] - 2026-05-10
+
+### Bug Fixes
+- fix(tools): add content size limit (10MB) to `write_file` tool — previously an agent could write arbitrarily large files to disk, only the read/edit tools had size limits (Issue #322)
+
 ## [v0.9.11] - 2026-05-10
 
 ### Bug Fixes

--- a/crates/kestrel-tools/src/builtins/filesystem.rs
+++ b/crates/kestrel-tools/src/builtins/filesystem.rs
@@ -9,6 +9,7 @@ const FILESYSTEM_IO_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_MAX_LIST_DIR_DEPTH: usize = 10;
 const DEFAULT_MAX_LIST_DIR_ENTRIES: usize = 10_000;
 const MAX_READ_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+const MAX_WRITE_FILE_SIZE: usize = 10 * 1024 * 1024; // 10 MB
 
 // ─── ReadFileTool ────────────────────────────────────────────
 
@@ -154,6 +155,14 @@ impl Tool for WriteFileTool {
             .as_str()
             .ok_or_else(|| ToolError::Validation("Missing 'content'".to_string()))?;
         let append = args["append"].as_bool().unwrap_or(false);
+
+        if content.len() > MAX_WRITE_FILE_SIZE {
+            return Err(ToolError::Execution(format!(
+                "Content too large ({} bytes, max {} bytes)",
+                content.len(),
+                MAX_WRITE_FILE_SIZE
+            )));
+        }
 
         let timeout_dur = std::time::Duration::from_secs(FILESYSTEM_IO_TIMEOUT_SECS);
 
@@ -661,6 +670,26 @@ mod tests {
 
         let content = tokio::fs::read_to_string(&file_path).await.unwrap();
         assert_eq!(content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_oversized_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("big_write.txt");
+
+        let tool = WriteFileTool::new();
+        let result = tool
+            .execute(json!({
+                "path": file_path.to_str().unwrap(),
+                "content": "A".repeat(MAX_WRITE_FILE_SIZE + 1)
+            }))
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("too large"),
+            "expected 'too large', got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/kestrel-tools/src/builtins/terminal/tools.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/tools.rs
@@ -724,7 +724,7 @@ mod tests {
 
         // Wait briefly for output, then read
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        let output = read
+        let _output = read
             .execute(json!({
                 "session_id": session_id,
                 "timeout_ms": 500


### PR DESCRIPTION
## Summary
- Add `MAX_WRITE_FILE_SIZE` (10MB) content size check to `WriteFileTool::execute()` — matches the existing `MAX_READ_FILE_SIZE` limit on ReadFileTool/EditFileTool
- Fix unused variable warning in terminal tools test (pre-existing clippy error)
- Add regression test `test_write_file_rejects_oversized_content`

## Why
Every other tool that handles content has a size limit:
- ReadFileTool: 10MB (Issue #320)
- EditFileTool: 10MB (Issue #320)
- ScriptTool `kestrel.write_file`: 10MB (`max_write_bytes`)
- ExecTool: 1MB output limit
- GrepTool: 1MB per-file

WriteFileTool was the only tool without one. An agent could write arbitrarily large files.

Closes #322

## Test plan
- [x] `cargo clippy -p kestrel-tools --all-targets -- -D warnings` passes
- [x] `cargo fmt` passes
- [ ] CI tests pass
- [ ] Deploy and verify via websocket testing