### PR TITLE
feat(doctor): auto-complete missing config fields with --fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-agent"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-api"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-bus"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "chrono",
  "kestrel-core",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-channels"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-config"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1844,12 +1844,13 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "toml",
+ "toml_edit",
  "tracing",
 ]
 
 [[package]]
 name = "kestrel-core"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "chrono",
  "hickory-resolver",
@@ -1863,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-cron"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1882,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-daemon"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1903,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-heartbeat"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1927,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-learning"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1948,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-memory"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1970,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-providers"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1991,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-security"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -2004,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-session"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2022,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-skill"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2041,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-test-utils"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2057,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "kestrel-tools"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/kestrel-config/Cargo.toml
+++ b/crates/kestrel-config/Cargo.toml
@@ -16,6 +16,7 @@ tracing = { workspace = true }
 ipnet = "2"
 aes-gcm = { workspace = true }
 argon2 = { workspace = true }
+toml_edit = "0.22"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kestrel-config/src/documented.rs
+++ b/crates/kestrel-config/src/documented.rs
@@ -31,13 +31,6 @@ fn all_documented_fields() -> FieldMap {
         (value_str("gpt-4o"), "默认模型名称".into()),
     );
     m.insert(
-        "agent.provider".into(),
-        (
-            value_str(""),
-            "指定 provider 名称（如 \"openai\"），留空则使用第一个已注册的 provider".into(),
-        ),
-    );
-    m.insert(
         "agent.temperature".into(),
         (value_float(0.7), "生成温度 (0.0~2.0)，越高越随机".into()),
     );
@@ -201,20 +194,12 @@ pub fn insert_missing_fields(doc: &mut DocumentMut) -> Vec<String> {
     inserted
 }
 
