### PR TITLE
fix(terminal): DSR response and wait_for_screen_change timeout improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-core"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/kestrel-tools/src/builtins/terminal/emulator.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/emulator.rs
@@ -96,6 +96,8 @@ pub enum TerminalOp {
     DeviceAttributes(Vec<u16>),
     /// REP — Repeat last printed character (CSI Ps b).
     Repeat(u16),
+    /// DSR — Device Status Report (CSI Ps n). Ps=5: respond OK, Ps=6: respond with cursor position.
+    DeviceStatusReport(u16),
 }
 
 /// Erase scope for ED/EL operations.
@@ -339,6 +341,20 @@ impl vte::Perform for VtePerformer<'_> {
             // REP — Repeat last printed character
             'b' => self.ops.push(TerminalOp::Repeat(param1(0, 1))),
 
+            // DSR — Device Status Report
+            'n' => {
+                let p = param(0, 0);
+                if p == 5 {
+                    // CSI 5 n → respond CSI 0 n (device OK)
+                    self.ops.push(TerminalOp::DeviceStatusReport(5));
+                } else if p == 6 {
+                    // CSI 6 n → respond CSI row ; col R (cursor position)
+                    self.ops.push(TerminalOp::DeviceStatusReport(6));
+                } else {
+                    debug!(param = p, "Unhandled DSR");
+                }
+            }
+
             // Device Attributes — log but don't act
             'c' => {
                 let attrs: Vec<u16> = params.iter().flat_map(|s| s.iter().copied()).collect();
@@ -442,6 +458,7 @@ pub struct TerminalEmulatorHandle {
     pending_ops: Vec<TerminalOp>,
     deferred_text_ops: Vec<TerminalOp>,
     screen: super::screen::TerminalScreen,
+    pending_response: Option<String>,
 }
 
 impl TerminalEmulatorHandle {
@@ -453,6 +470,7 @@ impl TerminalEmulatorHandle {
             pending_ops: Vec::new(),
             deferred_text_ops: Vec::new(),
             screen: super::screen::TerminalScreen::new(cols as usize, rows as usize),
+            pending_response: None,
         }
     }
 
@@ -481,7 +499,18 @@ impl TerminalEmulatorHandle {
             performer.flush_print();
         }
         for op in &ops {
-            self.screen.process_op(op);
+            match op {
+                TerminalOp::DeviceStatusReport(5) => {
+                    // CSI 5 n → respond CSI 0 n (device OK)
+                    self.pending_response = Some("\x1b[0n".to_string());
+                }
+                TerminalOp::DeviceStatusReport(6) => {
+                    // CSI 6 n → respond CSI row ; col R (1-based cursor position)
+                    let (row, col) = self.screen.cursor_position();
+                    self.pending_response = Some(format!("\x1b[{};{}R", row + 1, col + 1));
+                }
+                _ => self.screen.process_op(op),
+            }
         }
         let pure_print_chunk = ops.iter().all(|op| matches!(op, TerminalOp::Print(_)))
             && bytes.iter().all(|b| !matches!(b, 0x00..=0x1F | 0x7F));
@@ -515,6 +544,12 @@ impl TerminalEmulatorHandle {
 
     pub fn state_hash(&self) -> u64 {
         self.screen.state_hash()
+    }
+
+    /// Take any pending response that should be sent back through the PTY input pipe.
+    /// Returns the response string (e.g., DSR cursor position reply) or None.
+    pub fn take_pending_response(&mut self) -> Option<String> {
+        self.pending_response.take()
     }
 }
 
@@ -1107,5 +1142,46 @@ mod tests {
                 TerminalOp::DecPrivateModeSet(25),   // ?25h = DECTCEM set (show cursor)
             ]
         );
