### PR TITLE
fix(channels,ws,agent): downgrade not-connected to WARN and forward reply_to

### DIFF
--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -233,7 +233,7 @@ impl AgentLoop {
                             channel: msg.channel.clone(),
                             chat_id: msg.chat_id.clone(),
                             content: "Stopped.".to_string(),
-                            reply_to: msg.message_id.clone(),
+                            reply_to: msg.reply_to.clone().or(msg.message_id.clone()),
                             trace_id: msg.trace_id.clone(),
                             media: vec![],
                             metadata: Default::default(),
@@ -248,7 +248,8 @@ impl AgentLoop {
                     // so the timeout branch can still build a reply.
                     let timeout_channel = msg.channel.clone();
                     let timeout_chat_id = msg.chat_id.clone();
-                    let timeout_message_id = msg.message_id.clone();
+                    let _timeout_message_id = msg.message_id.clone();
+                    let timeout_reply_to = msg.reply_to.clone().or(msg.message_id.clone());
                     let timeout_trace_id = msg.trace_id.clone();
                     let timeout_session_key = msg.session_key();
 
@@ -275,7 +276,7 @@ impl AgentLoop {
                                      Please try again later.",
                                     timeout_secs
                                 ),
-                                reply_to: timeout_message_id,
+                                reply_to: timeout_reply_to.clone(),
                                 trace_id: timeout_trace_id.clone(),
                                 media: vec![],
                                 metadata: Default::default(),
@@ -332,7 +333,7 @@ impl AgentLoop {
                     channel: msg.channel.clone(),
                     chat_id: msg.chat_id.clone(),
                     content: "收到新指令，正在重新规划...".to_string(),
-                    reply_to: msg.message_id.clone(),
+                    reply_to: msg.reply_to.clone().or(msg.message_id.clone()),
                     trace_id: msg.trace_id.clone(),
                     media: vec![],
                     metadata: Default::default(),
@@ -729,7 +730,7 @@ impl AgentLoop {
                             channel: msg.channel.clone(),
                             chat_id: msg.chat_id.clone(),
                             content: result.content.clone(),
-                            reply_to: msg.message_id.clone(),
+                            reply_to: msg.reply_to.clone().or(msg.message_id.clone()),
                             trace_id: msg.trace_id.clone(),
                             media: vec![],
                             metadata: Default::default(),
@@ -812,7 +813,7 @@ impl AgentLoop {
                         channel: msg.channel.clone(),
                         chat_id: msg.chat_id.clone(),
                         content: error_msg,
-                        reply_to: msg.message_id.clone(),
+                        reply_to: msg.reply_to.clone().or(msg.message_id.clone()),
                         trace_id: msg.trace_id.clone(),
                         media: vec![],
                         metadata: Default::default(),

--- a/crates/kestrel-channels/src/manager.rs
+++ b/crates/kestrel-channels/src/manager.rs
@@ -121,7 +121,7 @@ impl ChannelManager {
                     {
                         Ok(result) => {
                             if !result.success {
-                                error!(
+                                warn!(
                                     trace_id = %trace_id.as_deref().unwrap_or("-"),
                                     "Failed to send message to {} via {}: {:?}",
                                     msg.chat_id, channel_name, result.error

--- a/crates/kestrel-channels/src/platforms/websocket.rs
+++ b/crates/kestrel-channels/src/platforms/websocket.rs
@@ -641,7 +641,7 @@ impl WebSocketChannel {
             }
 
             // Detect format: envelope has "type", legacy has "role" + "content".
-            let (content_text, envelope_trace_id, envelope_msg_id) =
+            let (content_text, envelope_trace_id, envelope_msg_id, envelope_reply_to) =
                 if raw_value.get("type").is_some() {
                     // New envelope format.
                     let envelope: WsEnvelope = match serde_json::from_value(raw_value.clone()) {
@@ -679,6 +679,7 @@ impl WebSocketChannel {
                             envelope.content.clone().unwrap_or_default(),
                             envelope.trace_id.clone(),
                             Some(envelope.id.clone()),
+                            envelope.reply_to.clone(),
                         ),
                         _ => {
                             info!(
@@ -718,7 +719,7 @@ impl WebSocketChannel {
                             continue;
                         }
                     };
-                    (legacy.content, None, None)
+                    (legacy.content, None, None, None)
                 } else {
                     info!(
                         "WebSocket unrecognized message format from {}: {}",
@@ -859,7 +860,7 @@ impl WebSocketChannel {
                 message_type,
                 message_id: envelope_msg_id.clone(),
                 trace_id: Some(trace_id.clone()),
-                reply_to: None,
+                reply_to: envelope_reply_to,
                 timestamp: chrono::Local::now(),
             };
 


### PR DESCRIPTION
## Summary

- **Fixes #349**: Downgrade `kestrel_channels::manager::handle_outbound` log from `error!` to `warn!` when send result fails (e.g., "client not connected"). PR #348 only fixed the websocket platform level but missed the manager module.
- **Fixes #350**: Forward client `reply_to` field through the WebSocket → InboundMessage → OutboundMessage pipeline. Previously `InboundMessage.reply_to` was always `None` for WebSocket, and outbound responses used `msg.message_id` which would be empty if the client didn't send an `id` field.

## Changes

### `manager.rs`
- `error!` → `warn!` for failed send results (line 124)

### `websocket.rs`
- Extract `envelope.reply_to` in the envelope parsing tuple
- Forward it to `InboundMessage.reply_to` (was always `None`)

### `loop_mod.rs`
- All `OutboundMessage.reply_to` fields now use `msg.reply_to.clone().or(msg.message_id.clone())` to prefer the client's explicit `reply_to`, falling back to `message_id`
- Applied to: `/stop` reply, timeout reply, interrupt confirmation, normal response, and error response paths

## Test Plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes (zero warnings)
- [ ] CI validates build
- [ ] Local WebSocket test: send `{"type":"message","content":"test","reply_to":"my-ref-123"}` and verify response includes `"reply_to":"my-ref-123"`
- [ ] Local WebSocket test: verify "not connected" log now shows as WARN instead of ERROR

Bahtya