### PR TITLE
chore: bump version to 0.9.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.9.17] - 2026-05-10
+
+### Bug Fixes
+- fix(channels): downgrade "client not connected" log from ERROR to WARN in manager::handle_outbound — fixes incomplete #346 fix that only changed the WebSocket platform level (Issue #349, PR #351)
+- fix(channels): forward client-sent `reply_to` from WebSocket envelope through InboundMessage and use it (with fallback to `message_id`) in all OutboundMessage constructions — ensures request-response correlation works when client sends `reply_to` without `id` (Issue #350, PR #351)
+
 ## [v0.9.16] - 2026-05-10
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION
## Summary
- Version bump to 0.9.17 for release
- Includes fixes from PR #351 (issues #349, #350)

## Test plan
- [x] CI passes on all platforms

Bahtya