-/// Check a raw TOML string for missing fields and optionally fix it.
-///
-/// Returns `(missing_fields, was_fixed)`.
-pub fn check_and_fix(raw_toml: &str, fix: bool) -> Result<(Vec<String>, bool), String> {
+/// Check a raw TOML string for missing fields (read-only, no serialization).
+pub fn check_missing(raw_toml: &str) -> Result<Vec<String>, String> {
     let mut doc: DocumentMut = raw_toml
         .parse()
         .map_err(|e: toml_edit::TomlError| e.to_string())?;
-    let missing = insert_missing_fields(&mut doc);
-
-    if missing.is_empty() || !fix {
-        return Ok((missing, false));
-    }
-
-    Ok((missing.clone(), true))
+    Ok(insert_missing_fields(&mut doc))
 }
 
 /// Parse a TOML string, insert missing fields, and return the updated string.

--- a/crates/kestrel-config/src/documented.rs
+++ b/crates/kestrel-config/src/documented.rs
@@ -1,0 +1,358 @@
+//! Generate documented TOML config with Chinese comments.
+//!
+//! Used by `kestrel doctor --fix` to fill in missing config fields
+//! while preserving user's existing formatting, values, and comments.
+
+use std::collections::BTreeMap;
+use toml_edit::{DocumentMut, Item, Table, Value};
+
+type FieldMap = BTreeMap<String, (Value, String)>;
+
+/// All known config fields with their default values and Chinese comments.
+///
+/// Key format: dotted path like `"agent.model"`.
+/// Only includes scalar fields (not nested tables like providers/channels
+/// which are user-configured on demand).
+fn all_documented_fields() -> FieldMap {
+    let mut m = FieldMap::new();
+
+    // ── Top-level ──────────────────────────────────────────────
+    m.insert(
+        "_config_version".into(),
+        (
+            value_int(4),
+            "配置格式版本号（用于自动迁移，请勿手动修改）".into(),
+        ),
+    );
+
+    // ── [agent] ────────────────────────────────────────────────
+    m.insert(
+        "agent.model".into(),
+        (value_str("gpt-4o"), "默认模型名称".into()),
+    );
+    m.insert(
+        "agent.provider".into(),
+        (
+            value_str(""),
+            "指定 provider 名称（如 \"openai\"），留空则使用第一个已注册的 provider".into(),
+        ),
+    );
+    m.insert(
+        "agent.temperature".into(),
+        (value_float(0.7), "生成温度 (0.0~2.0)，越高越随机".into()),
+    );
+    m.insert(
+        "agent.max_tokens".into(),
+        (
+            value_int(4096),
+            "单次回复最大 token 数（推理模型会自动放大）".into(),
+        ),
+    );
+    m.insert(
+        "agent.max_iterations".into(),
+        (value_int(50), "工具调用循环最大迭代次数".into()),
+    );
+    m.insert(
+        "agent.streaming".into(),
+        (value_bool(true), "是否启用流式输出".into()),
+    );
+    m.insert(
+        "agent.tool_timeout".into(),
+        (value_int(60), "工具执行超时（秒）".into()),
+    );
+    m.insert(
+        "agent.connect_timeout".into(),
+        (value_int(10), "HTTP 连接超时（秒）".into()),
+    );
+    m.insert(
+        "agent.first_byte_timeout".into(),
+        (
+            value_int(15),
+            "首字节超时（秒），等待模型开始输出的时间".into(),
+        ),
+    );
+    m.insert(
+        "agent.idle_timeout".into(),
+        (
+            value_int(120),
+            "流式传输中两个 chunk 之间的空闲超时（秒）".into(),
+        ),
+    );
+    m.insert(
+        "agent.stale_poll_timeout".into(),
+        (value_int(30), "流式停滞时的轮询间隔（秒）".into()),
+    );
+    m.insert(
+        "agent.message_timeout".into(),
+        (value_int(300), "单条消息处理总超时（秒）".into()),
+    );
+
+    // ── [dream] ────────────────────────────────────────────────
+    m.insert(
+        "dream.enabled".into(),
+        (value_bool(true), "是否启用记忆整合（dream）".into()),
+    );
+    m.insert(
+        "dream.interval_secs".into(),
+        (value_int(7200), "dream 周期（秒），默认 2 小时".into()),
+    );
+
+    // ── [heartbeat] ────────────────────────────────────────────
+    m.insert(
+        "heartbeat.enabled".into(),
+        (value_bool(false), "是否启用心跳检测".into()),
+    );
+    m.insert(
+        "heartbeat.interval_secs".into(),
+        (value_int(1800), "心跳间隔（秒），默认 30 分钟".into()),
+    );
+
+    // ── [cron] ─────────────────────────────────────────────────
+    m.insert(
+        "cron.enabled".into(),
+        (value_bool(false), "是否启用定时任务调度".into()),
+    );
+    m.insert(
+        "cron.tick_secs".into(),
+        (value_int(60), "定时任务检查间隔（秒）".into()),
+    );
+
+    // ── [security] ─────────────────────────────────────────────
+    m.insert(
+        "security.block_private_ips".into(),
+        (value_bool(false), "是否禁止访问内网/私有 IP 地址".into()),
+    );
+
+    // ── [api] ──────────────────────────────────────────────────
+    m.insert(
+        "api.host".into(),
+        (value_str("0.0.0.0"), "API 服务监听地址".into()),
+    );
+    m.insert(
+        "api.port".into(),
+        (value_int(8080), "API 服务监听端口".into()),
+    );
+    m.insert(
+        "api.max_body_size".into(),
+        (
+            value_int(10_485_760),
+            "请求体最大字节数（默认 10MB）".into(),
+        ),
+    );
+
+    // ── [daemon] ───────────────────────────────────────────────
+    m.insert(
+        "daemon.grace_period_secs".into(),
+        (
+            value_int(30),
+            "守护进程关闭时等待在途任务的宽限时间（秒）".into(),
+        ),
+    );
+    m.insert(
+        "daemon.log_level".into(),
+        (
+            value_str("info"),
+            "日志级别: trace, debug, info, warn, error".into(),
+        ),
+    );
+    m.insert(
+        "daemon.log_retain_days".into(),
+        (value_int(30), "日志文件保留天数".into()),
+    );
+    m.insert(
+        "daemon.log_format".into(),
+        (value_str("text"), "日志格式: text 或 json".into()),
+    );
+
+    // ── [notifications] ────────────────────────────────────────
+    m.insert(
+        "notifications.online_notify".into(),
+        (value_bool(true), "渠道连接成功时是否发送上线通知".into()),
+    );
+    m.insert(
+        "notifications.online_message".into(),
+        (
+            value_str("🟢 Kestrel v{version} online — {channel} connected"),
+            "上线通知消息模板，支持 {version} 和 {channel} 占位符".into(),
+        ),
+    );
+
+    m
+}
+
+/// Insert missing config fields into an existing TOML document.
+///
+/// Returns a list of dotted paths that were added.
+/// Preserves existing values, comments, and formatting.
+pub fn insert_missing_fields(doc: &mut DocumentMut) -> Vec<String> {
+    let fields = all_documented_fields();
+    let mut inserted = Vec::new();
+
+    for (path, (default_val, comment)) in &fields {
+        if field_exists(doc, path) {
+            continue;
+        }
+
+        if insert_field(doc, path, default_val.clone(), comment) {
+            inserted.push(path.clone());
+        }
+    }
+
+    inserted
+}
+
+/// Check a raw TOML string for missing fields and optionally fix it.
+///
+/// Returns `(missing_fields, was_fixed)`.
+pub fn check_and_fix(raw_toml: &str, fix: bool) -> Result<(Vec<String>, bool), String> {
+    let mut doc: DocumentMut = raw_toml
+        .parse()
+        .map_err(|e: toml_edit::TomlError| e.to_string())?;
+    let missing = insert_missing_fields(&mut doc);
+
+    if missing.is_empty() || !fix {
+        return Ok((missing, false));
+    }
+
+    Ok((missing.clone(), true))
+}
+
+/// Parse a TOML string, insert missing fields, and return the updated string.
+pub fn apply_fix(raw_toml: &str) -> Result<(Vec<String>, String), String> {
+    let mut doc: DocumentMut = raw_toml
+        .parse()
+        .map_err(|e: toml_edit::TomlError| e.to_string())?;
+    let missing = insert_missing_fields(&mut doc);
+    Ok((missing, doc.to_string()))
+}
+
+/// Check if a dotted path already exists in the document.
+fn field_exists(doc: &DocumentMut, path: &str) -> bool {
+    let parts: Vec<&str> = path.split('.').collect();
+    let mut current: Option<&Item> = Some(doc.as_item());
+
+    for part in parts.iter().copied() {
+        match current.and_then(|item| item.as_table()) {
+            Some(table) => match table.get(part) {
+                Some(item) => current = Some(item),
+                None => return false,
+            },
+            None => return false,
+        }
+    }
+    true
+}
+
+/// Insert a value at a dotted path, creating intermediate tables as needed.
+fn insert_field(doc: &mut DocumentMut, path: &str, value: Value, comment: &str) -> bool {
+    let parts: Vec<&str> = path.split('.').collect();
+    if parts.is_empty() {
+        return false;
+    }
+
+    // Navigate/create parent tables
+    let root = doc.as_table_mut();
+    let mut current: &mut Table = root;
+
+    for key in &parts[..parts.len() - 1] {
+        if !current.contains_key(key) {
+            current.insert(key, Item::Table(Table::new()));
+        }
+        current = current
+            .get_mut(key)
+            .and_then(|item| item.as_table_mut())
+            .expect("created table above");
+    }
+
+    let leaf_key = parts[parts.len() - 1];
+    let mut val = value;
+    val.decor_mut().set_prefix(format!("# {}\n", comment));
+    current.insert(leaf_key, Item::Value(val));
+    true
+}
+
+// ── Value constructors ────────────────────────────────────────
+
+fn value_str(s: &str) -> Value {
+    Value::from(s)
+}
+
+fn value_int(n: i64) -> Value {
+    Value::from(n)
+}
+
+fn value_float(f: f64) -> Value {
+    Value::from(f)
+}
+
+fn value_bool(b: bool) -> Value {
+    Value::from(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_into_empty_doc() {
+        let mut doc = "".parse::<DocumentMut>().unwrap();
+        let inserted = insert_missing_fields(&mut doc);
+        assert!(!inserted.is_empty());
+        assert!(inserted.contains(&"agent.model".to_string()));
+        assert!(inserted.contains(&"dream.enabled".to_string()));
+    }
+
+    #[test]
+    fn test_no_insert_when_field_exists() {
+        let toml = r#"
+[agent]
+model = "gpt-4o-mini"
+"#;
+        let mut doc = toml.parse::<DocumentMut>().unwrap();
+        let inserted = insert_missing_fields(&mut doc);
+        assert!(!inserted.contains(&"agent.model".to_string()));
+        assert!(inserted.contains(&"agent.temperature".to_string()));
+    }
+
+    #[test]
+    fn test_preserves_existing_values() {
+        let toml = r#"
+[agent]
+model = "my-custom-model"
+temperature = 0.5
+"#;
+        let mut doc = toml.parse::<DocumentMut>().unwrap();
+        insert_missing_fields(&mut doc);
+
+        let agent = doc.get("agent").unwrap().as_table().unwrap();
+        assert_eq!(
+            agent.get("model").unwrap().as_str(),
+            Some("my-custom-model")
+        );
+        let temp = agent
+            .get("temperature")
+            .unwrap()
+            .as_value()
+            .unwrap()
+            .as_float()
+            .unwrap();
+        assert!((temp - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_output_has_comments() {
+        let mut doc = "".parse::<DocumentMut>().unwrap();
+        insert_missing_fields(&mut doc);
+        let output = doc.to_string();
+        assert!(output.contains("默认模型名称"));
+        assert!(output.contains("是否启用记忆整合"));
+    }
+
+    #[test]
+    fn test_all_fields_have_comments() {
+        let fields = all_documented_fields();
+        for (path, (_, comment)) in &fields {
+            assert!(!comment.is_empty(), "missing comment for {}", path);
+        }
+    }
+}

--- a/crates/kestrel-config/src/lib.rs
+++ b/crates/kestrel-config/src/lib.rs
@@ -4,6 +4,7 @@
 //! Uses TOML format for the config file (`config.toml`).
 
 pub mod crypto;
+pub mod documented;
 pub mod loader;
 pub mod migration;
 pub mod paths;

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -382,13 +382,25 @@ fn check_config_completeness(fix: bool, warnings: &mut usize) -> Result<()> {
         }
     };
 
-    let (missing, updated) = match documented::apply_fix(&raw) {
-        Ok(r) => r,
-        Err(e) => {
-            println!("  FAIL — cannot parse TOML: {}", e);
-            println!();
-            return Ok(());
+    let (missing, updated) = if fix {
+        match documented::apply_fix(&raw) {
+            Ok(r) => r,
+            Err(e) => {
+                println!("  FAIL — cannot parse TOML: {}", e);
+                println!();
+                return Ok(());
+            }
         }
+    } else {
+        let missing = match documented::check_missing(&raw) {
+            Ok(r) => r,
+            Err(e) => {
+                println!("  FAIL — cannot parse TOML: {}", e);
+                println!();
+                return Ok(());
+            }
+        };
+        (missing, String::new())
     };
 
     if missing.is_empty() {
@@ -401,6 +413,12 @@ fn check_config_completeness(fix: bool, warnings: &mut usize) -> Result<()> {
         }
 
         if fix {
+            // Backup original config
+            let backup_path = config_path.with_extension("toml.bak");
+            std::fs::write(&backup_path, &raw)
+                .map_err(|e| anyhow::anyhow!("failed to backup config: {}", e))?;
+            println!("  Backup: {}", backup_path.display());
+
             std::fs::write(&config_path, updated)
                 .map_err(|e| anyhow::anyhow!("failed to write config: {}", e))?;
             println!("  Fixed: {} field(s) added with comments.", missing.len());

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,6 +1,7 @@
 //! Doctor command — comprehensive system diagnostics.
 
 use anyhow::Result;
+use kestrel_config::documented;
 use kestrel_config::paths::get_config_path;
 use kestrel_config::schema::Config;
 use kestrel_config::validate;
@@ -10,7 +11,7 @@ use std::net::TcpStream;
 use std::time::{Duration, Instant};
 
 /// Run all diagnostic checks.
-pub async fn run(config: &Config) -> Result<()> {
+pub async fn run(config: &Config, fix: bool) -> Result<()> {
     println!("=== Kestrel Doctor ===\n");
 
     let mut errors = 0usize;
@@ -20,6 +21,7 @@ pub async fn run(config: &Config) -> Result<()> {
     check_websocket(config, &mut errors, &mut warnings);
     check_providers(config, &mut errors, &mut warnings).await;
     check_telegram(config, &mut errors, &mut warnings).await;
+    check_config_completeness(fix, &mut warnings)?;
 
     println!("\n--- Summary ---");
     if errors == 0 && warnings == 0 {
@@ -45,7 +47,7 @@ pub async fn run(config: &Config) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn check_config_file(config: &Config, errors: &mut usize, warnings: &mut usize) {
-    println!("[1/4] Config file validation");
+    println!("[1/5] Config file validation");
 
     // Check that config file exists
     match get_config_path() {
@@ -111,7 +113,7 @@ fn check_config_file(config: &Config, errors: &mut usize, warnings: &mut usize) 
 // ---------------------------------------------------------------------------
 
 fn check_websocket(config: &Config, errors: &mut usize, warnings: &mut usize) {
-    println!("[2/4] WebSocket port health");
+    println!("[2/5] WebSocket port health");
 
     match &config.channels.websocket {
         Some(ws) if ws.enabled => {
@@ -164,7 +166,7 @@ fn check_websocket(config: &Config, errors: &mut usize, warnings: &mut usize) {
 // ---------------------------------------------------------------------------
 
 async fn check_providers(config: &Config, errors: &mut usize, warnings: &mut usize) {
-    println!("[3/4] Provider model availability");
+    println!("[3/5] Provider model availability");
 
     let registry = match ProviderRegistry::from_config(config) {
         Ok(r) => r,
@@ -252,7 +254,7 @@ async fn check_providers(config: &Config, errors: &mut usize, warnings: &mut usi
 // ---------------------------------------------------------------------------
 
 async fn check_telegram(config: &Config, errors: &mut usize, _warnings: &mut usize) {
-    println!("[4/4] Telegram API health");
+    println!("[4/5] Telegram API health");
 
     let tg = match &config.channels.telegram {
         Some(tg) if tg.enabled && !tg.token.is_empty() => tg,
@@ -347,4 +349,69 @@ fn build_telegram_http_client(proxy: Option<&str>) -> Result<reqwest::Client> {
     }
 
     Ok(builder.build()?)
+}
+
+// ---------------------------------------------------------------------------
+// 5. Config completeness (missing fields)
+// ---------------------------------------------------------------------------
+
+fn check_config_completeness(fix: bool, warnings: &mut usize) -> Result<()> {
+    println!("[5/5] Config completeness");
+
+    let config_path = match get_config_path() {
+        Ok(p) => p,
+        Err(e) => {
+            println!("  SKIP — cannot determine config path: {}", e);
+            println!();
+            return Ok(());
+        }
+    };
+
+    if !config_path.exists() {
+        println!("  SKIP — no config file found");
+        println!();
+        return Ok(());
+    }
+
+    let raw = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("  FAIL — cannot read config: {}", e);
+            println!();
+            return Ok(());
+        }
+    };
+
+    let (missing, updated) = match documented::apply_fix(&raw) {
+        Ok(r) => r,
+        Err(e) => {
+            println!("  FAIL — cannot parse TOML: {}", e);
+            println!();
+            return Ok(());
+        }
+    };
+
+    if missing.is_empty() {
+        println!("  All known fields present.");
+    } else {
+        *warnings += missing.len();
+        println!("  {} missing field(s):", missing.len());
+        for field in &missing {
+            println!("    - {}", field);
+        }
+
+        if fix {
+            std::fs::write(&config_path, updated)
+                .map_err(|e| anyhow::anyhow!("failed to write config: {}", e))?;
+            println!("  Fixed: {} field(s) added with comments.", missing.len());
+            println!("  Updated: {}", config_path.display());
+        } else {
+            println!(
+                "  Run `kestrel doctor --fix` to add missing fields with documented defaults."
+            );
+        }
+    }
+
+    println!();
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,11 @@ enum Commands {
     Status,
 
     /// Run comprehensive system diagnostics.
-    Doctor,
+    Doctor {
+        /// Auto-fix issues (add missing config fields with documented defaults).
+        #[arg(long)]
+        fix: bool,
+    },
 
     /// Daemon management commands.
     Daemon {
@@ -228,9 +232,9 @@ fn main() -> Result<()> {
         Commands::Status => {
             commands::status::run(&config)?;
         }
-        Commands::Doctor => {
+        Commands::Doctor { fix } => {
             let rt = tokio::runtime::Runtime::new()?;
-            rt.block_on(commands::doctor::run(&config))?;
+            rt.block_on(commands::doctor::run(&config, fix))?;
         }
         Commands::Daemon { subcommand } => {
             let action = match subcommand {


### PR DESCRIPTION
## Summary

- Add `kestrel doctor --fix` to detect and auto-complete missing config fields
- Uses `toml_edit` to incrementally insert missing fields with Chinese comments, preserving existing formatting and values
- New `[5/5] Config completeness` check in doctor

## Changes

- **`crates/kestrel-config/src/documented.rs`** — New module with all known scalar config fields, their default values and Chinese comments. Provides `insert_missing_fields()` and `apply_fix()` functions.
- **`crates/kestrel-config/Cargo.toml`** — Add `toml_edit = "0.22"` dependency
- **`src/commands/doctor.rs`** — Add 5th check for config completeness, `--fix` writes back commented TOML
- **`src/main.rs`** — Add `--fix` flag to `Doctor` subcommand

## Test plan

- [x] `cargo clippy` clean, no warnings
- [x] `cargo fmt` clean
- [ ] CI passes on all platforms
- [ ] `kestrel doctor` reports missing fields without modifying file
- [ ] `kestrel doctor --fix` adds missing fields with Chinese comments
- [ ] Running `kestrel doctor` again shows "All known fields present"

Bahtya