### PR TITLE
fix(terminal): fix screen change detection baseline reset bug

### DIFF
--- a/crates/kestrel-tools/src/builtins/terminal/session.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/session.rs
@@ -428,12 +428,31 @@ impl TerminalSession {
     ) -> Result<ScreenSnapshot> {
         let current_input_seq = self.input_sequence.load(Ordering::Relaxed);
         let observed_input_seq = self.observed_input_sequence.load(Ordering::Relaxed);
+        let screen_observed = self.screen_observed.load(Ordering::Relaxed);
+
+        debug!(
+            session_id = %self.id,
+            current_input_seq,
+            observed_input_seq,
+            screen_observed,
+            last_observed_hash = self.last_observed_screen_hash.load(Ordering::Relaxed),
+            timeout_ms,
+            match_pattern = match_pattern.unwrap_or("none"),
+            "wait_for_screen_change: starting"
+        );
+
         let mut baseline_hash = {
             let emulator = self.emulator.lock().unwrap_or_else(|e| e.into_inner());
             let current_hash = emulator.state_hash();
-            let should_reset_baseline = (!self.screen_observed.load(Ordering::Relaxed)
-                && current_input_seq == 0)
-                || current_input_seq == observed_input_seq;
+            let should_reset_baseline = !screen_observed && current_input_seq == 0;
+            debug!(
+                session_id = %self.id,
+                should_reset_baseline,
+                current_hash,
+                stored_hash = self.last_observed_screen_hash.load(Ordering::Relaxed),
+                reason = if should_reset_baseline { "first observation, no inputs" } else { "using stored baseline" },
+                "wait_for_screen_change: baseline decision"
+            );
             if should_reset_baseline {
                 self.last_observed_screen_hash
                     .store(current_hash, Ordering::Relaxed);
@@ -459,8 +478,21 @@ impl TerminalSession {
             let snapshot = {
                 let emulator = self.emulator.lock().unwrap_or_else(|e| e.into_inner());
                 let current_hash = emulator.state_hash();
+                debug!(
+                    session_id = %self.id,
+                    current_hash,
+                    baseline_hash,
+                    changed = current_hash != baseline_hash,
+                    "wait_for_screen_change: poll"
+                );
                 if current_hash == baseline_hash {
                     if std::time::Instant::now() >= deadline {
+                        debug!(
+                            session_id = %self.id,
+                            baseline_hash,
+                            current_hash,
+                            "wait_for_screen_change: timeout, hash unchanged"
+                        );
                         anyhow::bail!(
                             "Timeout waiting for screen change ({}ms elapsed)",
                             timeout_ms
@@ -469,6 +501,10 @@ impl TerminalSession {
                     continue;
                 }
                 if current_input_seq == 0 {
+                    debug!(
+                        session_id = %self.id,
+                        "wait_for_screen_change: no inputs sent, updating baseline to current hash"
+                    );
                     baseline_hash = current_hash;
                     self.last_observed_screen_hash
                         .store(current_hash, Ordering::Relaxed);
@@ -482,6 +518,13 @@ impl TerminalSession {
                     }
                     continue;
                 }
+                debug!(
+                    session_id = %self.id,
+                    new_hash = current_hash,
+                    old_hash = baseline_hash,
+                    input_seq = current_input_seq,
+                    "wait_for_screen_change: screen changed"
+                );
                 self.last_observed_screen_hash
                     .store(current_hash, Ordering::Relaxed);
                 self.observed_input_sequence

--- a/crates/kestrel-tools/src/builtins/terminal/tools.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/tools.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use kestrel_core::MAX_TOOL_OUTPUT_LENGTH;
 use serde_json::{json, Value};
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, info};
 
 use super::manager::TerminalManager;
 
@@ -1052,6 +1052,13 @@ impl Tool for TerminalWaitForScreenChangeTool {
             .ok_or_else(|| ToolError::Validation("Missing 'session_id'".to_string()))?;
         let timeout_ms = args["timeout_ms"].as_u64().unwrap_or(5000);
         let match_pattern = args["match"].as_str();
+
+        info!(
+            session_id = session_id,
+            timeout_ms = timeout_ms,
+            match_pattern = match_pattern.unwrap_or("none"),
+            "terminal_wait_for_screen_change: executing"
+        );
 
         debug!(
             session_id = session_id,


### PR DESCRIPTION
## Summary
- Fix `should_reset_baseline` logic in `wait_for_screen_change`: removed the `current_input_seq == observed_input_seq` condition that caused the baseline hash to be unconditionally reset after every successful wait, making consecutive calls timeout
- Only reset baseline when the screen has never been observed AND no inputs have been sent (fresh session state)
- Add comprehensive DEBUG logging in `wait_for_screen_change`: baseline hash values, current hash, reset decision with reason, poll hash comparison results, screen change detection
- Add INFO logging in the tool's `execute()` method for parameter visibility (session_id, timeout_ms, match_pattern)

## Root Cause
The condition `|| current_input_seq == observed_input_seq` in `should_reset_baseline` was always true after a successful `wait_for_screen_change` call (since both sequences are set to the same value on success). This caused the baseline to be reset to the current screen hash, so the next poll saw no change and waited until timeout.

## Test plan
- [ ] Verify `send_input` → first `wait_for_screen_change(50)` succeeds (screen changed)
- [ ] Verify immediately calling `wait_for_screen_change(50)` again detects change (no timeout)
- [ ] Verify multiple consecutive `wait_for_screen_change` calls work without timeout
- [ ] Check DEBUG logs show correct baseline hash tracking across calls
- [ ] Run existing terminal session tests

Bahtya