### PR TITLE
fix(channels/telegram): empty message when streaming=false + idle timeout tuning

### DIFF
--- a/crates/kestrel-agent/src/adaptive_timeout.rs
+++ b/crates/kestrel-agent/src/adaptive_timeout.rs
@@ -228,11 +228,11 @@ mod tests {
         let t = resolve_timeouts(&config, &msgs, "gpt-4o", "openai");
 
         assert_eq!(t.first_byte_timeout, Duration::from_secs(15));
-        assert_eq!(t.idle_timeout, Duration::from_secs(60));
+        assert_eq!(t.idle_timeout, Duration::from_secs(120));
         assert_eq!(t.message_timeout, Duration::from_secs(300));
         assert_eq!(t.connect_timeout, Duration::from_secs(10));
-        // absolute_max = max(idle*10, 600) = max(600, 600) = 600
-        assert_eq!(t.absolute_max, Duration::from_secs(600));
+        // absolute_max = max(idle*10, 600) = max(1200, 600) = 1200
+        assert_eq!(t.absolute_max, Duration::from_secs(1200));
     }
 
     #[test]
@@ -275,8 +275,8 @@ mod tests {
         let config = default_config();
         let msgs = vec![];
         let t = resolve_timeouts(&config, &msgs, "gpt-4o", "openai");
-        // idle=60, max(60*10, 600) = 600
-        assert_eq!(t.absolute_max, Duration::from_secs(600));
+        // idle=120, max(120*10, 600) = 1200
+        assert_eq!(t.absolute_max, Duration::from_secs(1200));
     }
 
     #[test]

--- a/crates/kestrel-agent/src/loop_mod.rs
+++ b/crates/kestrel-agent/src/loop_mod.rs
@@ -743,14 +743,24 @@ impl AgentLoop {
 
                         // Send outbound message
                         let user_msg = msg.content.clone();
-                        let result_content = result.content.clone();
+                        // When channel streaming is disabled, the StreamConsumer
+                        // (which strips think tags) never ran. Strip them here so
+                        // the outbound message isn't empty when the model wraps its
+                        // entire response in <think()> blocks.
+                        let result_content = if !channel_streaming {
+                            kestrel_channels::stream_consumer::strip_think_blocks(
+                                &result.content,
+                            )
+                        } else {
+                            result.content.clone()
+                        };
                         let tool_calls = result.tool_calls_made;
                         let iterations = result.iterations_used;
                         let success = !result.hit_limit;
                         let outbound = OutboundMessage {
                             channel: msg.channel.clone(),
                             chat_id: msg.chat_id.clone(),
-                            content: result.content.clone(),
+                            content: result_content.clone(),
                             reply_to: msg.reply_to.clone().or(msg.message_id.clone()),
                             trace_id: msg.trace_id.clone(),
                             media: vec![],

--- a/crates/kestrel-agent/src/runner.rs
+++ b/crates/kestrel-agent/src/runner.rs
@@ -463,7 +463,7 @@ impl AgentRunner {
                             ));
                         }
                         crate::stream_health::HealthState::Stale => {
-                            std::time::Duration::from_secs(5)
+                            std::time::Duration::from_secs(self.config.agent.stale_poll_timeout)
                         }
                         crate::stream_health::HealthState::Healthy => {
                             if is_first {

--- a/crates/kestrel-channels/src/stream_consumer.rs
+++ b/crates/kestrel-channels/src/stream_consumer.rs
@@ -433,6 +433,40 @@ fn find_partial_tag_suffix(text: &str, tags: &[&str]) -> usize {
     held
 }
 
+/// Strip thinking/reasoning blocks from a complete (non-streaming) text.
+///
+/// Removes content between any matching open/close think tag pairs, keeping
+/// everything outside them. Used when channel streaming is disabled so the
+/// outbound message doesn't contain raw thinking tags.
+pub fn strip_think_blocks(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut in_think = false;
+    let mut remaining = text;
+
+    while !remaining.is_empty() {
+        if in_think {
+            let (idx, len) = find_earliest_tag(remaining, CLOSE_THINK_TAGS);
+            if len > 0 {
+                in_think = false;
+                remaining = &remaining[idx + len..];
+            } else {
+                break; // unclosed tag — discard rest
+            }
+        } else {
+            let (idx, len) = find_earliest_tag(remaining, OPEN_THINK_TAGS);
+            if len > 0 {
+                result.push_str(&remaining[..idx]);
+                in_think = true;
+                remaining = &remaining[idx + len..];
+            } else {
+                result.push_str(remaining);
+                break;
+            }
+        }
+    }
+    result
+}
+
 /// Split text into chunks that fit within `limit` characters, respecting
 /// newline boundaries.
 pub fn split_message(text: &str, limit: usize) -> Vec<String> {

--- a/crates/kestrel-config/src/schema.rs
+++ b/crates/kestrel-config/src/schema.rs
@@ -715,6 +715,11 @@ pub struct AgentDefaults {
     #[serde(default = "default_idle_timeout")]
     pub idle_timeout: u64,
 
+    /// Poll interval in seconds when the SSE stream is classified as Stale.
+    /// Controls how often we re-check for incoming chunks during idle periods.
+    #[serde(default = "default_stale_poll_timeout")]
+    pub stale_poll_timeout: u64,
+
     /// Message processing timeout in seconds.
     ///
     /// When a single message exceeds this duration, the agent loop sends a
@@ -743,6 +748,7 @@ impl Default for AgentDefaults {
             connect_timeout: default_connect_timeout(),
             first_byte_timeout: default_first_byte_timeout(),
             idle_timeout: default_idle_timeout(),
+            stale_poll_timeout: default_stale_poll_timeout(),
             message_timeout: default_message_timeout(),
             reasoning_effort: None,
         }
@@ -1210,7 +1216,11 @@ const fn default_first_byte_timeout() -> u64 {
 }
 
 const fn default_idle_timeout() -> u64 {
-    60
+    120
+}
+
+const fn default_stale_poll_timeout() -> u64 {
+    30
 }
 
 fn default_dream_interval() -> u64 {


### PR DESCRIPTION
## Summary

- **Strip think/reasoning blocks** from response content when Telegram `streaming=false`, fixing empty message (`Bad Request: message text is empty`) caused by models that wrap their output in thinking tags
- **Increase default `idle_timeout`** from 60s → 120s for more tolerant SSE streaming
- **Add configurable `stale_poll_timeout`** (default 30s) replacing hardcoded 5s in the Stale health state

## Root Cause

When `channels.telegram.streaming = false`, the `StreamConsumer` (which filters `<think()>` blocks) is never spawned. Models emitting content only via `reasoning_content` chunks produce an empty `full_content`, resulting in an empty outbound message.

## Test plan

- [ ] Set `channels.telegram.streaming = false` in config, send a message that triggers a thinking model, verify response is delivered (not empty)
- [ ] Verify `idle_timeout` defaults to 120 in logs on startup
- [ ] Verify `stale_poll_timeout` is respected when set in config
- [ ] CI passes

Closes #374

Bahtya