+    }
+
+    #[test]
+    fn test_parser_dsr_cursor_position() {
+        let ops = parse_bytes(b"\x1b[6n");
+        assert_eq!(ops, vec![TerminalOp::DeviceStatusReport(6)]);
+    }
+
+    #[test]
+    fn test_parser_dsr_device_ok() {
+        let ops = parse_bytes(b"\x1b[5n");
+        assert_eq!(ops, vec![TerminalOp::DeviceStatusReport(5)]);
+    }
+
+    #[test]
+    fn test_dsr_response_cursor_position() {
+        let mut emu = TerminalEmulatorHandle::new(80, 24);
+        // Feed DSR query — emulator should generate a response
+        emu.feed_bytes(b"\x1b[6n");
+        let resp = emu.take_pending_response();
+        assert_eq!(resp, Some("\x1b[1;1R".to_string()));
+        // Second take should return None
+        assert!(emu.take_pending_response().is_none());
+    }
+
+    #[test]
+    fn test_dsr_response_device_ok() {
+        let mut emu = TerminalEmulatorHandle::new(80, 24);
+        emu.feed_bytes(b"\x1b[5n");
+        let resp = emu.take_pending_response();
+        assert_eq!(resp, Some("\x1b[0n".to_string()));
+    }
+
+    #[test]
+    fn test_dsr_response_after_cursor_move() {
+        let mut emu = TerminalEmulatorHandle::new(80, 24);
+        // Move cursor to row 3, col 5 (0-based: row=2, col=4)
+        emu.feed_bytes(b"\x1b[3;5H");
+        emu.feed_bytes(b"\x1b[6n");
+        let resp = emu.take_pending_response();
+        assert_eq!(resp, Some("\x1b[3;5R".to_string()));
     }
 }

--- a/crates/kestrel-tools/src/builtins/terminal/manager.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/manager.rs
@@ -242,12 +242,15 @@ impl TerminalManager {
     }
 
     /// Wait for the screen state of a session to change.
+    ///
+    /// Returns `(ScreenSnapshot, bool)` — the bool is `true` when a change
+    /// was detected, `false` on timeout (screen snapshot still populated).
     pub fn wait_for_screen_change(
         &self,
         session_id: &str,
         timeout_ms: u64,
         match_pattern: Option<&str>,
-    ) -> Result<ScreenSnapshot> {
+    ) -> Result<(ScreenSnapshot, bool)> {
         let session = {
             let sessions = self.sessions.read();
             sessions

--- a/crates/kestrel-tools/src/builtins/terminal/screen.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/screen.rs
@@ -761,6 +761,9 @@ impl TerminalScreen {
             TerminalOp::DeviceAttributes(_) => {
                 // DA response — no screen action needed
             }
+            TerminalOp::DeviceStatusReport(_) => {
+                // DSR — handled in feed_bytes, no screen action
+            }
         }
     }
 
@@ -784,6 +787,11 @@ impl TerminalScreen {
 
     /// Compute a lightweight hash of the current screen state for change detection.
     ///
+    /// Returns the current cursor position as (row, col), 0-based.
+    pub fn cursor_position(&self) -> (usize, usize) {
+        (self.cursor.row, self.cursor.col)
+    }
+
     /// Uses a simple FNV-1a-inspired hash over all cell characters, cursor position,
     /// active buffer flag, and window title. This is intentionally fast rather than
     /// cryptographically strong — its purpose is to detect *any* visible mutation.

--- a/crates/kestrel-tools/src/builtins/terminal/session.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/session.rs
@@ -434,12 +434,13 @@ impl TerminalSession {
     /// - (if `match_pattern` is provided) the screen text matches the pattern
     /// - The timeout elapses
     ///
-    /// Returns the final snapshot on success, or an error on timeout.
+    /// Returns `(ScreenSnapshot, bool)` — the snapshot is always populated.
+    /// The bool is `true` when a change was detected, `false` on timeout.
     pub fn wait_for_screen_change(
         &self,
         timeout_ms: u64,
         match_pattern: Option<&str>,
-    ) -> Result<ScreenSnapshot> {
+    ) -> Result<(ScreenSnapshot, bool)> {
         let current_input_seq = self.input_sequence.load(Ordering::Relaxed);
         let observed_input_seq = self.observed_input_sequence.load(Ordering::Relaxed);
         let screen_observed = self.screen_observed.load(Ordering::Relaxed);
@@ -507,10 +508,12 @@ impl TerminalSession {
                             current_hash,
                             "wait_for_screen_change: timeout, hash unchanged"
                         );
-                        anyhow::bail!(
-                            "Timeout waiting for screen change ({}ms elapsed)",
-                            timeout_ms
-                        );
+                        self.last_observed_screen_hash
+                            .store(current_hash, Ordering::Relaxed);
+                        self.observed_input_sequence
+                            .store(current_input_seq, Ordering::Relaxed);
+                        self.screen_observed.store(true, Ordering::Relaxed);
+                        return Ok((emulator.screen().snapshot(), false));
                     }
                     continue;
                 }
@@ -525,10 +528,7 @@ impl TerminalSession {
                     self.observed_input_sequence.store(0, Ordering::Relaxed);
                     self.screen_observed.store(true, Ordering::Relaxed);
                     if std::time::Instant::now() >= deadline {
-                        anyhow::bail!(
-                            "Timeout waiting for screen change ({}ms elapsed)",
-                            timeout_ms
-                        );
+                        return Ok((emulator.screen().snapshot(), false));
                     }
                     continue;
                 }
@@ -552,17 +552,13 @@ impl TerminalSession {
                 let screen_text = snapshot.lines.join("\n");
                 if !re.is_match(&screen_text) {
                     if std::time::Instant::now() >= deadline {
-                        anyhow::bail!(
-                            "Screen changed but pattern '{}' not found within timeout ({}ms)",
-                            match_pattern.unwrap_or(""),
-                            timeout_ms
-                        );
+                        return Ok((snapshot, false));
                     }
                     continue;
                 }
             }
 
-            return Ok(snapshot);
+            return Ok((snapshot, true));
         }
     }
 

