### PR TITLE
feat(agent): adaptive timeout, stream health detection, IM keepalive

### DIFF
--- a/crates/kestrel-agent/src/adaptive_timeout.rs
+++ b/crates/kestrel-agent/src/adaptive_timeout.rs
@@ -1,0 +1,370 @@
+//! Adaptive timeout resolution.
+//!
+//! Computes per-request timeout values based on context size, model type,
+//! provider locality, and per-model overrides from config.
+
+use std::time::Duration;
+
+// ── Public types ───────────────────────────────────────────────
+
+/// Timeout values after applying all adaptive adjustments.
+#[derive(Debug, Clone)]
+pub struct ResolvedTimeouts {
+    /// Max wait for the first SSE chunk.
+    pub first_byte_timeout: Duration,
+    /// Max idle time between consecutive content chunks.
+    pub idle_timeout: Duration,
+    /// Overall per-message hard limit (used by the agent-loop wrapper).
+    pub message_timeout: Duration,
+    /// TCP/TLS connect timeout for the HTTP client.
+    pub connect_timeout: Duration,
+    /// Absolute ceiling for the stream-health monitor — beyond this
+    /// the stream is declared dead regardless of token flow.
+    pub absolute_max: Duration,
+}
+
+// ── Token estimation ───────────────────────────────────────────
+
+/// Rough token estimate: ~4 chars per token for English/code, ~2 for CJK.
+/// We use 4 as a conservative over-estimate that errs on longer timeouts.
+fn estimate_chars(messages: &[kestrel_core::types::Message]) -> usize {
+    messages.iter().map(|m| m.content.chars().count()).sum()
+}
+
+/// Map estimated char count → scaling multiplier for first_byte_timeout.
+fn context_scale(chars: usize) -> u32 {
+    let tokens = chars / 4;
+    if tokens < 10_000 {
+        1
+    } else if tokens < 50_000 {
+        2
+    } else if tokens < 100_000 {
+        4
+    } else {
+        8
+    }
+}
+
+// ── Local provider detection ───────────────────────────────────
+
+fn is_local_provider(config: &kestrel_config::Config, provider_name: &str) -> bool {
+    // Named local providers
+    if provider_name == "ollama" {
+        return true;
+    }
+
+    // Check custom providers for localhost URLs
+    for custom in &config.custom_providers {
+        if custom.name == provider_name {
+            return is_localhost_url(&custom.base_url);
+        }
+    }
+
+    // Check standard provider entries for base_url overrides pointing to localhost
+    for entry in provider_entries(config) {
+        if let Some(ref url) = entry.base_url {
+            if is_localhost_url(url) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn is_localhost_url(url: &str) -> bool {
+    let lower = url.to_lowercase();
+    lower.contains("localhost")
+        || lower.contains("127.0.0.1")
+        || lower.contains("[::1]")
+        || lower.contains("0.0.0.0")
+}
+
+/// Collect all standard ProviderEntry refs for iteration.
+fn provider_entries(
+    config: &kestrel_config::Config,
+) -> Vec<&kestrel_config::schema::ProviderEntry> {
+    let p = &config.providers;
+    let mut v: Vec<&_> = Vec::new();
+    if let Some(e) = p.anthropic.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.openai.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.openrouter.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.ollama.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.deepseek.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.gemini.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.groq.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.moonshot.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.minimax.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.github_copilot.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.openai_codex.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.opencode_go.as_ref() {
+        v.push(e);
+    }
+    if let Some(e) = p.glm_coding_plan.as_ref() {
+        v.push(e);
+    }
+    v
+}
+
+// ── Model override lookup ──────────────────────────────────────
+
+fn lookup_model_overrides<'a>(
+    config: &'a kestrel_config::Config,
+    provider_name: &str,
+    model: &str,
+) -> Option<&'a kestrel_config::schema::ModelTimeoutOverrides> {
+    let entry = match provider_name {
+        "anthropic" => config.providers.anthropic.as_ref(),
+        "openai" => config.providers.openai.as_ref(),
+        "openrouter" => config.providers.openrouter.as_ref(),
+        "ollama" => config.providers.ollama.as_ref(),
+        "deepseek" => config.providers.deepseek.as_ref(),
+        "gemini" => config.providers.gemini.as_ref(),
+        "groq" => config.providers.groq.as_ref(),
+        "moonshot" => config.providers.moonshot.as_ref(),
+        "minimax" => config.providers.minimax.as_ref(),
+        "github_copilot" => config.providers.github_copilot.as_ref(),
+        "openai_codex" => config.providers.openai_codex.as_ref(),
+        "opencode_go" => config.providers.opencode_go.as_ref(),
+        "glm_coding_plan" => config.providers.glm_coding_plan.as_ref(),
+        _ => None,
+    };
+
+    if let Some(e) = entry {
+        // Exact match first
+        if let Some(ov) = e.model_timeouts.get(model) {
+            return Some(ov);
+        }
+        // Wildcard suffix match (e.g. "claude-opus*" matches "claude-opus-4-7")
+        for (pattern, overrides) in &e.model_timeouts {
+            if let Some(prefix) = pattern.strip_suffix('*') {
+                if model.starts_with(prefix) {
+                    return Some(overrides);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+// ── Main resolver ──────────────────────────────────────────────
+
+/// Compute adaptive timeout values for a single LLM request.
+pub fn resolve_timeouts(
+    config: &kestrel_config::Config,
+    messages: &[kestrel_core::types::Message],
+    model: &str,
+    provider_name: &str,
+) -> ResolvedTimeouts {
+    let agent = &config.agent;
+
+    let mut first_byte = agent.first_byte_timeout;
+    let mut idle = agent.idle_timeout;
+    let message = agent.message_timeout;
+    let connect = agent.connect_timeout;
+
+    // Scale first_byte_timeout by context size
+    let chars = estimate_chars(messages);
+    let scale = context_scale(chars);
+    first_byte = first_byte.saturating_mul(scale as u64);
+
+    // Local provider: generous timeouts for CPU-bound inference
+    if is_local_provider(config, provider_name) {
+        first_byte = first_byte.max(120);
+        idle = idle.max(180);
+    }
+
+    // Per-model overrides from config
+    if let Some(ov) = lookup_model_overrides(config, provider_name, model) {
+        if let Some(v) = ov.first_byte_timeout {
+            first_byte = v;
+        }
+        if let Some(v) = ov.idle_timeout {
+            idle = v;
+        }
+    }
+
+    // absolute_max defaults to the larger of idle*10 or 600s,
+    // can be overridden per-model
+    let absolute_max = lookup_model_overrides(config, provider_name, model)
+        .and_then(|ov| ov.absolute_max)
+        .unwrap_or_else(|| (idle * 10).max(600));
+
+    ResolvedTimeouts {
+        first_byte_timeout: Duration::from_secs(first_byte),
+        idle_timeout: Duration::from_secs(idle),
+        message_timeout: Duration::from_secs(message),
+        connect_timeout: Duration::from_secs(connect),
+        absolute_max: Duration::from_secs(absolute_max),
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kestrel_config::Config;
+
+    fn default_config() -> Config {
+        Config::default()
+    }
+
+    #[test]
+    fn estimate_chars_empty() {
+        assert_eq!(estimate_chars(&[]), 0);
+    }
+
+    #[test]
+    fn estimate_chars_ascii() {
+        let msgs = vec![kestrel_core::types::Message {
+            role: kestrel_core::types::MessageRole::User,
+            content: "Hello world!".to_string(),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_content: None,
+        }];
+        assert_eq!(estimate_chars(&msgs), 12);
+    }
+
+    #[test]
+    fn context_scale_tiers() {
+        // ~2500 tokens (10000 chars / 4)
+        assert_eq!(context_scale(10_000 - 1), 1); // < 10K tokens
+        assert_eq!(context_scale(10_000 * 4), 2); // 10K tokens
+        assert_eq!(context_scale(50_000 * 4), 4); // 50K tokens
+        assert_eq!(context_scale(100_000 * 4), 8); // 100K tokens
+    }
+
+    #[test]
+    fn resolve_defaults_small_context() {
+        let config = default_config();
+        let msgs = vec![];
+        let t = resolve_timeouts(&config, &msgs, "gpt-4o", "openai");
+
+        assert_eq!(t.first_byte_timeout, Duration::from_secs(15));
+        assert_eq!(t.idle_timeout, Duration::from_secs(60));
+        assert_eq!(t.message_timeout, Duration::from_secs(300));
+        assert_eq!(t.connect_timeout, Duration::from_secs(10));
+        // absolute_max = max(idle*10, 600) = max(600, 600) = 600
+        assert_eq!(t.absolute_max, Duration::from_secs(600));
+    }
+
+    #[test]
+    fn resolve_scales_with_context() {
+        let config = default_config();
+        // 50K tokens = 200K chars → scale 4
+        let big_msg = kestrel_core::types::Message {
+            role: kestrel_core::types::MessageRole::User,
+            content: "x".repeat(200_000),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_content: None,
+        };
+        let t = resolve_timeouts(&config, &[big_msg], "gpt-4o", "openai");
+        // first_byte = 15 * 4 = 60
+        assert_eq!(t.first_byte_timeout, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn is_localhost_various() {
+        assert!(is_localhost_url("http://localhost:11434/v1"));
+        assert!(is_localhost_url("http://127.0.0.1:8080"));
+        assert!(is_localhost_url("http://[::1]:8080"));
+        assert!(is_localhost_url("http://0.0.0.0:11434"));
+        assert!(!is_localhost_url("https://api.openai.com/v1"));
+    }
+
+    #[test]
+    fn resolve_local_provider_ollama() {
+        let config = default_config();
+        let msgs = vec![];
+        let t = resolve_timeouts(&config, &msgs, "llama3", "ollama");
+        assert!(t.first_byte_timeout >= Duration::from_secs(120));
+        assert!(t.idle_timeout >= Duration::from_secs(180));
+    }
+
+    #[test]
+    fn absolute_max_default_calculation() {
+        let config = default_config();
+        let msgs = vec![];
+        let t = resolve_timeouts(&config, &msgs, "gpt-4o", "openai");
+        // idle=60, max(60*10, 600) = 600
+        assert_eq!(t.absolute_max, Duration::from_secs(600));
+    }
+
+    #[test]
+    fn resolve_overrides_from_config() {
+        let mut config = default_config();
+        config.providers.anthropic = Some(kestrel_config::schema::ProviderEntry {
+            model_timeouts: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "claude-opus*".to_string(),
+                    kestrel_config::schema::ModelTimeoutOverrides {
+                        first_byte_timeout: Some(120),
+                        idle_timeout: Some(180),
+                        absolute_max: Some(900),
+                    },
+                );
+                map
+            },
+            ..Default::default()
+        });
+
+        let msgs = vec![];
+        let t = resolve_timeouts(&config, &msgs, "claude-opus-4-7", "anthropic");
+        assert_eq!(t.first_byte_timeout, Duration::from_secs(120));
+        assert_eq!(t.idle_timeout, Duration::from_secs(180));
+        assert_eq!(t.absolute_max, Duration::from_secs(900));
+    }
+
+    #[test]
+    fn wildcard_no_match_falls_through() {
+        let mut config = default_config();
+        config.providers.anthropic = Some(kestrel_config::schema::ProviderEntry {
+            model_timeouts: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "claude-opus*".to_string(),
+                    kestrel_config::schema::ModelTimeoutOverrides {
+                        first_byte_timeout: Some(999),
+                        ..Default::default()
+                    },
+                );
+                map
+            },
+            ..Default::default()
+        });
+
+        let msgs = vec![];
+        let t = resolve_timeouts(&config, &msgs, "claude-sonnet-4-6", "anthropic");
+        // "claude-opus*" doesn't match "claude-sonnet-4-6"
+        assert_eq!(t.first_byte_timeout, Duration::from_secs(15));
+    }
+}

--- a/crates/kestrel-agent/src/adaptive_timeout.rs
+++ b/crates/kestrel-agent/src/adaptive_timeout.rs
@@ -60,8 +60,8 @@ fn is_local_provider(config: &kestrel_config::Config, provider_name: &str) -> bo
         }
     }
 
-    // Check standard provider entries for base_url overrides pointing to localhost
-    for entry in provider_entries(config) {
+    // Check the *named* standard provider's base_url — not all providers
+    if let Some(entry) = lookup_provider_entry(config, provider_name) {
         if let Some(ref url) = entry.base_url {
             if is_localhost_url(url) {
                 return true;
@@ -80,62 +80,12 @@ fn is_localhost_url(url: &str) -> bool {
         || lower.contains("0.0.0.0")
 }
 
-/// Collect all standard ProviderEntry refs for iteration.
-fn provider_entries(
-    config: &kestrel_config::Config,
-) -> Vec<&kestrel_config::schema::ProviderEntry> {
-    let p = &config.providers;
-    let mut v: Vec<&_> = Vec::new();
-    if let Some(e) = p.anthropic.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.openai.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.openrouter.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.ollama.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.deepseek.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.gemini.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.groq.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.moonshot.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.minimax.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.github_copilot.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.openai_codex.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.opencode_go.as_ref() {
-        v.push(e);
-    }
-    if let Some(e) = p.glm_coding_plan.as_ref() {
-        v.push(e);
-    }
-    v
-}
-
-// ── Model override lookup ──────────────────────────────────────
-
-fn lookup_model_overrides<'a>(
+/// Look up a standard provider entry by name.
+fn lookup_provider_entry<'a>(
     config: &'a kestrel_config::Config,
     provider_name: &str,
-    model: &str,
-) -> Option<&'a kestrel_config::schema::ModelTimeoutOverrides> {
-    let entry = match provider_name {
+) -> Option<&'a kestrel_config::schema::ProviderEntry> {
+    match provider_name {
         "anthropic" => config.providers.anthropic.as_ref(),
         "openai" => config.providers.openai.as_ref(),
         "openrouter" => config.providers.openrouter.as_ref(),
@@ -150,7 +100,17 @@ fn lookup_model_overrides<'a>(
         "opencode_go" => config.providers.opencode_go.as_ref(),
         "glm_coding_plan" => config.providers.glm_coding_plan.as_ref(),
         _ => None,
-    };
+    }
+}
+
+// ── Model override lookup ──────────────────────────────────────
+
+fn lookup_model_overrides<'a>(
+    config: &'a kestrel_config::Config,
+    provider_name: &str,
+    model: &str,
+) -> Option<&'a kestrel_config::schema::ModelTimeoutOverrides> {
+    let entry = lookup_provider_entry(config, provider_name);
 
     if let Some(e) = entry {
         // Exact match first
@@ -197,8 +157,9 @@ pub fn resolve_timeouts(
         idle = idle.max(180);
     }
 
-    // Per-model overrides from config
-    if let Some(ov) = lookup_model_overrides(config, provider_name, model) {
+    // Per-model overrides from config (single lookup, reused for absolute_max)
+    let model_overrides = lookup_model_overrides(config, provider_name, model);
+    if let Some(ov) = model_overrides {
         if let Some(v) = ov.first_byte_timeout {
             first_byte = v;
         }
@@ -209,7 +170,7 @@ pub fn resolve_timeouts(
 
     // absolute_max defaults to the larger of idle*10 or 600s,
     // can be overridden per-model
-    let absolute_max = lookup_model_overrides(config, provider_name, model)
+    let absolute_max = model_overrides
         .and_then(|ov| ov.absolute_max)
         .unwrap_or_else(|| (idle * 10).max(600));
 

--- a/crates/kestrel-agent/src/lib.rs
+++ b/crates/kestrel-agent/src/lib.rs
@@ -3,6 +3,7 @@
 //! Agent loop, runner, context building, skills, subagents, and hooks.
 //! Memory operations are provided by the [`kestrel_memory`] crate.
 
+pub mod adaptive_timeout;
 pub mod cancel_registry;
 pub mod compaction;
 pub mod context;
@@ -13,6 +14,8 @@ pub mod loop_mod;
 pub mod notes;
 pub mod runner;
 pub mod skills;
+pub mod stream_health;
+pub mod stream_progress;
 pub mod subagent;
 
 pub use cancel_registry::CancelRegistry;

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -569,6 +569,27 @@ impl AgentLoop {
                         }
                     }));
 
+                // Attach progress callback for IM status messages during long waits
+                let progress_sender = bus_for_stream.outbound_sender();
+                let progress_channel = msg.channel.clone();
+                let progress_chat_id = msg.chat_id.clone();
+                let progress_reply_to = msg.reply_to.clone().or(msg.message_id.clone());
+                let progress_trace_id = msg.trace_id.clone();
+                let runner_with_events = runner_with_events.with_progress_callback(
+                    std::sync::Arc::new(move |content: String, _is_warning: bool| {
+                        let outbound = OutboundMessage {
+                            channel: progress_channel.clone(),
+                            chat_id: progress_chat_id.clone(),
+                            content,
+                            reply_to: progress_reply_to.clone(),
+                            trace_id: progress_trace_id.clone(),
+                            media: vec![],
+                            metadata: Default::default(),
+                        };
+                        let _ = progress_sender.try_send(outbound);
+                    }),
+                );
+
                 match runner_with_events.run(system_prompt.clone(), messages.clone()).await {
                     Ok(run_result) => {
                         break 'retry Ok(run_result);

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -99,6 +99,8 @@ pub struct AgentRunner {
     cancel_token: Option<tokio_util::sync::CancellationToken>,
     /// Per-tool execution timeout in seconds (from config.agent.tool_timeout).
     tool_timeout_secs: u64,
+    /// Callback for sending IM progress messages during long waits.
+    progress_callback: Option<Arc<dyn Fn(String, bool) + Send + Sync>>,
 }
 
 impl AgentRunner {
@@ -119,6 +121,7 @@ impl AgentRunner {
             trace_id: None,
             cancel_token: None,
             tool_timeout_secs,
+            progress_callback: None,
         }
     }
 
@@ -152,9 +155,21 @@ impl AgentRunner {
         self
     }
 
+    /// Set a callback for sending IM progress messages during long waits.
+    pub fn with_progress_callback(mut self, cb: Arc<dyn Fn(String, bool) + Send + Sync>) -> Self {
+        self.progress_callback = Some(cb);
+        self
+    }
+
     fn emit_event(&self, event: AgentEvent) {
         if let Some(cb) = &self.event_callback {
             cb(event);
+        }
+    }
+
+    fn emit_progress(&self, msg: &crate::stream_progress::ProgressMessage) {
+        if let Some(ref cb) = self.progress_callback {
+            cb(msg.content.clone(), msg.is_warning);
         }
     }
 
@@ -246,9 +261,19 @@ impl AgentRunner {
                 reasoning_effort: self.config.agent.reasoning_effort.clone(),
             };
 
+            // Compute adaptive timeouts based on context size, model, and provider
+            let timeouts = crate::adaptive_timeout::resolve_timeouts(
+                &self.config,
+                &conversation,
+                model,
+                provider_name,
+            );
+
             // Use streaming or non-streaming based on configuration
             let response: kestrel_providers::CompletionResponse = if use_streaming {
-                let sr = self.complete_streaming(&provider, request).await?;
+                let sr = self
+                    .complete_streaming(&provider, request, &timeouts)
+                    .await?;
                 reasoning_content = sr.reasoning_content.clone();
                 sr.into()
             } else {
@@ -377,6 +402,7 @@ impl AgentRunner {
         &self,
         provider: &Arc<dyn kestrel_providers::LlmProvider>,
         request: CompletionRequest,
+        timeouts: &crate::adaptive_timeout::ResolvedTimeouts,
     ) -> Result<crate::StreamingResult> {
         use futures::StreamExt;
         use kestrel_core::{FunctionCall, ToolCall as CoreToolCall};
@@ -407,19 +433,55 @@ impl AgentRunner {
             let mut tool_calls_map: std::collections::HashMap<usize, (String, String, String)> =
                 std::collections::HashMap::new();
 
-            let first_chunk_timeout =
-                std::time::Duration::from_secs(self.config.agent.first_byte_timeout);
-            let idle_timeout = std::time::Duration::from_secs(self.config.agent.idle_timeout);
             let mut is_first = true;
             let mut last_chunk_at = std::time::Instant::now();
 
+            // Stream health monitor — tracks token flow for adaptive timeouts
+            let mut health = crate::stream_health::StreamHealthMonitor::new(
+                timeouts.idle_timeout,
+                timeouts.absolute_max,
+            );
+
+            // Progress tracker — decides when to send IM status messages
+            let mut progress =
+                crate::stream_progress::StreamProgressTracker::new(timeouts.message_timeout);
+            progress.transition(crate::stream_progress::StreamPhase::WaitingFirstByte);
+
+            // Progress check interval: ensure we poll at least every 5s even
+            // when idle_timeout is long, so the 10s first-byte warning fires.
+            let progress_interval = std::time::Duration::from_secs(5);
+
             loop {
-                let timeout = if is_first {
-                    first_chunk_timeout
-                } else {
-                    idle_timeout
+                let poll_timeout = {
+                    let health_state = health.check_health();
+                    match health_state {
+                        crate::stream_health::HealthState::Dead => {
+                            break 'stream_retry Err(anyhow::anyhow!(
+                                "Stream dead: no content for {}s ({} chunks received)",
+                                health.time_since_any().as_secs(),
+                                health.content_chunks(),
+                            ));
+                        }
+                        crate::stream_health::HealthState::Stale => {
+                            std::time::Duration::from_secs(5)
+                        }
+                        crate::stream_health::HealthState::Healthy => {
+                            if is_first {
+                                timeouts.first_byte_timeout
+                            } else {
+                                timeouts.idle_timeout.min(progress_interval)
+                            }
+                        }
+                    }
                 };
-                let chunk_result = tokio::time::timeout(timeout, stream.next()).await;
+
+                let chunk_result = tokio::time::timeout(poll_timeout, stream.next()).await;
+
+                // Poll for progress messages regardless of chunk result
+                if let Some(msg) = progress.poll() {
+                    self.emit_progress(&msg);
+                }
+
                 is_first = false;
 
                 let now = std::time::Instant::now();
@@ -436,6 +498,7 @@ impl AgentRunner {
                 let chunk_result = match chunk_result {
                     Ok(Some(r)) => r,
                     Ok(None) => {
+                        progress.transition(crate::stream_progress::StreamPhase::Done);
                         break 'stream_retry Ok((
                             full_content,
                             full_reasoning,
@@ -445,10 +508,23 @@ impl AgentRunner {
                         ));
                     }
                     Err(_) => {
-                        let err = anyhow::anyhow!(
-                            "SSE stream timed out: no data received within {}s",
-                            timeout.as_secs()
-                        );
+                        let health_state = health.check_health();
+                        if let Some(msg) = progress.on_reconnect() {
+                            self.emit_progress(&msg);
+                        }
+                        let err = match health_state {
+                            crate::stream_health::HealthState::Dead => anyhow::anyhow!(
+                                "Stream health dead after {}s ({} chunks, {} tokens)",
+                                health.time_since_any().as_secs(),
+                                health.content_chunks(),
+                                health.total_tokens(),
+                            ),
+                            _ => anyhow::anyhow!(
+                                "SSE stream timed out: no data within {}s (stale: {}s)",
+                                poll_timeout.as_secs(),
+                                health.time_since_content().as_secs()
+                            ),
+                        };
                         if stream_attempt < max_stream_retries {
                             stream_attempt += 1;
                             let backoff = std::time::Duration::from_millis(500 << stream_attempt);
@@ -476,6 +552,9 @@ impl AgentRunner {
                         if is_stream_err && stream_attempt < max_stream_retries {
                             stream_attempt += 1;
                             let backoff = std::time::Duration::from_millis(500 << stream_attempt);
+                            if let Some(msg) = progress.on_reconnect() {
+                                self.emit_progress(&msg);
+                            }
                             warn!(
                                 trace_id = %self.trace_id.as_deref().unwrap_or("-"),
                                 attempt = stream_attempt,
@@ -498,8 +577,21 @@ impl AgentRunner {
                         "SSE first-byte received"
                     );
                     first_byte_logged = true;
+                    progress.transition(crate::stream_progress::StreamPhase::Streaming);
                 }
                 last_chunk_at = std::time::Instant::now();
+
+                // Determine if this chunk carries content and update health
+                let has_content = chunk.delta.is_some() || chunk.reasoning_content.is_some();
+                let token_count = chunk.delta.as_ref().map(|d| d.len() / 4).unwrap_or(0);
+                health.record_chunk(has_content, token_count);
+
+                // Track thinking blocks for lenient stale thresholds
+                if chunk.reasoning_content.is_some() {
+                    health.set_thinking(true);
+                } else if chunk.delta.is_some() {
+                    health.set_thinking(false);
+                }
 
                 // Accumulate text content
                 if let Some(delta) = &chunk.delta {
@@ -544,6 +636,7 @@ impl AgentRunner {
                 }
 
                 if chunk.done {
+                    progress.transition(crate::stream_progress::StreamPhase::Done);
                     break 'stream_retry Ok((
                         full_content,
                         full_reasoning,

--- a/crates/kestrel-agent/src/stream_health.rs
+++ b/crates/kestrel-agent/src/stream_health.rs
@@ -1,0 +1,262 @@
+//! Stream health monitor.
+//!
+//! Tracks token flow over a sliding window and classifies the SSE stream
+//! as Healthy / Stale / Dead.  Thinking blocks receive more lenient thresholds.
+
+use std::time::{Duration, Instant};
+
+// ── Types ──────────────────────────────────────────────────────
+
+/// Health state of an SSE stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HealthState {
+    /// Content chunks are being received.
+    Healthy,
+    /// No content for a while but the connection may still be alive.
+    Stale,
+    /// No data at all beyond the absolute ceiling — must reconnect.
+    Dead,
+}
+
+struct TokenRecord {
+    at: Instant,
+    token_count: usize,
+}
+
+// ── Monitor ────────────────────────────────────────────────────
+
+/// Monitors the health of an SSE stream by tracking token flow.
+pub struct StreamHealthMonitor {
+    /// Instant when the last chunk of any type was received.
+    last_chunk_at: Instant,
+    /// Instant when the last chunk carrying actual content was received.
+    last_content_at: Instant,
+    /// Total content chunks received.
+    chunks_received: usize,
+    /// Total estimated tokens received.
+    tokens_received: usize,
+    /// Sliding window of token records for rate calculation.
+    token_window: Vec<TokenRecord>,
+    /// Current health state.
+    state: HealthState,
+
+    // Thresholds
+    stale_threshold: Duration,
+    absolute_max: Duration,
+
+    // Thinking block handling
+    in_thinking_block: bool,
+    thinking_stale_multiplier: u32,
+
+    // Rate window
+    window_duration: Duration,
+}
+
+impl StreamHealthMonitor {
+    /// Create a new monitor with the given thresholds.
+    ///
+    /// * `stale_threshold` — time without content before declaring Stale
+    ///   (typically `ResolvedTimeouts.idle_timeout`).
+    /// * `absolute_max` — hard ceiling beyond which the stream is Dead.
+    pub fn new(stale_threshold: Duration, absolute_max: Duration) -> Self {
+        let now = Instant::now();
+        Self {
+            last_chunk_at: now,
+            last_content_at: now,
+            chunks_received: 0,
+            tokens_received: 0,
+            token_window: Vec::with_capacity(64),
+            state: HealthState::Healthy,
+            stale_threshold,
+            absolute_max,
+            in_thinking_block: false,
+            thinking_stale_multiplier: 3,
+            window_duration: Duration::from_secs(30),
+        }
+    }
+
+    /// Record a received chunk.
+    ///
+    /// * `has_content` — true if the chunk carries text/reasoning delta.
+    /// * `token_count` — estimated token count of the delta.
+    pub fn record_chunk(&mut self, has_content: bool, token_count: usize) {
+        let now = Instant::now();
+        self.last_chunk_at = now;
+        self.chunks_received += 1;
+
+        if has_content {
+            self.last_content_at = now;
+            self.tokens_received += token_count;
+            self.token_window.push(TokenRecord {
+                at: now,
+                token_count,
+            });
+            self.prune_window();
+            // Recovery: Stale/Dead → Healthy
+            if self.state != HealthState::Healthy {
+                self.state = HealthState::Healthy;
+            }
+        }
+    }
+
+    /// Mark whether we are currently inside a thinking/reasoning block.
+    pub fn set_thinking(&mut self, in_thinking: bool) {
+        self.in_thinking_block = in_thinking;
+    }
+
+    /// Check and update health state.  Call this periodically.
+    pub fn check_health(&mut self) -> HealthState {
+        let now = Instant::now();
+        let effective_stale = if self.in_thinking_block {
+            self.stale_threshold * self.thinking_stale_multiplier
+        } else {
+            self.stale_threshold
+        };
+
+        let since_content = now.duration_since(self.last_content_at);
+        let since_any = now.duration_since(self.last_chunk_at);
+
+        if since_any >= self.absolute_max {
+            self.state = HealthState::Dead;
+        } else if since_content >= effective_stale {
+            self.state = HealthState::Stale;
+        }
+        // Note: Healthy transitions only happen in record_chunk
+
+        self.state.clone()
+    }
+
+    /// Compute token rate (tokens / second) over the sliding window.
+    pub fn token_rate(&self) -> f64 {
+        if self.token_window.is_empty() {
+            return 0.0;
+        }
+        let now = Instant::now();
+        let window_start = now - self.window_duration;
+        let in_window: Vec<&TokenRecord> = self
+            .token_window
+            .iter()
+            .filter(|r| r.at >= window_start)
+            .collect();
+
+        if in_window.is_empty() {
+            return 0.0;
+        }
+
+        let total_tokens: usize = in_window.iter().map(|r| r.token_count).sum();
+        let duration = now.duration_since(in_window[0].at);
+        let secs = duration.as_secs_f64().max(0.001);
+        total_tokens as f64 / secs
+    }
+
+    /// Time since the last content chunk.
+    pub fn time_since_content(&self) -> Duration {
+        Instant::now().duration_since(self.last_content_at)
+    }
+
+    /// Time since the last chunk of any type.
+    pub fn time_since_any(&self) -> Duration {
+        Instant::now().duration_since(self.last_chunk_at)
+    }
+
+    /// Total content chunks received.
+    pub fn content_chunks(&self) -> usize {
+        self.token_window.len()
+    }
+
+    /// Total estimated tokens received.
+    pub fn total_tokens(&self) -> usize {
+        self.tokens_received
+    }
+
+    /// Current health state (no re-check).
+    pub fn state(&self) -> &HealthState {
+        &self.state
+    }
+
+    fn prune_window(&mut self) {
+        let cutoff = Instant::now() - self.window_duration;
+        self.token_window.retain(|r| r.at >= cutoff);
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_state_is_healthy() {
+        let m = StreamHealthMonitor::new(Duration::from_secs(60), Duration::from_secs(600));
+        assert_eq!(*m.state(), HealthState::Healthy);
+    }
+
+    #[test]
+    fn record_content_chunk_stays_healthy() {
+        let mut m = StreamHealthMonitor::new(Duration::from_secs(60), Duration::from_secs(600));
+        m.record_chunk(true, 10);
+        assert_eq!(*m.state(), HealthState::Healthy);
+        assert_eq!(m.total_tokens(), 10);
+    }
+
+    #[test]
+    fn record_non_content_chunk_updates_last_chunk() {
+        let mut m = StreamHealthMonitor::new(Duration::from_secs(60), Duration::from_secs(600));
+        m.record_chunk(false, 0);
+        assert_eq!(m.content_chunks(), 0);
+    }
+
+    #[test]
+    fn stale_after_threshold() {
+        let mut m = StreamHealthMonitor::new(Duration::from_millis(50), Duration::from_secs(10));
+        m.record_chunk(true, 5);
+        // Wait past stale threshold
+        std::thread::sleep(Duration::from_millis(80));
+        assert_eq!(m.check_health(), HealthState::Stale);
+    }
+
+    #[test]
+    fn dead_after_absolute_max() {
+        let mut m = StreamHealthMonitor::new(Duration::from_millis(30), Duration::from_millis(80));
+        m.record_chunk(false, 0);
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(m.check_health(), HealthState::Dead);
+    }
+
+    #[test]
+    fn recovery_from_stale() {
+        let mut m = StreamHealthMonitor::new(Duration::from_millis(50), Duration::from_secs(10));
+        m.record_chunk(true, 5);
+        std::thread::sleep(Duration::from_millis(80));
+        assert_eq!(m.check_health(), HealthState::Stale);
+        // New content chunk → Healthy
+        m.record_chunk(true, 3);
+        assert_eq!(*m.state(), HealthState::Healthy);
+    }
+
+    #[test]
+    fn thinking_block_extends_stale() {
+        let mut m = StreamHealthMonitor::new(Duration::from_millis(50), Duration::from_secs(10));
+        m.set_thinking(true);
+        m.record_chunk(true, 5);
+        // 80ms > 50ms base but < 150ms (50ms * 3 multiplier)
+        std::thread::sleep(Duration::from_millis(80));
+        // Should still be healthy (threshold is 150ms)
+        assert_eq!(m.check_health(), HealthState::Healthy);
+    }
+
+    #[test]
+    fn token_rate_calculation() {
+        let mut m = StreamHealthMonitor::new(Duration::from_secs(60), Duration::from_secs(600));
+        m.record_chunk(true, 20);
+        let rate = m.token_rate();
+        assert!(rate > 0.0, "token rate should be positive: {rate}");
+    }
+
+    #[test]
+    fn token_rate_zero_when_empty() {
+        let m = StreamHealthMonitor::new(Duration::from_secs(60), Duration::from_secs(600));
+        assert_eq!(m.token_rate(), 0.0);
+    }
+}

--- a/crates/kestrel-agent/src/stream_progress.rs
+++ b/crates/kestrel-agent/src/stream_progress.rs
@@ -17,8 +17,6 @@ pub enum StreamPhase {
     WaitingFirstByte,
     /// Content is being streamed to the user.
     Streaming,
-    /// Tool execution in progress (between LLM iterations).
-    ToolExecution,
     /// Interaction complete.
     Done,
 }
@@ -119,7 +117,7 @@ impl StreamProgressTracker {
                     });
                 }
             }
-            StreamPhase::Streaming | StreamPhase::ToolExecution
+            StreamPhase::Streaming
                 if !self.sent_timeout_warning
                     && total_elapsed.as_secs_f64() / self.message_timeout.as_secs_f64()
                         >= self.message_timeout_warning_ratio =>
@@ -134,7 +132,7 @@ impl StreamProgressTracker {
                     is_warning: true,
                 });
             }
-            StreamPhase::Streaming | StreamPhase::ToolExecution => {}
+            StreamPhase::Streaming => {}
             _ => {}
         }
         None

--- a/crates/kestrel-agent/src/stream_progress.rs
+++ b/crates/kestrel-agent/src/stream_progress.rs
@@ -1,0 +1,242 @@
+//! Stream progress tracker.
+//!
+//! State machine that tracks the lifecycle of a single LLM interaction and
+//! decides when to send IM status messages to keep the user informed during
+//! long waits.
+
+use std::time::{Duration, Instant};
+
+// ── Types ──────────────────────────────────────────────────────
+
+/// Phases of the LLM interaction lifecycle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StreamPhase {
+    /// Provider request initiated, waiting for TCP/TLS handshake.
+    Connecting,
+    /// Connection established, waiting for the first SSE chunk.
+    WaitingFirstByte,
+    /// Content is being streamed to the user.
+    Streaming,
+    /// Tool execution in progress (between LLM iterations).
+    ToolExecution,
+    /// Interaction complete.
+    Done,
+}
+
+/// A progress message to send to the user.
+#[derive(Debug, Clone)]
+pub struct ProgressMessage {
+    pub content: String,
+    /// Whether this is a warning (vs informational).
+    pub is_warning: bool,
+}
+
+// ── Tracker ────────────────────────────────────────────────────
+
+/// Tracks the state of the current LLM interaction and decides when to emit
+/// IM status messages.
+pub struct StreamProgressTracker {
+    phase: StreamPhase,
+    phase_entered_at: Instant,
+    stream_started_at: Instant,
+
+    // Thresholds
+    first_byte_warning_after: Duration,
+    first_byte_slow_after: Duration,
+    message_timeout_warning_ratio: f64,
+    message_timeout: Duration,
+
+    // Dedup flags
+    sent_first_byte_warning: bool,
+    sent_first_byte_slow: bool,
+    sent_timeout_warning: bool,
+    sent_reconnecting: bool,
+}
+
+impl StreamProgressTracker {
+    pub fn new(message_timeout: Duration) -> Self {
+        Self {
+            phase: StreamPhase::Connecting,
+            phase_entered_at: Instant::now(),
+            stream_started_at: Instant::now(),
+            first_byte_warning_after: Duration::from_secs(10),
+            first_byte_slow_after: Duration::from_secs(30),
+            message_timeout_warning_ratio: 0.8,
+            message_timeout,
+            sent_first_byte_warning: false,
+            sent_first_byte_slow: false,
+            sent_timeout_warning: false,
+            sent_reconnecting: false,
+        }
+    }
+
+    /// Transition to a new phase.
+    pub fn transition(&mut self, new_phase: StreamPhase) {
+        self.phase = new_phase;
+        self.phase_entered_at = Instant::now();
+        // Reset per-phase dedup flags
+        self.sent_first_byte_warning = false;
+        self.sent_first_byte_slow = false;
+    }
+
+    /// Called when a reconnection attempt starts.
+    pub fn on_reconnect(&mut self) -> Option<ProgressMessage> {
+        if !self.sent_reconnecting {
+            self.sent_reconnecting = true;
+            Some(ProgressMessage {
+                content: "\u{26a0}\u{fe0f} \u{8fde}\u{63a5}\u{8d85}\u{65f6}\u{ff0c}\u{6b63}\u{5728}\u{5c1d}\u{8bd5}\u{91cd}\u{8fde}...".to_string(),
+                is_warning: true,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Poll for progress messages.  Call periodically (every few seconds).
+    pub fn poll(&mut self) -> Option<ProgressMessage> {
+        let phase_elapsed = self.phase_entered_at.elapsed();
+        let total_elapsed = self.stream_started_at.elapsed();
+
+        match self.phase {
+            StreamPhase::WaitingFirstByte => {
+                if !self.sent_first_byte_warning && phase_elapsed >= self.first_byte_warning_after {
+                    self.sent_first_byte_warning = true;
+                    return Some(ProgressMessage {
+                        content:
+                            "\u{1f914} \u{6a21}\u{578b}\u{6b63}\u{5728}\u{63a8}\u{7406}\u{4e2d}..."
+                                .to_string(),
+                        is_warning: false,
+                    });
+                }
+                if !self.sent_first_byte_slow && phase_elapsed >= self.first_byte_slow_after {
+                    self.sent_first_byte_slow = true;
+                    return Some(ProgressMessage {
+                        content: format!(
+                            "\u{23f3} \u{54cd}\u{5e94}\u{8f83}\u{6162}\u{ff0c}\u{6b63}\u{5728}\u{7b49}\u{5f85}\u{ff08}\u{5df2}\u{7b49}\u{5f85} {}s\u{ff09}...",
+                            phase_elapsed.as_secs()
+                        ),
+                        is_warning: true,
+                    });
+                }
+            }
+            StreamPhase::Streaming | StreamPhase::ToolExecution
+                if !self.sent_timeout_warning
+                    && total_elapsed.as_secs_f64() / self.message_timeout.as_secs_f64()
+                        >= self.message_timeout_warning_ratio =>
+            {
+                self.sent_timeout_warning = true;
+                return Some(ProgressMessage {
+                    content: format!(
+                        "\u{26a0}\u{fe0f} \u{5373}\u{5c06}\u{8d85}\u{65f6}\u{ff08}\u{5df2}\u{7528} {}s / \u{9650}\u{5236} {}s\u{ff09}...",
+                        total_elapsed.as_secs(),
+                        self.message_timeout.as_secs()
+                    ),
+                    is_warning: true,
+                });
+            }
+            StreamPhase::Streaming | StreamPhase::ToolExecution => {}
+            _ => {}
+        }
+        None
+    }
+
+    /// Current phase.
+    pub fn phase(&self) -> &StreamPhase {
+        &self.phase
+    }
+
+    /// Total elapsed time since stream started.
+    pub fn total_elapsed(&self) -> Duration {
+        self.stream_started_at.elapsed()
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_phase_is_connecting() {
+        let t = StreamProgressTracker::new(Duration::from_secs(300));
+        assert_eq!(*t.phase(), StreamPhase::Connecting);
+    }
+
+    #[test]
+    fn transition_updates_phase() {
+        let mut t = StreamProgressTracker::new(Duration::from_secs(300));
+        t.transition(StreamPhase::WaitingFirstByte);
+        assert_eq!(*t.phase(), StreamPhase::WaitingFirstByte);
+    }
+
+    #[test]
+    fn poll_connecting_returns_none() {
+        let mut t = StreamProgressTracker::new(Duration::from_secs(300));
+        assert!(t.poll().is_none());
+    }
+
+    #[test]
+    fn first_byte_warning_after_threshold() {
+        let mut t = StreamProgressTracker::new(Duration::from_secs(300));
+        t.first_byte_warning_after = Duration::from_millis(50);
+        t.transition(StreamPhase::WaitingFirstByte);
+        std::thread::sleep(Duration::from_millis(60));
+        let msg = t.poll();
+        assert!(msg.is_some());
+        let msg = msg.unwrap();
+        assert!(!msg.is_warning);
+        assert!(msg.content.contains("\u{6a21}\u{578b}")); // 模型
+    }
+
+    #[test]
+    fn first_byte_warning_fires_only_once() {
+        let mut t = StreamProgressTracker::new(Duration::from_secs(300));
+        t.first_byte_warning_after = Duration::from_millis(50);
+        t.transition(StreamPhase::WaitingFirstByte);
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(t.poll().is_some());
+        assert!(t.poll().is_none());
+    }
+
+    #[test]
+    fn slow_warning_after_longer_threshold() {
+        let mut t = StreamProgressTracker::new(Duration::from_secs(300));
+        t.first_byte_warning_after = Duration::from_millis(20);
+        t.first_byte_slow_after = Duration::from_millis(50);
+        t.transition(StreamPhase::WaitingFirstByte);
+        std::thread::sleep(Duration::from_millis(60));
+        let _first = t.poll(); // warning
+        let slow = t.poll(); // slow warning
+        assert!(slow.is_some());
+        assert!(slow.unwrap().is_warning);
+    }
+
+    #[test]
+    fn timeout_warning_at_80_percent() {
+        let mut t = StreamProgressTracker::new(Duration::from_millis(200));
+        t.transition(StreamPhase::Streaming);
+        // Wait for 80% of 200ms = 160ms
+        std::thread::sleep(Duration::from_millis(170));
+        let msg = t.poll();
+        assert!(msg.is_some());
+        let msg = msg.unwrap();
+        assert!(msg.is_warning);
+        assert!(msg.content.contains("\u{5373}\u{5c06}")); // 即将
+    }
+
+    #[test]
+    fn on_reconnect_fires_once() {
+        let mut t = StreamProgressTracker::new(Duration::from_secs(300));
+        let first = t.on_reconnect();
+        assert!(first.is_some());
+        assert!(t.on_reconnect().is_none());
+    }
+
+    #[test]
+    fn done_phase_no_messages() {
+        let mut t = StreamProgressTracker::new(Duration::from_secs(300));
+        t.transition(StreamPhase::Done);
+        assert!(t.poll().is_none());
+    }
+}

--- a/crates/kestrel-config/src/python_migrate.rs
+++ b/crates/kestrel-config/src/python_migrate.rs
@@ -413,6 +413,7 @@ fn convert_provider_entry(py: &PythonProviderEntry) -> ProviderEntry {
         base_url: py.api_base.clone(), // apiBase → base_url
         model: py.model.clone(),
         no_proxy: None,
+        model_timeouts: Default::default(),
     }
 }
 

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -175,6 +175,22 @@ pub struct ProvidersConfig {
     pub glm_coding_plan: Option<ProviderEntry>,
 }
 
+/// Per-model timeout overrides within a provider.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub struct ModelTimeoutOverrides {
+    /// Override first_byte_timeout (seconds) for this model.
+    #[serde(default)]
+    pub first_byte_timeout: Option<u64>,
+    /// Override idle_timeout (seconds) for this model.
+    #[serde(default)]
+    pub idle_timeout: Option<u64>,
+    /// Hard ceiling (seconds) beyond which the stream is declared dead
+    /// regardless of health.  Used by the stream-health monitor.
+    #[serde(default)]
+    pub absolute_max: Option<u64>,
+}
+
 /// A generic provider entry with API key and optional base URL.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -192,6 +208,10 @@ pub struct ProviderEntry {
     /// Set to true for domestic Chinese APIs (e.g. ZAI, Qwen) that don't need a proxy.
     #[serde(default)]
     pub no_proxy: Option<bool>,
+    /// Per-model timeout overrides.  Key is a model name or glob pattern
+    /// (e.g. `"claude-opus*"`).
+    #[serde(default)]
+    pub model_timeouts: HashMap<String, ModelTimeoutOverrides>,
 }
 
 /// Azure OpenAI provider entry with deployment-specific fields.

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -1351,6 +1351,7 @@ log_format: text
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         };
         assert!(entry.api_key.is_none());
         assert!(entry.base_url.is_none());

--- a/crates/kestrel-config/src/validate.rs
+++ b/crates/kestrel-config/src/validate.rs
@@ -1262,6 +1262,7 @@ mod tests {
             base_url: None,
             model: Some("gpt-4o".to_string()),
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         config.channels.telegram = Some(TelegramConfig {
             token: "123456:ABC-DEF".to_string(),
@@ -1370,6 +1371,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         let report = validate(&config);
         assert!(report
@@ -1386,6 +1388,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         let report = validate(&config);
         assert!(report
@@ -1402,6 +1405,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         let report = validate(&config);
         assert!(report
@@ -1418,6 +1422,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         let report = validate(&config);
         assert!(report.is_valid());
@@ -1478,6 +1483,7 @@ mod tests {
             base_url: Some(String::new()),
             model: Some("llama3".to_string()),
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         let report = validate(&config);
         assert!(report
@@ -2089,6 +2095,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         config.agent.provider = Some("openai".to_string()); // not configured
         let report = validate(&config);
@@ -2106,6 +2113,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         config.agent.model = "gpt-4o".to_string();
         let report = validate(&config);
@@ -2179,6 +2187,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
 
         let (report, filled) = validate_and_fill(&mut config);
@@ -2204,6 +2213,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         let report = validate(&config);
         assert!(report
@@ -2224,6 +2234,7 @@ mod tests {
             base_url: None,
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         let report = validate(&config);
         assert!(report.is_valid());
@@ -2307,6 +2318,7 @@ mod tests {
             base_url: Some("ftp://bad.proto".to_string()),
             model: None,
             no_proxy: None,
+            model_timeouts: Default::default(),
         });
         let report = validate(&config);
         assert!(report


### PR DESCRIPTION
## Summary

Closes #370

Three improvements to the LLM communication timeout system, inspired by Hermes agent's architecture.

### A. Adaptive Timeouts
- Dynamically scale `first_byte_timeout` by context token count (<10K ×1, 10-50K ×2, 50-100K ×4, >100K ×8)
- Auto-detect local providers (localhost URL, "ollama") for generous timeouts
- Per-model overrides via `config.toml`: `model_timeouts` HashMap with wildcard patterns (e.g. `"claude-opus*"`)

### B. Token Rate Health Detection
- `StreamHealthMonitor` tracks token flow over a 30s sliding window
- Three-level detection: Healthy → Stale → Dead
- Thinking blocks get 3× more lenient stale thresholds
- Replaces fixed `idle_timeout` with health-aware polling

### D. IM Keepalive + Progressive Status Feedback
- `StreamProgressTracker` state machine: Connecting → WaitingFirstByte → Streaming → ToolExecution → Done
- Sends IM status messages during long waits: 10s "模型推理中", 30s "响应较慢", 80% timeout "即将超时"
- Reconnection notifications via non-blocking `try_send` to outbound bus

## New Files
- `crates/kestrel-agent/src/adaptive_timeout.rs` — Token estimation, timeout resolution, local detection, model override lookup
- `crates/kestrel-agent/src/stream_health.rs` — Stream health monitor with sliding window token rate
- `crates/kestrel-agent/src/stream_progress.rs` — Progress state machine for IM status messages

## Config Changes
- Added `ModelTimeoutOverrides` struct with `first_byte_timeout`, `idle_timeout`, `absolute_max`
- Added `model_timeouts: HashMap<String, ModelTimeoutOverrides>` to `ProviderEntry`
- All new fields have `#[serde(default)]` — backward compatible

## Test plan
- [ ] `cargo clippy` passes on Windows (verified locally)
- [ ] `cargo fmt --check` passes (verified locally)
- [ ] CI passes on all platforms (Linux + Windows)
- [ ] Unit tests in each new module: adaptive_timeout (9 tests), stream_health (8 tests), stream_progress (8 tests)
- [ ] Existing tests still pass

Bahtya