### PR TITLE
fix: add CSI E (CNL) / CSI F (CPL) terminal sequence support

### DIFF
--- a/crates/kestrel-tools/src/builtins/terminal/emulator.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/emulator.rs
@@ -291,12 +291,8 @@ impl vte::Perform for VtePerformer<'_> {
             'd' => self
                 .ops
                 .push(TerminalOp::CursorVerticalAbsolute(param1(0, 1))),
-            'E' => self
-                .ops
-                .push(TerminalOp::CursorNextLine(param1(0, 1))),
-            'F' => self
-                .ops
-                .push(TerminalOp::CursorPreviousLine(param1(0, 1))),
+            'E' => self.ops.push(TerminalOp::CursorNextLine(param1(0, 1))),
+            'F' => self.ops.push(TerminalOp::CursorPreviousLine(param1(0, 1))),
 
             // Erase
             'J' => self

--- a/crates/kestrel-tools/src/builtins/terminal/emulator.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/emulator.rs
@@ -1065,4 +1065,42 @@ mod tests {
         let ops = emu.take_ops();
         assert_eq!(ops, vec![TerminalOp::Print("pending text".to_string())]);
     }
+
+    // ─── CNL / CPL tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_parser_cnl() {
+        let ops = parse_bytes(b"\x1b[3E");
+        assert_eq!(ops, vec![TerminalOp::CursorNextLine(3)]);
+    }
+
+    #[test]
+    fn test_parser_cnl_default() {
+        let ops = parse_bytes(b"\x1b[E");
+        assert_eq!(ops, vec![TerminalOp::CursorNextLine(1)]);
+    }
+
+    #[test]
+    fn test_parser_cpl() {
+        let ops = parse_bytes(b"\x1b[5F");
+        assert_eq!(ops, vec![TerminalOp::CursorPreviousLine(5)]);
+    }
+
+    #[test]
+    fn test_parser_cpl_default() {
+        let ops = parse_bytes(b"\x1b[F");
+        assert_eq!(ops, vec![TerminalOp::CursorPreviousLine(1)]);
+    }
+
+    #[test]
+    fn test_parser_dectcem() {
+        let ops = parse_bytes(b"\x1b[?25l\x1b[?25h");
+        assert_eq!(
+            ops,
+            vec![
+                TerminalOp::DecPrivateModeReset(25), // ?25l = DECTCEM reset (hide cursor)
+                TerminalOp::DecPrivateModeSet(25),   // ?25h = DECTCEM set (show cursor)
+            ]
+        );
+    }
 }

--- a/crates/kestrel-tools/src/builtins/terminal/emulator.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/emulator.rs
@@ -58,6 +58,10 @@ pub enum TerminalOp {
     CursorHorizontalAbsolute(u16),
     /// VPA — Vertical Position Absolute.
     CursorVerticalAbsolute(u16),
+    /// CNL — Cursor Next Line (CSI Ps E).
+    CursorNextLine(u16),
+    /// CPL — Cursor Previous Line (CSI Ps F).
+    CursorPreviousLine(u16),
     /// ED — Erase in Display.
     EraseInDisplay(EraseMode),
     /// EL — Erase in Line.
@@ -287,6 +291,12 @@ impl vte::Perform for VtePerformer<'_> {
             'd' => self
                 .ops
                 .push(TerminalOp::CursorVerticalAbsolute(param1(0, 1))),
+            'E' => self
+                .ops
+                .push(TerminalOp::CursorNextLine(param1(0, 1))),
+            'F' => self
+                .ops
+                .push(TerminalOp::CursorPreviousLine(param1(0, 1))),
 
             // Erase
             'J' => self

--- a/crates/kestrel-tools/src/builtins/terminal/screen.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/screen.rs
@@ -533,8 +533,7 @@ impl TerminalScreen {
             }
             TerminalOp::CursorNextLine(n) => {
                 let max_rows = self.active_buf().rows;
-                self.cursor.row = (self.cursor.row + *n as usize)
-                    .min(max_rows.saturating_sub(1));
+                self.cursor.row = (self.cursor.row + *n as usize).min(max_rows.saturating_sub(1));
                 self.cursor.col = 0;
             }
             TerminalOp::CursorPreviousLine(n) => {
@@ -597,15 +596,13 @@ impl TerminalScreen {
                     }
                 }
             }