--- a/crates/kestrel-tools/src/builtins/terminal/session.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/session.rs
@@ -96,7 +96,7 @@ pub struct TerminalSession {
     last_activity: AtomicU64,
     master: Mutex<Option<Box<dyn MasterPty + Send>>>,
     child: Mutex<Option<Box<dyn Child + Send + Sync>>>,
-    writer: Mutex<Box<dyn Write + Send>>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
     /// Raw PTY byte buffer (for debug/escaped modes).
     #[allow(dead_code)] // Used by future escaped mode and debug output
     raw_buffer: Arc<Mutex<RingBuffer>>,
@@ -183,12 +183,14 @@ impl TerminalSession {
         let utf8_decoder = Arc::new(Mutex::new(IncrementalUtf8Decoder::new()));
         let emulator = Arc::new(Mutex::new(TerminalEmulatorHandle::new(cols, rows)));
         let alive = Arc::new(AtomicBool::new(true));
+        let writer = Arc::new(Mutex::new(writer));
 
         let raw_clone = raw_buffer.clone();
         let decoder_clone = utf8_decoder.clone();
         let decoded_clone = decoded_buffer.clone();
         let emulator_clone = emulator.clone();
         let alive_clone = alive.clone();
+        let writer_clone = writer.clone();
         let session_id = id.clone();
         let reader_handle = std::thread::Builder::new()
             .name(format!("pty-reader-{id}"))
@@ -200,6 +202,7 @@ impl TerminalSession {
                     &decoded_clone,
                     &emulator_clone,
                     &alive_clone,
+                    &writer_clone,
                     &session_id,
                 );
             })
