### PR TITLE
fix(terminal): set TERM=xterm-256color for PTY child processes

### DIFF
--- a/crates/kestrel-tools/src/builtins/terminal/session.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/session.rs
@@ -165,6 +165,7 @@ impl TerminalSession {
         if let Some(dir) = cwd {
             cmd.cwd(dir);
         }
+        cmd.env("TERM", "xterm-256color");
 
         let child = pair.slave.spawn_command(cmd)?;
 


### PR DESCRIPTION
## Summary
- Set `TERM=xterm-256color` on `CommandBuilder` in `TerminalSession::spawn()` so PTY child processes get a proper terminal type instead of inheriting the daemon's environment (which has no `TERM` when started by systemd)

## Root Cause
Daemon is launched by systemd (PPid=1), which doesn't set `TERM`. `CommandBuilder` inherits the daemon's env via `std::env::vars_os()`, so the PTY child shell also has no `TERM`. Programs like Codex detect `TERM=dumb` (the default when unset) and refuse to start their TUI:
```
"TERM is set to "dumb". Refusing to start the interactive TUI"
```

## Test plan
- [ ] Verify `terminal_create_session` spawns a shell where `echo $TERM` returns `xterm-256color`
- [ ] Verify Codex TUI renders in the PTY (alternate screen buffer is captured by `terminal_capture_screen`)
- [ ] Verify existing terminal session tests still pass

Bahtya