### PR TITLE
perf(ci): optimize CI build speed — rust-cache, nextest, mold, Defender, lld

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ rustflags = ["-C", "target-feature=-avx512f,-avx512vl,-avx512bw,-avx512dq"]
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,3 +145,6 @@ futures = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
 kestrel-test-utils = { path = "crates/kestrel-test-utils" }
+
+[profile.dev]
+debug = "line-tables-only"


### PR DESCRIPTION
## Summary

- Replace manual `actions/cache` with `Swatinem/rust-cache` for smarter Rust artifact caching
- Replace `cargo test` with `cargo-nextest` for faster parallel test execution
- Parallelize Linux/Windows test jobs into 2 shards via `nextest --partition`
- Add `mold` linker for Linux x86_64 and `rust-lld` linker for Windows MSVC
- Disable Windows Defender real-time scanning on Windows CI runners
- Remove redundant `cargo check` from Windows build job (nextest already compiles)
- Set `debug = "line-tables-only"` in dev profile to avoid expensive full PDB generation

## Performance

| Job | Before | After |
|-----|--------|-------|
| Total CI time | ~10m | **6m** |
| Clippy (Windows) | 6m21s | **1m38s** |
| Build & Test (Windows) | 9m36s (serial) | **~6m** (parallel) |
| Test (Linux) | 3m24s (serial) | **~2m** (parallel) |

## Test plan

- [x] All CI jobs pass on this branch
- [ ] Verify `rust-lld` works correctly with MSVC target on Windows
- [ ] Confirm `debug = "line-tables-only"` preserves useful backtraces

Bahtya