@@ -219,7 +222,7 @@ impl TerminalSession {
             last_activity: AtomicU64::new(epoch_secs()),
             master: Mutex::new(Some(master)),
             child: Mutex::new(Some(child)),
-            writer: Mutex::new(writer),
+            writer,
             raw_buffer,
             utf8_decoder,
             decoded_buffer,
@@ -593,6 +596,7 @@ impl Drop for TerminalSession {
 
 /// Background output pump: reads from PTY, stores raw bytes, feeds the ANSI
 /// parser, and incrementally decodes UTF-8 into the decoded text buffer.
+#[allow(clippy::too_many_arguments)]
 fn pump_output(
     mut reader: Box<dyn Read + Send>,
     raw_buffer: &Arc<Mutex<RingBuffer>>,
@@ -600,6 +604,7 @@ fn pump_output(
     decoded_buffer: &Arc<Mutex<String>>,
     emulator: &Arc<Mutex<TerminalEmulatorHandle>>,
     alive: &AtomicBool,
+    writer: &Arc<Mutex<Box<dyn Write + Send>>>,
     session_id: &str,
 ) {
     let mut first_chunk_logged = false;
@@ -650,6 +655,14 @@ fn pump_output(
                 // Feed bytes through ANSI parser.
                 if let Ok(mut emu) = emulator.lock() {
                     emu.feed_bytes(chunk);
+                    // Send any pending response (e.g., DSR cursor position reply) back to PTY.
+                    if let Some(response) = emu.take_pending_response() {
+                        drop(emu); // Release emulator lock before acquiring writer.
+                        if let Ok(mut w) = writer.lock() {
+                            let _ = w.write_all(response.as_bytes());
+                            let _ = w.flush();
+                        }
+                    }
                 }
 
                 // Incrementally decode UTF-8 and append to decoded buffer.

--- a/crates/kestrel-tools/src/builtins/terminal/tools.rs
+++ b/crates/kestrel-tools/src/builtins/terminal/tools.rs
@@ -1069,7 +1069,7 @@ impl Tool for TerminalWaitForScreenChangeTool {
 
         let sid = session_id.to_string();
         let pattern_owned = match_pattern.map(String::from);
-        let snapshot = tokio::task::spawn_blocking(move || {
+        let (snapshot, changed) = tokio::task::spawn_blocking(move || {
             mgr.wait_for_screen_change(&sid, timeout_ms, pattern_owned.as_deref())
         })
         .await
@@ -1077,6 +1077,9 @@ impl Tool for TerminalWaitForScreenChangeTool {
         .map_err(|e| ToolError::Execution(e.to_string()))?;
 
         let mut output = String::new();
+        if !changed {
+            output.push_str(&format!("Screen unchanged after {}ms.\n\n", timeout_ms));
+        }
         for (i, line) in snapshot.lines.iter().enumerate() {
             if i == snapshot.cursor_row {
                 output.push_str(&format!(
@@ -1537,7 +1540,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Wait with very short timeout — no output sent, should time out
+        // Wait with very short timeout — no output sent, should return screen unchanged
         let result = wait
             .execute(json!({
                 "session_id": session_id,
@@ -1545,11 +1548,20 @@ mod tests {
             }))
             .await;
 
-        assert!(result.is_err());
-        let error = result.unwrap_err().to_string();
         assert!(
-            error.contains("Timeout") || error.contains("timeout"),
-            "Expected timeout error"
+            result.is_ok(),
+            "Expected Ok with screen content, got: {:?}",
+            result
+        );
+        let output = result.unwrap();
+        assert!(
+            output.contains("Screen unchanged"),
+            "Expected 'Screen unchanged' prefix, got: {:?}",
+            output
+        );
+        assert!(
+            output.contains("cursor:") || output.contains("dims:"),
+            "Expected screen metadata in output"
         );
 
         kill.execute(json!({"session_id": session_id}))


### PR DESCRIPTION
## Summary
- Fix `capture_screen` returning empty on Windows by handling DSR (CSI 6n) cursor position queries in the VT emulator (#361)
- Return screen snapshot on `wait_for_screen_change` timeout instead of error, giving LLM agents visibility into terminal state when interactive programs idle

## Changes
- `emulator.rs`: Respond to DSR with `CSI row;col R` through the PTY input pipe
- `session.rs`: `wait_for_screen_change` returns `Result<(ScreenSnapshot, bool)>` — `false` indicates timeout with current screen
- `tools.rs`: On timeout, prepend `"Screen unchanged after Xms."` before screen content
- `manager.rs`: Updated wrapper signature

## Test plan
- [x] cargo fmt / clippy pass locally
- [ ] CI full test suite passes
- [ ] Deploy and verify via TG/WS that agent no longer loops on interactive CLIs

Bahtya