### PR TITLE
fix(channels/telegram): split after MarkdownV2 conversion, not before

### DIFF
--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1942,7 +1942,7 @@ impl BaseChannel for TelegramChannel {
         let (text, parse_mode) = Self::prepare_outbound_text(content);
         if text.len() <= 4096 {
             return self
-                .send_single_message(chat_id, &text, parse_mode, reply_to)
+                .send_single_message(chat_id, &text, &parse_mode, reply_to)
                 .await;
         }
 
@@ -1959,7 +1959,7 @@ impl BaseChannel for TelegramChannel {
             };
             // Chunk is already in MarkdownV2; reuse the same parse_mode.
             let result = self
-                .send_single_message(chat_id, chunk, parse_mode, reply)
+                .send_single_message(chat_id, chunk, &parse_mode, reply)
                 .await?;
             if !result.success {
                 return Ok(result);
@@ -2198,7 +2198,7 @@ impl TelegramChannel {
         &self,
         chat_id: &str,
         text: &str,
-        parse_mode: Option<String>,
+        parse_mode: &Option<String>,
         reply_to: Option<&str>,
     ) -> Result<SendResult> {
         let chat_id_num: i64 = match chat_id.parse() {
@@ -2217,7 +2217,7 @@ impl TelegramChannel {
         let body = SendMessageBody {
             chat_id: chat_id_num,
             text: text.to_string(),
-            parse_mode,
+            parse_mode: parse_mode.clone(),
             reply_to_message_id: reply_to_id,
             reply_markup: None,
         };

--- a/crates/kestrel-channels/src/platforms/telegram.rs
+++ b/crates/kestrel-channels/src/platforms/telegram.rs
@@ -1935,8 +1935,10 @@ impl BaseChannel for TelegramChannel {
     ) -> Result<SendResult> {
         debug!("Sending Telegram message to chat {}", chat_id);
 
-        // Defensive split: if content exceeds 4096 chars after markdown
-        // conversion, split on newline boundaries and send multiple messages.
+        // Convert to MarkdownV2 first, then split the converted text.
+        // Previously we split first then converted each chunk, which caused
+        // the MarkdownV2 escaping to inflate chunk sizes beyond the 4096-char
+        // Telegram limit, silently dropping the tail of long messages.
         let (text, parse_mode) = Self::prepare_outbound_text(content);
         if text.len() <= 4096 {
             return self
@@ -1944,8 +1946,8 @@ impl BaseChannel for TelegramChannel {
                 .await;
         }
 
-        // Split original content (pre-conversion) and send each chunk.
-        let chunks = crate::split_message(content, 4096);
+        // Split the already-converted text so each chunk stays within limit.
+        let chunks = crate::split_message(&text, 4096);
         let mut last_result: Option<SendResult> = None;
         let mut first = true;
         for chunk in &chunks {
@@ -1955,9 +1957,9 @@ impl BaseChannel for TelegramChannel {
             } else {
                 None
             };
-            let (chunk_text, chunk_parse_mode) = Self::prepare_outbound_text(chunk);
+            // Chunk is already in MarkdownV2; reuse the same parse_mode.
             let result = self
-                .send_single_message(chat_id, &chunk_text, chunk_parse_mode, reply)
+                .send_single_message(chat_id, chunk, parse_mode, reply)
                 .await?;
             if !result.success {
                 return Ok(result);


### PR DESCRIPTION
## Summary

- Swap the order of MarkdownV2 conversion and message splitting in `TelegramChannel::send_message`
- Previously: split into 4096-char chunks first, then convert each chunk to MarkdownV2. Escaping (`|` → `\|`, `*` → `\*`, etc.) inflated the first chunk past the 4096-char Telegram API limit, causing rejection and silently dropping all subsequent chunks.
- Now: convert the full text to MarkdownV2 first via `prepare_outbound_text`, then split the already-escaped result into 4096-char chunks. Each chunk is guaranteed to stay within the Telegram limit.

Closes #372

## Test plan

- [ ] Send a message close to 4096 chars with heavy MarkdownV2-special characters (e.g. `_`, `*`, `[`, `|`, `!`) and verify it arrives in full without API errors
- [ ] Send a short message (< 4096 chars) and verify single-chunk delivery still works
- [ ] Send a message well over 4096 chars and verify all chunks are delivered in order

Bahtya