### PR TITLE
fix(channels): emit InterruptRequested when WebSocket client disconnects (Issue #326)

### DIFF
--- a/crates/kestrel-channels/src/base.rs
+++ b/crates/kestrel-channels/src/base.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use kestrel_bus::events::InboundMessage;
+use kestrel_bus::events::{AgentEvent, InboundMessage};
 use kestrel_core::Platform;
 use tracing::debug;
 
@@ -116,4 +116,7 @@ pub trait BaseChannel: Send + Sync {
 
     /// Set the message handler for inbound messages.
     fn set_message_handler(&mut self, handler: tokio::sync::mpsc::Sender<InboundMessage>);
+
+    /// Set the event sender for emitting agent events.
+    fn set_event_sender(&mut self, _tx: tokio::sync::broadcast::Sender<AgentEvent>) {}
 }

--- a/crates/kestrel-channels/src/manager.rs
+++ b/crates/kestrel-channels/src/manager.rs
@@ -66,6 +66,9 @@ impl ChannelManager {
         let bus = self.bus.clone();
         channel.set_message_handler(bus.inbound_sender());
 
+        // Inject event sender so channels can emit events (e.g. InterruptRequested).
+        channel.set_event_sender(bus.event_sender());
+
         let connected = channel.connect().await?;
         if connected {
             info!("Channel '{}' connected", name);

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -60,7 +60,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
-use kestrel_bus::events::InboundMessage;
+use kestrel_bus::events::{AgentEvent, InboundMessage};
 use kestrel_core::{MessageType, Platform, SessionSource, VERSION};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -272,6 +272,8 @@ pub struct WebSocketChannel {
     auth_required: bool,
     /// Expected auth token (if auth is required).
     auth_token: Option<String>,
+    /// Broadcast sender for emitting agent events (e.g. InterruptRequested on disconnect).
+    event_tx: Option<tokio::sync::broadcast::Sender<AgentEvent>>,
     /// Pre-bound TCP listener for zero-port-contention tests.
     #[cfg(test)]
     pre_bound_listener: Option<TcpListener>,
@@ -288,6 +290,7 @@ impl WebSocketChannel {
             clients: Arc::new(DashMap::new()),
             auth_required: false,
             auth_token: None,
+            event_tx: None,
             #[cfg(test)]
             pre_bound_listener: None,
         }
@@ -303,6 +306,7 @@ impl WebSocketChannel {
             clients: Arc::new(DashMap::new()),
             auth_required: false,
             auth_token: None,
+            event_tx: None,
             #[cfg(test)]
             pre_bound_listener: None,
         }
@@ -322,6 +326,7 @@ impl WebSocketChannel {
             clients: Arc::new(DashMap::new()),
             auth_required,
             auth_token: token,
+            event_tx: None,
             #[cfg(test)]
             pre_bound_listener: None,
         }
@@ -330,6 +335,11 @@ impl WebSocketChannel {
     /// Number of currently connected clients.
     pub fn client_count(&self) -> usize {
         self.clients.len()
+    }
+
+    /// Set the event sender for emitting agent events (e.g. InterruptRequested on disconnect).
+    pub fn set_event_tx(&mut self, tx: tokio::sync::broadcast::Sender<AgentEvent>) {
+        self.event_tx = Some(tx);
     }
 
     /// Send a text reply envelope to a WebSocket client.
@@ -388,6 +398,7 @@ impl WebSocketChannel {
         clients: Arc<DashMap<String, mpsc::UnboundedSender<String>>>,
         auth_required: bool,
         auth_token: Option<String>,
+        event_tx: Option<tokio::sync::broadcast::Sender<AgentEvent>>,
     ) {
         use futures::StreamExt;
 
@@ -468,6 +479,7 @@ impl WebSocketChannel {
             let read_clients = clients.clone();
             let read_running = running.clone();
             let read_auth_token = auth_token.clone();
+            let read_event_tx = event_tx.clone();
 
             let write_client_id = client_id.clone();
             let write_clients = clients.clone();
@@ -493,6 +505,7 @@ impl WebSocketChannel {
                     read_running,
                     initial_state,
                     read_auth_token,
+                    read_event_tx,
                 )
                 .await;
             });
@@ -506,6 +519,7 @@ impl WebSocketChannel {
     ///
     /// Handles authentication flow: if `auth_state` is `Pending`, the first
     /// message must be an `{"type":"auth","token":"xxx"}` envelope.
+    #[allow(clippy::too_many_arguments)]
     async fn read_loop(
         stream: futures::stream::SplitStream<
             tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
@@ -516,6 +530,7 @@ impl WebSocketChannel {
         running: Arc<AtomicBool>,
         mut auth_state: AuthState,
         auth_token: Option<String>,
+        event_tx: Option<tokio::sync::broadcast::Sender<AgentEvent>>,
     ) {
         use futures::StreamExt;
         use tokio_tungstenite::tungstenite::Message as WsMessage;
@@ -799,6 +814,18 @@ impl WebSocketChannel {
         // Client disconnected — clean up.
         clients.remove(&client_id);
         info!("WebSocket client disconnected: {}", client_id);
+
+        // Cancel any in-progress agent processing for this session.
+        if let Some(ref tx) = event_tx {
+            let session_key = format!("websocket:{}", client_id);
+            let _ = tx.send(AgentEvent::InterruptRequested {
+                session_key: session_key.clone(),
+            });
+            debug!(
+                "Emitted InterruptRequested for disconnected client {}",
+                session_key
+            );
+        }
     }
 
     /// Write loop for a single client — forwards outbound messages to the
@@ -877,6 +904,7 @@ impl BaseChannel for WebSocketChannel {
             let listen_addr = listener.local_addr()?.to_string();
             let auth_required = self.auth_required;
             let auth_token = self.auth_token.clone();
+            let event_tx = self.event_tx.clone();
             tokio::spawn(async move {
                 Self::run_accept_loop(
                     listener,
@@ -885,6 +913,7 @@ impl BaseChannel for WebSocketChannel {
                     clients,
                     auth_required,
                     auth_token,
+                    event_tx,
                 )
                 .await;
                 info!("WebSocket server on {} stopped", listen_addr);
@@ -1046,6 +1075,10 @@ impl BaseChannel for WebSocketChannel {
 
     fn set_message_handler(&mut self, handler: mpsc::Sender<InboundMessage>) {
         self.message_handler = Some(handler);
+    }
+
+    fn set_event_sender(&mut self, tx: tokio::sync::broadcast::Sender<AgentEvent>) {
+        self.set_event_tx(tx);
     }
 }
 


### PR DESCRIPTION
## Summary
- When a WebSocket client disconnects, emit `AgentEvent::InterruptRequested` to cancel any in-progress agent processing for that session
- Prevents cascading "WebSocket client 'xxx' not connected" ERROR logs (dozens per disconnected session)
- Prevents wasted API tokens and compute from the agent continuing to process requests for disconnected clients

## Changes
- Add `event_tx` field to `WebSocketChannel` (similar pattern to Telegram's `event_tx`)
- Add `set_event_sender()` default method to `BaseChannel` trait — channels that need events override it
- `ChannelManager::start_channel()` now injects the bus event sender into every channel after creation
- `WebSocketChannel::read_loop()` emits `InterruptRequested` when a client disconnects, which the agent loop already listens for and cancels

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes (zero warnings)
- [ ] CI passes
- [ ] Local websocket test: connect, send message, disconnect mid-processing → verify agent processing is cancelled and no cascading errors in logs

Fixes #326

Bahtya