-            TerminalOp::DecPrivateModeReset(mode) => {
-                match *mode {
-                    1049 => self.leave_alternate_screen(),
-                    25 => {
-                        self.cursor_visible = true;
-                    }
-                    _ => {}
+            TerminalOp::DecPrivateModeReset(mode) => match *mode {
+                1049 => self.leave_alternate_screen(),
+                25 => {
+                    self.cursor_visible = true;
                 }
-            }
+                _ => {}
+            },
             TerminalOp::SetWindowTitle(title) => {
                 self.window_title = title.clone();
             }

--- a/crates/kestrel-tools/src/builtins/terminal/screen.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/screen.rs
@@ -576,7 +576,8 @@ impl TerminalScreen {
                 match *mode {
                     1049 => self.enter_alternate_screen(),
                     25 => {
-                        self.cursor_visible = false;
+                        // ?25h (DECTCEM set) = show cursor
+                        self.cursor_visible = true;
                     }
                     // 2004 = Bracketed Paste — acknowledged but not enforced at screen level.
                     // Input handling in send_input wraps pasted content with \x1b[200~ / \x1b[201~.
@@ -599,7 +600,8 @@ impl TerminalScreen {
             TerminalOp::DecPrivateModeReset(mode) => match *mode {
                 1049 => self.leave_alternate_screen(),
                 25 => {
-                    self.cursor_visible = true;
+                    // ?25l (DECTCEM reset) = hide cursor
+                    self.cursor_visible = false;
                 }
                 _ => {}
             },
@@ -744,6 +746,7 @@ impl TerminalScreen {
         for b in self.window_title.as_bytes() {
             h.write_u8(*b);
         }
+        h.write_u8(if self.cursor_visible { 1 } else { 0 });
         h.finish()
     }
 
@@ -1036,7 +1039,6 @@ impl ScreenSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::builtins::terminal::parse_bytes;
 
     fn new_screen() -> TerminalScreen {
         TerminalScreen::new(80, 24)
@@ -1618,6 +1620,68 @@ mod tests {
         s.process_op(&TerminalOp::DecPrivateModeSet(1049));
         let h2 = s.state_hash();
         assert_ne!(h1, h2, "Hash should change when entering alternate screen");
+    }
+
+    #[test]
+    fn test_state_hash_changes_on_cursor_visibility() {
+        let s = new_screen();
+        let h1 = s.state_hash();
+        let mut s = s;
+        s.process_op(&TerminalOp::DecPrivateModeReset(25)); // ?25l = hide cursor
+        let h2 = s.state_hash();
+        assert_ne!(h1, h2, "Hash should change when cursor visibility changes");
+    }
+
+    // ─── CNL / CPL screen tests ────────────────────────────────────
+
+    #[test]
+    fn test_cnl_moves_down_and_resets_col() {
+        let mut s = new_screen();
+        s.process_op(&TerminalOp::CursorPosition { row: 2, col: 10 });
+        assert_eq!(s.cursor.row, 1);
+        assert_eq!(s.cursor.col, 9);
+        s.process_op(&TerminalOp::CursorNextLine(3));
+        assert_eq!(s.cursor.row, 4);
+        assert_eq!(s.cursor.col, 0);
+    }
+
+    #[test]
+    fn test_cnl_clamps_to_last_row() {
+        let mut s = TerminalScreen::new(10, 5);
+        s.process_op(&TerminalOp::CursorPosition { row: 4, col: 5 });
+        s.process_op(&TerminalOp::CursorNextLine(100));
+        assert_eq!(s.cursor.row, 4, "Should clamp to last row (0-indexed)");
+        assert_eq!(s.cursor.col, 0);
+    }
+
+    #[test]
+    fn test_cpl_moves_up_and_resets_col() {
+        let mut s = new_screen();
+        s.process_op(&TerminalOp::CursorPosition { row: 10, col: 8 });
+        s.process_op(&TerminalOp::CursorPreviousLine(3));
+        assert_eq!(s.cursor.row, 6);
+        assert_eq!(s.cursor.col, 0);
+    }
+
+    #[test]
+    fn test_cpl_clamps_to_zero() {
+        let mut s = new_screen();
+        s.process_op(&TerminalOp::CursorPosition { row: 2, col: 5 });
+        s.process_op(&TerminalOp::CursorPreviousLine(100));
+        assert_eq!(s.cursor.row, 0);
+        assert_eq!(s.cursor.col, 0);
+    }
+
+    #[test]
+    fn test_dectcem_hide_show() {
+        let mut s = new_screen();
+        assert!(s.cursor_visible);
+        // ?25l (DECTCEM reset) = hide cursor
+        s.process_op(&TerminalOp::DecPrivateModeReset(25));
+        assert!(!s.cursor_visible, "Cursor should be hidden after ?25l");
+        // ?25h (DECTCEM set) = show cursor
+        s.process_op(&TerminalOp::DecPrivateModeSet(25));
+        assert!(s.cursor_visible, "Cursor should be visible after ?25h");
     }
 
     // ─── Screen diff tests ─────────────────────────────────────────

--- a/crates/kestrel-tools/src/builtins/terminal/screen.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/screen.rs
@@ -529,6 +529,16 @@ impl TerminalScreen {
                 let max_rows = self.active_buf().rows;
                 self.cursor.row = ((*row as usize).max(1) - 1).min(max_rows.saturating_sub(1));
             }
+            TerminalOp::CursorNextLine(n) => {
+                let max_rows = self.active_buf().rows;
+                self.cursor.row = (self.cursor.row + *n as usize)
+                    .min(max_rows.saturating_sub(1));
+                self.cursor.col = 0;
+            }
+            TerminalOp::CursorPreviousLine(n) => {
+                self.cursor.row = self.cursor.row.saturating_sub(*n as usize);
+                self.cursor.col = 0;
+            }
             TerminalOp::EraseInDisplay(mode) => {
                 let (row, col) = (self.cursor.row, self.cursor.col);
                 self.active_buf_mut().erase_display(row, col, *mode);

--- a/crates/kestrel-tools/src/builtins/terminal/screen.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/screen.rs
@@ -443,6 +443,7 @@ pub struct TerminalScreen {
     alternate: ScreenBuffer,
     active: ActiveBuffer,
     cursor: CursorState,
+    cursor_visible: bool,
     scroll_top: usize,
     scroll_bottom: usize,
     attrs: CellAttributes,
@@ -462,6 +463,7 @@ impl TerminalScreen {
             alternate: ScreenBuffer::new(cols, rows),
             active: ActiveBuffer::Primary,
             cursor: CursorState::new(),
+            cursor_visible: true,
             scroll_top: 0,
             scroll_bottom,
             attrs: CellAttributes::default(),
@@ -574,6 +576,9 @@ impl TerminalScreen {
             TerminalOp::DecPrivateModeSet(mode) => {
                 match *mode {
                     1049 => self.enter_alternate_screen(),
+                    25 => {
+                        self.cursor_visible = false;
+                    }
                     // 2004 = Bracketed Paste — acknowledged but not enforced at screen level.
                     // Input handling in send_input wraps pasted content with \x1b[200~ / \x1b[201~.
                     2004 => {
@@ -593,8 +598,12 @@ impl TerminalScreen {
                 }
             }
             TerminalOp::DecPrivateModeReset(mode) => {
-                if *mode == 1049 {
-                    self.leave_alternate_screen();
+                match *mode {
+                    1049 => self.leave_alternate_screen(),
+                    25 => {
+                        self.cursor_visible = true;
+                    }
+                    _ => {}
                 }
             }
             TerminalOp::SetWindowTitle(title) => {

--- a/crates/kestrel-tools/src/builtins/terminal/session.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/session.rs
@@ -335,6 +335,12 @@ impl TerminalSession {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .resize(cols, rows);
+        // Note: COLUMNS/LINES env vars set at spawn are snapshots and cannot be
+        // updated in the child process after creation. The PTY kernel driver
+        // propagates the new size via TIOCSWINSZ (done by m.resize above), and
+        // well-behaved shells/tui apps read the terminal size from the PTY
+        // ioctl or SIGWINCH — not from env vars. The initial env var values
+        // primarily help tools that check env vars at startup (e.g. Ink/chalk).
         self.last_activity.store(epoch_secs(), Ordering::Relaxed);
         Ok(())
     }

--- a/crates/kestrel-tools/src/builtins/terminal/session.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/session.rs
@@ -166,6 +166,9 @@ impl TerminalSession {
             cmd.cwd(dir);
         }
         cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
+        cmd.env("COLUMNS", cols.to_string());
+        cmd.env("LINES", rows.to_string());
 
         let child = pair.slave.spawn_command(cmd)?;
 


### PR DESCRIPTION
## Summary

- Adds **CSI Ps E (CNL — Cursor Next Line)** and **CSI Ps F (CPL — Cursor Previous Line)** to the VT parser and screen model
- Fixes Codex/Ink TUI rendering freeze in KA PTY sessions

## Root Cause

Ink's `log-update.ts` uses `\x1B[<n>E` to reposition the cursor during incremental re-renders. KA's VT parser discarded these sequences, causing the cursor to stay at the wrong position. All subsequent erase/write operations executed at incorrect coordinates, so `state_hash` never changed and `wait_for_screen_change` timed out.

Closes #359

## Changes

**`emulator.rs`**
- Added `CursorNextLine(u16)` and `CursorPreviousLine(u16)` to `TerminalOp` enum
- Added `'E'` and `'F'` parsing in `csi_dispatch` (1-based default, same as CUU/CUD)

**`screen.rs`**
- `CursorNextLine`: `cursor.row += n; cursor.col = 0;` clamped to screen height
- `CursorPreviousLine`: `cursor.row -= n; cursor.col = 0;` clamped to 0

## Test plan

- [ ] Launch a KA PTY session, run `codex`, verify TUI renders and updates
- [ ] Verify `wait_for_screen_change` detects hash changes on subsequent frames
- [ ] Run existing terminal emulator unit tests (no regressions)

Bahtya