### PR TITLE
fix(agent): increase LLM timeouts and use config values for streaming

### DIFF
--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -407,8 +407,9 @@ impl AgentRunner {
             let mut tool_calls_map: std::collections::HashMap<usize, (String, String, String)> =
                 std::collections::HashMap::new();
 
-            let first_chunk_timeout = std::time::Duration::from_secs(15);
-            let idle_timeout = std::time::Duration::from_secs(30);
+            let first_chunk_timeout =
+                std::time::Duration::from_secs(self.config.agent.first_byte_timeout);
+            let idle_timeout = std::time::Duration::from_secs(self.config.agent.idle_timeout);
             let mut is_first = true;
             let mut last_chunk_at = std::time::Instant::now();
 

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -1178,7 +1178,7 @@ fn default_tool_timeout() -> u64 {
 }
 
 const fn default_message_timeout() -> u64 {
-    90
+    300
 }
 
 const fn default_connect_timeout() -> u64 {
@@ -1190,7 +1190,7 @@ const fn default_first_byte_timeout() -> u64 {
 }
 
 const fn default_idle_timeout() -> u64 {
-    30
+    60
 }
 
 fn default_dream_interval() -> u64 {

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -195,7 +195,7 @@ pub fn fill_defaults(config: &mut Config) -> Vec<String> {
         filled.push("agent.tool_timeout".to_string());
     }
     if config.agent.message_timeout == 0 {
-        config.agent.message_timeout = 90;
+        config.agent.message_timeout = 300;
         filled.push("agent.message_timeout".to_string());
     }
     if config.agent.tool_timeout > config.agent.message_timeout {

--- a/crates/kestrel-providers/src/openai_compat.rs
+++ b/crates/kestrel-providers/src/openai_compat.rs
@@ -174,7 +174,7 @@ impl OpenAiCompatProvider {
 
     /// Parse SSE lines from byte stream and yield CompletionChunks.
     ///
-    /// Each byte chunk read is guarded by an idle timeout (30s). If no data
+    /// Each byte chunk read is guarded by an idle timeout (60s). If no data
     /// arrives within the timeout, an error is sent and parsing stops.
     /// The optional cancellation token allows callers to abort the parse early.
     fn parse_sse_stream(
@@ -197,7 +197,7 @@ impl OpenAiCompatProvider {
                 }
 
                 let chunk_result =
-                    tokio::time::timeout(std::time::Duration::from_secs(30), stream.next()).await;
+                    tokio::time::timeout(std::time::Duration::from_secs(60), stream.next()).await;
 
                 let chunk_result = match chunk_result {
                     Ok(Some(r)) => r,
@@ -205,7 +205,7 @@ impl OpenAiCompatProvider {
                     Err(_) => {
                         let _ = tx
                             .send(Err(anyhow::anyhow!(
-                                "SSE byte stream idle timeout after 30s"
+                                "SSE byte stream idle timeout after 60s"
                             )))
                             .await;
                         return;


### PR DESCRIPTION
## Summary

- **Fix `runner.rs` to use config values** for streaming timeouts (`first_byte_timeout`, `idle_timeout`) instead of hardcoded 15s/30s constants — these were defined in the config schema but never read by the runner
- **Increase `message_timeout` default: 90s → 300s** — the 90s limit was too aggressive for complex LLM responses with multiple tool-call iterations, causing premature "Message processing timed out" errors
- **Increase `idle_timeout` default: 30s → 60s** and align the OpenAI-compatible provider's SSE byte-level timeout to match, reducing unnecessary stream retries
- **Update `validate.rs` fallback** to match the new 300s message_timeout default

## Root cause

The logs showed three timeout symptoms:
1. `WARN "Slow provider response: took >5s to establish stream"` — informational, no fix needed
2. `WARN "SSE stream slow: long gap between chunks"` (21s gap) — caused by 30s idle timeout being too tight
3. `ERROR "Message processing timed out after 90s"` — the critical issue: 90s was insufficient for complex LLM tool-use responses

The `runner.rs` hardcoded `first_chunk_timeout = 15s` and `idle_timeout = 30s` at lines 410-411, completely ignoring `config.agent.first_byte_timeout` and `config.agent.idle_timeout`. Users could configure these values but they had no effect.

## Test plan

- [ ] Verify CI passes (cargo check + clippy + tests)
- [ ] Test with a complex multi-tool prompt that previously timed out at 90s
- [ ] Verify configurable timeouts work by setting `message_timeout`, `idle_timeout`, `first_byte_timeout` in config
- [ ] Confirm no regressions in timeout warning/error logging

Bahtya