### PR TITLE
chore: bump version to 0.9.16

### DIFF
--- a/.claude-flow/data/pending-insights.jsonl
+++ b/.claude-flow/data/pending-insights.jsonl
@@ -1,0 +1,2 @@
+{"type":"edit","file":"/home/bahtyar/Documents/kestrel-agent/.claude/worktrees/release-0.9.16/Cargo.toml","timestamp":1778385266449,"sessionId":null}
+{"type":"edit","file":"/home/bahtyar/Documents/kestrel-agent/.claude/worktrees/release-0.9.16/CHANGELOG.md","timestamp":1778385276223,"sessionId":null}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.9.16] - 2026-05-10
+
+### Bug Fixes
+- fix(channels): WebSocket read_loop now sends structured error envelopes for invalid JSON, unknown message types, empty messages, unrecognized formats, and invalid legacy messages instead of silently ignoring them (Issues #342, #343, PR #344)
+- fix(channels): upgrade WebSocket error condition logging from `debug!` to `info!` for production visibility
+
 ## [v0.9.15] - 2026-05-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.15"
+version = "0.9.16"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION
## Summary
- Bumps version from 0.9.15 to 0.9.16
- Updates CHANGELOG with WebSocket error handling fix from PR #344

## Changes since v0.9.15
- fix(channels): WebSocket sends structured error envelopes for invalid JSON, unknown message types, empty messages, unrecognized formats, and invalid legacy messages (Issues #342, #343, PR #344)
- fix(channels): WebSocket error logging upgraded from debug! to info!

## Test plan
- [ ] CI passes
- [ ] Download binary and verify WebSocket error handling via test suite

Bahtya