### PR TITLE
fix(tools): add response body size limit to WebFetchTool (Issue #324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.9.13] - 2026-05-10
+
+### Bug Fixes
+- fix(tools): add response body size limit (10MB) to `web_fetch` tool — previously the entire HTTP response was read into memory before truncation, allowing a multi-GB response to OOM the daemon (Issue #324)
+- fix(tools): add overall redirect chain timeout (55s) to `web_fetch` — prevents redirect loops from exceeding the default `tool_timeout`
+- fix(tools): add URL length validation (2048 chars) to `web_fetch` — rejects unreasonably long URLs
+
 ## [v0.9.12] - 2026-05-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/kestrel-tools/src/builtins/web.rs
+++ b/crates/kestrel-tools/src/builtins/web.rs
@@ -3,10 +3,15 @@
 use crate::trait_def::{Tool, ToolError};
 use async_trait::async_trait;
 use kestrel_security::{SsrfGuard, DEFAULT_MAX_REDIRECTS};
-use reqwest::header::LOCATION;
+use reqwest::header::{CONTENT_LENGTH, LOCATION};
 use serde_json::{json, Value};
+use std::time::{Duration, Instant};
 use tracing::debug;
 use url::Url;
+
+const MAX_FETCH_RESPONSE_SIZE: usize = 10 * 1024 * 1024; // 10 MB
+const MAX_URL_LENGTH: usize = 2048;
+const REDIRECT_CHAIN_TIMEOUT_SECS: u64 = 55;
 
 // ─── WebSearchTool ────────────────────────────────────────────
 
@@ -234,6 +239,14 @@ impl Tool for WebFetchTool {
             .as_str()
             .ok_or_else(|| ToolError::Validation("Missing 'url'".to_string()))?;
 
+        if url.len() > MAX_URL_LENGTH {
+            return Err(ToolError::Validation(format!(
+                "URL too long ({} bytes, max {})",
+                url.len(),
+                MAX_URL_LENGTH
+            )));
+        }
+
         debug!("Fetching URL: {}", url);
 
         let mut current_url =
@@ -245,7 +258,16 @@ impl Tool for WebFetchTool {
             .build()
             .map_err(|e| ToolError::Execution(e.to_string()))?;
 
+        let chain_deadline = Instant::now() + Duration::from_secs(REDIRECT_CHAIN_TIMEOUT_SECS);
+
         for _ in 0..=self.max_redirects {
+            if Instant::now() >= chain_deadline {
+                return Err(ToolError::Timeout(format!(
+                    "Redirect chain exceeded {}s timeout",
+                    REDIRECT_CHAIN_TIMEOUT_SECS
+                )));
+            }
+
             self.ssrf_guard
                 .validate_url(current_url.as_str())
                 .await
@@ -282,15 +304,24 @@ impl Tool for WebFetchTool {
                 return Err(ToolError::Execution(format!("HTTP {}", resp.status())));
             }
 
-            let html = resp
-                .text()
-                .await
-                .map_err(|e| ToolError::Execution(format!("Failed to read response: {}", e)))?;
+            if let Some(content_length) = resp
+                .headers()
+                .get(CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<usize>().ok())
+            {
+                if content_length > MAX_FETCH_RESPONSE_SIZE {
+                    return Err(ToolError::Execution(format!(
+                        "Response too large (Content-Length: {} bytes, max {} bytes)",
+                        content_length, MAX_FETCH_RESPONSE_SIZE
+                    )));
+                }
+            }
 
-            // Simple HTML to text extraction (strip tags)
+            let html = read_body_with_limit(resp, MAX_FETCH_RESPONSE_SIZE).await?;
+
             let text = html_to_text(&html);
 
-            // Truncate if too long
             let text = if text.len() > 50_000 {
                 format!("{}...\n(content truncated)", &text[..50_000])
             } else {
@@ -305,6 +336,32 @@ impl Tool for WebFetchTool {
             self.max_redirects
         )))
     }
+}
+
+async fn read_body_with_limit(
+    mut resp: reqwest::Response,
+    max_bytes: usize,
+) -> Result<String, ToolError> {
+    let mut total = 0usize;
+    let mut body = Vec::new();
+
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| ToolError::Execution(format!("Failed to read response chunk: {}", e)))?
+    {
+        total += chunk.len();
+        if total > max_bytes {
+            return Err(ToolError::Execution(format!(
+                "Response body too large ({} bytes, max {} bytes)",
+                total, max_bytes
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    String::from_utf8(body)
+        .map_err(|e| ToolError::Execution(format!("Response body is not valid UTF-8: {}", e)))
 }
 
 /// Very basic HTML to text conversion.
@@ -379,5 +436,25 @@ mod tests {
             result.unwrap_err(),
             ToolError::PermissionDenied(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_web_fetch_rejects_oversized_url() {
+        let tool = WebFetchTool::new();
+        let long_url = format!("https://example.com/{}", "a".repeat(MAX_URL_LENGTH));
+        let result = tool.execute(json!({"url": long_url})).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("URL too long"),
+            "expected 'URL too long', got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_max_fetch_constants() {
+        assert_eq!(MAX_FETCH_RESPONSE_SIZE, 10 * 1024 * 1024);
+        assert_eq!(MAX_URL_LENGTH, 2048);
+        const { assert!(REDIRECT_CHAIN_TIMEOUT_SECS > 0) };
     }
 }


### PR DESCRIPTION
## Summary
- Added 10MB response body size limit to `WebFetchTool::execute()` with chunked reading — prevents OOM from multi-GB HTTP responses
- Added `Content-Length` header check before reading body for early rejection
- Added overall redirect chain timeout (55s) — prevents redirect amplification exceeding default `tool_timeout`
- Added URL length validation (2048 chars) — rejects unreasonably long URLs

## Why
`resp.text().await` read the **entire HTTP response body into memory** before truncation. A server returning a 5GB response would OOM the daemon before the 50K truncation kicked in. Same class of bug as ReadFileTool (Issue #320).

The redirect chain also had no overall timeout — with 10 redirects each getting a 30s per-request timeout, worst case was 300s, far exceeding the 60s `tool_timeout`.

Closes #324

## Test plan
- [x] `cargo clippy -p kestrel-tools --all-targets -- -D warnings` passes
- [x] `cargo fmt` passes
- [ ] CI tests pass
- [ ] Deploy and verify via websocket testing