### PR TITLE
fix(websocket): binary message error response and not-connected log level

### DIFF
--- a/crates/kestrel-channels/src/manager.rs
+++ b/crates/kestrel-channels/src/manager.rs
@@ -121,11 +121,20 @@ impl ChannelManager {
                     {
                         Ok(result) => {
                             if !result.success {
-                                error!(
-                                    trace_id = %trace_id.as_deref().unwrap_or("-"),
-                                    "Failed to send message to {} via {}: {:?}",
-                                    msg.chat_id, channel_name, result.error
-                                );
+                                let err_msg = result.error.as_deref().unwrap_or("unknown error");
+                                if err_msg.contains("not connected") {
+                                    warn!(
+                                        trace_id = %trace_id.as_deref().unwrap_or("-"),
+                                        "Client gone before response: {} via {}",
+                                        msg.chat_id, channel_name
+                                    );
+                                } else {
+                                    error!(
+                                        trace_id = %trace_id.as_deref().unwrap_or("-"),
+                                        "Failed to send message to {} via {}: {:?}",
+                                        msg.chat_id, channel_name, result.error
+                                    );
+                                }
                             }
                         }
                         Err(e) => {

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -574,6 +574,22 @@ impl WebSocketChannel {
                     // tungstenite auto-replies with pong
                     continue;
                 }
+                Ok(WsMessage::Binary(_)) => {
+                    info!(
+                        "WebSocket binary message from {} — not supported",
+                        client_id
+                    );
+                    let err = WsEnvelope::error(
+                        "binary_not_supported",
+                        "Binary messages are not supported. Send text messages with JSON payload.",
+                    );
+                    if let Ok(json) = err.to_json() {
+                        if let Some(client_tx) = clients.get(&client_id) {
+                            let _ = client_tx.send(json);
+                        }
+                    }
+                    continue;
+                }
                 Ok(_) => continue,
                 Err(e) => {
                     warn!("WebSocket read error for {}: {}", client_id, e);


### PR DESCRIPTION
## Summary
- Add structured error response for binary WebSocket messages (Issue #347)
- Downgrade "client not connected" from ERROR to WARN (Issue #346)

## Changes
- `websocket.rs`: Added explicit `WsMessage::Binary` handler that sends `{"type": "error", "code": "binary_not_supported"}` instead of silently ignoring
- `manager.rs`: Changed "Failed to send message" to check if error contains "not connected" and log at WARN level instead of ERROR

## Test Plan
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy` — no warnings
- [ ] CI passes
- [ ] WebSocket test suite v3: UTF.1 should now pass

Closes #346, Closes #347

Bahtya